### PR TITLE
feat(wallpapers): conform to GNOME specifications

### DIFF
--- a/build/backgrounds/Makefile
+++ b/build/backgrounds/Makefile
@@ -4,9 +4,12 @@ RPMBUILD := $(UBLUE_ROOT)/rpmbuild
 
 all: build-rpm
 
-tarball:
-	mkdir -p $(SOURCE_DIR) $(UBLUE_ROOT)/$(TARGET) $(RPMBUILD)/SOURCES
-	cp -r ./src/* LICENSE $(UBLUE_ROOT)/$(TARGET)
+clean:
+	rm -rf $(RPMBUILD)
+
+tarball: clean
+	mkdir -p $(UBLUE_ROOT)/$(TARGET) $(RPMBUILD)/SOURCES xml
+	cp -r src xml LICENSE $(UBLUE_ROOT)/$(TARGET)
 	tar czf $(RPMBUILD)/SOURCES/$(TARGET).tar.gz -C $(UBLUE_ROOT)/$(TARGET) .
 	
 build-rpm: tarball
@@ -17,5 +20,6 @@ build-rpm: tarball
     	--define '%_tmppath %{_topdir}/tmp' \
     	$(UBLUE_ROOT)/$(TARGET).spec
 
-clean: $(SOURCE_DIR) $(RPMBUILD)
-	rm -rf $^
+xml-files:
+	mkdir -p xml
+	sh gen-xml-files.sh

--- a/build/backgrounds/gen-xml-files.sh
+++ b/build/backgrounds/gen-xml-files.sh
@@ -1,0 +1,41 @@
+#!/bin/sh
+# Run this script to update XML files for the backgrounds
+set -euo pipefail
+
+function titlecase {
+    set ${*,,} 
+    printf "%s" "${*^}"
+}
+
+# Returns a list of main colors of an image with the format "<ammount of pixels w/ color>,<#HEXVALUE>", decreasing in color importance for each line
+function get_dominant_color {
+    convert ${1} -scale 50x50! -depth 8 +dither -colors 8 -format "%c" histogram:info: \
+        | sed -n 's/^[ ]*\(.*\):.*[#]\([0-9a-fA-F]*\) .*$/\1,#\2/p' \
+        | sort -r -n -k 1 -t ","
+}
+
+BACKGROUNDDIR="/usr/share/backgrounds"
+VENDOR="ublue-os"
+
+if ! command -v convert &> /dev/null ; then
+    printf '%c' "Error! This script requires ImageMagick to generate these XML files."
+    exit 1
+fi
+
+for FILE in $(realpath $(dirname $0))/src/*/* ; do
+    FILE_COLOR_GRADIENT=$(get_dominant_color ${FILE})
+    tee xml/$(basename ${FILE%.*}.xml) <<EOF
+<?xml version="1.0"?>
+<!DOCTYPE wallpapers SYSTEM "gnome-wp-list.dtd">
+<wallpapers>
+  <wallpaper deleted="false">
+    <name>$(titlecase $(basename ${FILE%.*} | sed 's/\-/ /g'))</name>
+    <filename>$BACKGROUNDDIR/$VENDOR/$(basename $(dirname ${FILE}))/$(basename ${FILE})</filename>
+    <options>zoom</options>
+    <shade_type>solid</shade_type>
+    <pcolor>$(echo -e "${FILE_COLOR_GRADIENT}" | head -n 1 | cut -d',' -f 2)</pcolor>
+    <scolor>$(echo -e "${FILE_COLOR_GRADIENT}" | head -2 | tail -1 | cut -d',' -f 2)</scolor>
+  </wallpaper>
+</wallpapers>
+EOF
+done

--- a/build/backgrounds/ublue-os-wallpapers.spec
+++ b/build/backgrounds/ublue-os-wallpapers.spec
@@ -17,13 +17,22 @@ Collection of wallpapers for the Universal Blue operating systems
 %build
 
 %install
-mkdir -p -m0755 %{buildroot}%{_datadir}/wallpapers/%{VENDOR}
-tar xzf %{SOURCE0} -C %{buildroot}%{_datadir}/wallpapers --directory ./%{VENDOR} --strip-components=1
- 
+mkdir -p -m0755 \
+    %{buildroot}%{_datadir}/backgrounds/%{VENDOR} \
+    %{buildroot}/tmp \
+    %{buildroot}%{_datadir}/gnome-background-properties
+tar xzf %{SOURCE0} -C %{buildroot}/tmp --directory . --strip-components=1
+mv %{buildroot}/tmp/src/* %{buildroot}%{_datadir}/backgrounds/%{VENDOR}
+mv %{buildroot}/tmp/xml/* %{buildroot}%{_datadir}/gnome-background-properties
+mv %{buildroot}/tmp/LICENSE %{buildroot}%{_datadir}/backgrounds/%{VENDOR}
+cd %{buildroot}%{_datadir}/backgrounds/%{VENDOR}
+rm -rf %{buildroot}/tmp
+
 %files
 %license LICENSE
-%attr(0755,root,root) %{_datadir}/wallpapers/%{VENDOR}/*
-%exclude %{_datadir}/wallpapers/%{VENDOR}/LICENSE
+%attr(0755,root,root) %{_datadir}/backgrounds/%{VENDOR}/*
+%attr(0755,root,root) %{_datadir}/gnome-background-properties/*.xml
+%exclude %{_datadir}/background/%{VENDOR}/LICENSE
 
 %changelog
 %autochangelog

--- a/build/backgrounds/xml/3D-1-cattppuccin-frappe.xml
+++ b/build/backgrounds/xml/3D-1-cattppuccin-frappe.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<!DOCTYPE wallpapers SYSTEM "gnome-wp-list.dtd">
+<wallpapers>
+  <wallpaper deleted="false">
+    <name>3d 1 Cattppuccin Frappe</name>
+    <filename>/usr/share/backgrounds/ublue-os/3D-1/3D-1-cattppuccin-frappe.png</filename>
+    <options>zoom</options>
+    <shade_type>solid</shade_type>
+    <pcolor>#313542FF</pcolor>
+    <scolor>#323542FF</scolor>
+  </wallpaper>
+</wallpapers>

--- a/build/backgrounds/xml/3D-1-cattppuccin-latte.xml
+++ b/build/backgrounds/xml/3D-1-cattppuccin-latte.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<!DOCTYPE wallpapers SYSTEM "gnome-wp-list.dtd">
+<wallpapers>
+  <wallpaper deleted="false">
+    <name>3d 1 Cattppuccin Latte</name>
+    <filename>/usr/share/backgrounds/ublue-os/3D-1/3D-1-cattppuccin-latte.png</filename>
+    <options>zoom</options>
+    <shade_type>solid</shade_type>
+    <pcolor>#AAACAEFF</pcolor>
+    <scolor>#A2A8ADFF</scolor>
+  </wallpaper>
+</wallpapers>

--- a/build/backgrounds/xml/3D-1-cattppuccin-macchiato.xml
+++ b/build/backgrounds/xml/3D-1-cattppuccin-macchiato.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<!DOCTYPE wallpapers SYSTEM "gnome-wp-list.dtd">
+<wallpapers>
+  <wallpaper deleted="false">
+    <name>3d 1 Cattppuccin Macchiato</name>
+    <filename>/usr/share/backgrounds/ublue-os/3D-1/3D-1-cattppuccin-macchiato.png</filename>
+    <options>zoom</options>
+    <shade_type>solid</shade_type>
+    <pcolor>#2A2D3AFF</pcolor>
+    <scolor>#1F2532FF</scolor>
+  </wallpaper>
+</wallpapers>

--- a/build/backgrounds/xml/3D-1-cattppuccin-mocha.xml
+++ b/build/backgrounds/xml/3D-1-cattppuccin-mocha.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<!DOCTYPE wallpapers SYSTEM "gnome-wp-list.dtd">
+<wallpapers>
+  <wallpaper deleted="false">
+    <name>3d 1 Cattppuccin Mocha</name>
+    <filename>/usr/share/backgrounds/ublue-os/3D-1/3D-1-cattppuccin-mocha.png</filename>
+    <options>zoom</options>
+    <shade_type>solid</shade_type>
+    <pcolor>#272933FF</pcolor>
+    <scolor>#282933FF</scolor>
+  </wallpaper>
+</wallpapers>

--- a/build/backgrounds/xml/3D-1-cyan.xml
+++ b/build/backgrounds/xml/3D-1-cyan.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<!DOCTYPE wallpapers SYSTEM "gnome-wp-list.dtd">
+<wallpapers>
+  <wallpaper deleted="false">
+    <name>3d 1 Cyan</name>
+    <filename>/usr/share/backgrounds/ublue-os/3D-1/3D-1-cyan.png</filename>
+    <options>zoom</options>
+    <shade_type>solid</shade_type>
+    <pcolor>#64AC96FF</pcolor>
+    <scolor>#64AC96FF</scolor>
+  </wallpaper>
+</wallpapers>

--- a/build/backgrounds/xml/3D-1-darkblue.xml
+++ b/build/backgrounds/xml/3D-1-darkblue.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<!DOCTYPE wallpapers SYSTEM "gnome-wp-list.dtd">
+<wallpapers>
+  <wallpaper deleted="false">
+    <name>3d 1 Darkblue</name>
+    <filename>/usr/share/backgrounds/ublue-os/3D-1/3D-1-darkblue.png</filename>
+    <options>zoom</options>
+    <shade_type>solid</shade_type>
+    <pcolor>#424890FF</pcolor>
+    <scolor>#434890FF</scolor>
+  </wallpaper>
+</wallpapers>

--- a/build/backgrounds/xml/3D-1-green.xml
+++ b/build/backgrounds/xml/3D-1-green.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<!DOCTYPE wallpapers SYSTEM "gnome-wp-list.dtd">
+<wallpapers>
+  <wallpaper deleted="false">
+    <name>3d 1 Green</name>
+    <filename>/usr/share/backgrounds/ublue-os/3D-1/3D-1-green.png</filename>
+    <options>zoom</options>
+    <shade_type>solid</shade_type>
+    <pcolor>#63A458FF</pcolor>
+    <scolor>#4B9750FF</scolor>
+  </wallpaper>
+</wallpapers>

--- a/build/backgrounds/xml/3D-1-lightblue.xml
+++ b/build/backgrounds/xml/3D-1-lightblue.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<!DOCTYPE wallpapers SYSTEM "gnome-wp-list.dtd">
+<wallpapers>
+  <wallpaper deleted="false">
+    <name>3d 1 Lightblue</name>
+    <filename>/usr/share/backgrounds/ublue-os/3D-1/3D-1-lightblue.png</filename>
+    <options>zoom</options>
+    <shade_type>solid</shade_type>
+    <pcolor>#467098FF</pcolor>
+    <scolor>#305D8FFF</scolor>
+  </wallpaper>
+</wallpapers>

--- a/build/backgrounds/xml/3D-1-orange.xml
+++ b/build/backgrounds/xml/3D-1-orange.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<!DOCTYPE wallpapers SYSTEM "gnome-wp-list.dtd">
+<wallpapers>
+  <wallpaper deleted="false">
+    <name>3d 1 Orange</name>
+    <filename>/usr/share/backgrounds/ublue-os/3D-1/3D-1-orange.png</filename>
+    <options>zoom</options>
+    <shade_type>solid</shade_type>
+    <pcolor>#BE5E49FF</pcolor>
+    <scolor>#BD604AFF</scolor>
+  </wallpaper>
+</wallpapers>

--- a/build/backgrounds/xml/3D-1-pink.xml
+++ b/build/backgrounds/xml/3D-1-pink.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<!DOCTYPE wallpapers SYSTEM "gnome-wp-list.dtd">
+<wallpapers>
+  <wallpaper deleted="false">
+    <name>3d 1 Pink</name>
+    <filename>/usr/share/backgrounds/ublue-os/3D-1/3D-1-pink.png</filename>
+    <options>zoom</options>
+    <shade_type>solid</shade_type>
+    <pcolor>#AD63A5FF</pcolor>
+    <scolor>#93529EFF</scolor>
+  </wallpaper>
+</wallpapers>

--- a/build/backgrounds/xml/3D-1-pride.xml
+++ b/build/backgrounds/xml/3D-1-pride.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<!DOCTYPE wallpapers SYSTEM "gnome-wp-list.dtd">
+<wallpapers>
+  <wallpaper deleted="false">
+    <name>3d 1 Pride</name>
+    <filename>/usr/share/backgrounds/ublue-os/3D-1/3D-1-pride.png</filename>
+    <options>zoom</options>
+    <shade_type>solid</shade_type>
+    <pcolor>#5B5B93FF</pcolor>
+    <scolor>#625E93FF</scolor>
+  </wallpaper>
+</wallpapers>

--- a/build/backgrounds/xml/3D-1-red.xml
+++ b/build/backgrounds/xml/3D-1-red.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<!DOCTYPE wallpapers SYSTEM "gnome-wp-list.dtd">
+<wallpapers>
+  <wallpaper deleted="false">
+    <name>3d 1 Red</name>
+    <filename>/usr/share/backgrounds/ublue-os/3D-1/3D-1-red.png</filename>
+    <options>zoom</options>
+    <shade_type>solid</shade_type>
+    <pcolor>#BE4241FF</pcolor>
+    <scolor>#C04241FF</scolor>
+  </wallpaper>
+</wallpapers>

--- a/build/backgrounds/xml/3D-1-violet.xml
+++ b/build/backgrounds/xml/3D-1-violet.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<!DOCTYPE wallpapers SYSTEM "gnome-wp-list.dtd">
+<wallpapers>
+  <wallpaper deleted="false">
+    <name>3d 1 Violet</name>
+    <filename>/usr/share/backgrounds/ublue-os/3D-1/3D-1-violet.png</filename>
+    <options>zoom</options>
+    <shade_type>solid</shade_type>
+    <pcolor>#82469CFF</pcolor>
+    <scolor>#82479CFF</scolor>
+  </wallpaper>
+</wallpapers>

--- a/build/backgrounds/xml/3D-1-yellow.xml
+++ b/build/backgrounds/xml/3D-1-yellow.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<!DOCTYPE wallpapers SYSTEM "gnome-wp-list.dtd">
+<wallpapers>
+  <wallpaper deleted="false">
+    <name>3d 1 Yellow</name>
+    <filename>/usr/share/backgrounds/ublue-os/3D-1/3D-1-yellow.png</filename>
+    <options>zoom</options>
+    <shade_type>solid</shade_type>
+    <pcolor>#BEAB61FF</pcolor>
+    <scolor>#C0AC61FF</scolor>
+  </wallpaper>
+</wallpapers>

--- a/build/backgrounds/xml/3D-2-cyan.xml
+++ b/build/backgrounds/xml/3D-2-cyan.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<!DOCTYPE wallpapers SYSTEM "gnome-wp-list.dtd">
+<wallpapers>
+  <wallpaper deleted="false">
+    <name>3d 2 Cyan</name>
+    <filename>/usr/share/backgrounds/ublue-os/3D-2/3D-2-cyan.png</filename>
+    <options>zoom</options>
+    <shade_type>solid</shade_type>
+    <pcolor>#447C71FF</pcolor>
+    <scolor>#4F8274FF</scolor>
+  </wallpaper>
+</wallpapers>

--- a/build/backgrounds/xml/3D-2-darkblue.xml
+++ b/build/backgrounds/xml/3D-2-darkblue.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<!DOCTYPE wallpapers SYSTEM "gnome-wp-list.dtd">
+<wallpapers>
+  <wallpaper deleted="false">
+    <name>3d 2 Darkblue</name>
+    <filename>/usr/share/backgrounds/ublue-os/3D-2/3D-2-darkblue.png</filename>
+    <options>zoom</options>
+    <shade_type>solid</shade_type>
+    <pcolor>#333A79FF</pcolor>
+    <scolor>#42427EFF</scolor>
+  </wallpaper>
+</wallpapers>

--- a/build/backgrounds/xml/3D-2-deepblue.xml
+++ b/build/backgrounds/xml/3D-2-deepblue.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<!DOCTYPE wallpapers SYSTEM "gnome-wp-list.dtd">
+<wallpapers>
+  <wallpaper deleted="false">
+    <name>3d 2 Deepblue</name>
+    <filename>/usr/share/backgrounds/ublue-os/3D-2/3D-2-deepblue.png</filename>
+    <options>zoom</options>
+    <shade_type>solid</shade_type>
+    <pcolor>#0F0F1AFF</pcolor>
+    <scolor>#565B61FF</scolor>
+  </wallpaper>
+</wallpapers>

--- a/build/backgrounds/xml/3D-2-green.xml
+++ b/build/backgrounds/xml/3D-2-green.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<!DOCTYPE wallpapers SYSTEM "gnome-wp-list.dtd">
+<wallpapers>
+  <wallpaper deleted="false">
+    <name>3d 2 Green</name>
+    <filename>/usr/share/backgrounds/ublue-os/3D-2/3D-2-green.png</filename>
+    <options>zoom</options>
+    <shade_type>solid</shade_type>
+    <pcolor>#52894FFF</pcolor>
+    <scolor>#629153FF</scolor>
+  </wallpaper>
+</wallpapers>

--- a/build/backgrounds/xml/3D-2-lightblue.xml
+++ b/build/backgrounds/xml/3D-2-lightblue.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<!DOCTYPE wallpapers SYSTEM "gnome-wp-list.dtd">
+<wallpapers>
+  <wallpaper deleted="false">
+    <name>3d 2 Lightblue</name>
+    <filename>/usr/share/backgrounds/ublue-os/3D-2/3D-2-lightblue.png</filename>
+    <options>zoom</options>
+    <shade_type>solid</shade_type>
+    <pcolor>#365E81FF</pcolor>
+    <scolor>#3C6183FF</scolor>
+  </wallpaper>
+</wallpapers>

--- a/build/backgrounds/xml/3D-2-lightgray.xml
+++ b/build/backgrounds/xml/3D-2-lightgray.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<!DOCTYPE wallpapers SYSTEM "gnome-wp-list.dtd">
+<wallpapers>
+  <wallpaper deleted="false">
+    <name>3d 2 Lightgray</name>
+    <filename>/usr/share/backgrounds/ublue-os/3D-2/3D-2-lightgray.png</filename>
+    <options>zoom</options>
+    <shade_type>solid</shade_type>
+    <pcolor>#848D99FF</pcolor>
+    <scolor>#7E8A98FF</scolor>
+  </wallpaper>
+</wallpapers>

--- a/build/backgrounds/xml/3D-2-orange.xml
+++ b/build/backgrounds/xml/3D-2-orange.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<!DOCTYPE wallpapers SYSTEM "gnome-wp-list.dtd">
+<wallpapers>
+  <wallpaper deleted="false">
+    <name>3d 2 Orange</name>
+    <filename>/usr/share/backgrounds/ublue-os/3D-2/3D-2-orange.png</filename>
+    <options>zoom</options>
+    <shade_type>solid</shade_type>
+    <pcolor>#985442FF</pcolor>
+    <scolor>#A45A44FF</scolor>
+  </wallpaper>
+</wallpapers>

--- a/build/backgrounds/xml/3D-2-pink.xml
+++ b/build/backgrounds/xml/3D-2-pink.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<!DOCTYPE wallpapers SYSTEM "gnome-wp-list.dtd">
+<wallpapers>
+  <wallpaper deleted="false">
+    <name>3d 2 Pink</name>
+    <filename>/usr/share/backgrounds/ublue-os/3D-2/3D-2-pink.png</filename>
+    <options>zoom</options>
+    <shade_type>solid</shade_type>
+    <pcolor>#875289FF</pcolor>
+    <scolor>#7B4F88FF</scolor>
+  </wallpaper>
+</wallpapers>

--- a/build/backgrounds/xml/3D-2-red.xml
+++ b/build/backgrounds/xml/3D-2-red.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<!DOCTYPE wallpapers SYSTEM "gnome-wp-list.dtd">
+<wallpapers>
+  <wallpaper deleted="false">
+    <name>3d 2 Red</name>
+    <filename>/usr/share/backgrounds/ublue-os/3D-2/3D-2-red.png</filename>
+    <options>zoom</options>
+    <shade_type>solid</shade_type>
+    <pcolor>#963839FF</pcolor>
+    <scolor>#A23D3CFF</scolor>
+  </wallpaper>
+</wallpapers>

--- a/build/backgrounds/xml/3D-2-violet.xml
+++ b/build/backgrounds/xml/3D-2-violet.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<!DOCTYPE wallpapers SYSTEM "gnome-wp-list.dtd">
+<wallpapers>
+  <wallpaper deleted="false">
+    <name>3d 2 Violet</name>
+    <filename>/usr/share/backgrounds/ublue-os/3D-2/3D-2-violet.png</filename>
+    <options>zoom</options>
+    <shade_type>solid</shade_type>
+    <pcolor>#6A3B86FF</pcolor>
+    <scolor>#5F3785FF</scolor>
+  </wallpaper>
+</wallpapers>

--- a/build/backgrounds/xml/3D-2-yellow.xml
+++ b/build/backgrounds/xml/3D-2-yellow.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<!DOCTYPE wallpapers SYSTEM "gnome-wp-list.dtd">
+<wallpapers>
+  <wallpaper deleted="false">
+    <name>3d 2 Yellow</name>
+    <filename>/usr/share/backgrounds/ublue-os/3D-2/3D-2-yellow.png</filename>
+    <options>zoom</options>
+    <shade_type>solid</shade_type>
+    <pcolor>#A39C63FF</pcolor>
+    <scolor>#AEA266FF</scolor>
+  </wallpaper>
+</wallpapers>

--- a/build/backgrounds/xml/wallpaper-dark.xml
+++ b/build/backgrounds/xml/wallpaper-dark.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<!DOCTYPE wallpapers SYSTEM "gnome-wp-list.dtd">
+<wallpapers>
+  <wallpaper deleted="false">
+    <name>Wallpaper Dark</name>
+    <filename>/usr/share/backgrounds/ublue-os/2D/wallpaper-dark.png</filename>
+    <options>zoom</options>
+    <shade_type>solid</shade_type>
+    <pcolor>#10173DFF</pcolor>
+    <scolor>#D0DAECFF</scolor>
+  </wallpaper>
+</wallpapers>

--- a/build/backgrounds/xml/wallpaper-light.xml
+++ b/build/backgrounds/xml/wallpaper-light.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<!DOCTYPE wallpapers SYSTEM "gnome-wp-list.dtd">
+<wallpapers>
+  <wallpaper deleted="false">
+    <name>Wallpaper Light</name>
+    <filename>/usr/share/backgrounds/ublue-os/2D/wallpaper-light.png</filename>
+    <options>zoom</options>
+    <shade_type>solid</shade_type>
+    <pcolor>#B0CFF9FF</pcolor>
+    <scolor>#D9E7FDFF</scolor>
+  </wallpaper>
+</wallpapers>

--- a/build/backgrounds/xml/wallpaper-mid.xml
+++ b/build/backgrounds/xml/wallpaper-mid.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<!DOCTYPE wallpapers SYSTEM "gnome-wp-list.dtd">
+<wallpapers>
+  <wallpaper deleted="false">
+    <name>Wallpaper Mid</name>
+    <filename>/usr/share/backgrounds/ublue-os/2D/wallpaper-mid.png</filename>
+    <options>zoom</options>
+    <shade_type>solid</shade_type>
+    <pcolor>#4F5DA1FF</pcolor>
+    <scolor>#D6E0F5FF</scolor>
+  </wallpaper>
+</wallpapers>


### PR DESCRIPTION
This PR should partially fix #18 - It makes it so there are XML files for every single wallpaper and all of their configurations in the RPM spec
