### PR TITLE
fix(wallpapers): Symlink to wallpapers dir for KDE

### DIFF
--- a/build/backgrounds/ublue-os-wallpapers.spec
+++ b/build/backgrounds/ublue-os-wallpapers.spec
@@ -34,5 +34,8 @@ rm -rf %{buildroot}/tmp
 %attr(0755,root,root) %{_datadir}/gnome-background-properties/*.xml
 %exclude %{_datadir}/background/%{VENDOR}/LICENSE
 
+%post
+ln -sf %{_datadir}/backgrounds/%{VENDOR} %{_datadir}/wallpapers/%{VENDOR}
+
 %changelog
 %autochangelog


### PR DESCRIPTION
Fixes wallpapers under KDE via a symlink from .../backgrounds/ublue-os to .../wallpapers/ublue-os