### PR TITLE
feat: use bling COPR to enable f39 builds with ublue-update

### DIFF
--- a/modules/bling/bling.sh
+++ b/modules/bling/bling.sh
@@ -3,6 +3,10 @@
 # Tell build process to exit if there are any errors.
 set -oue pipefail
 
+# Fetch bling COPR
+REPO="https://copr.fedorainfracloud.org/coprs/ublue-os/bling/repo/fedora-${OS_VERSION}/ublue-os-bling-fedora-${OS_VERSION}.repo"
+wget "${REPO//[$'\t\r\n ']}" -P "/etc/yum.repos.d/"
+
 get_yaml_array INSTALL '.install[]' "$1"
 
 export BLING_DIRECTORY="/tmp/bling"
@@ -17,3 +21,6 @@ for ITEM in "${INSTALL[@]}"; do
     # The trainling newline from $ITEM is removed
     eval "$PWD/${ITEM%$'\n'}.sh"
 done
+
+# Remove bling COPR
+rm /etc/yum.repos.d/ublue-os-bling-fedora-*.repo

--- a/modules/bling/installers/ublue-update.sh
+++ b/modules/bling/installers/ublue-update.sh
@@ -17,4 +17,4 @@ if [[ -f $RPM_OSTREE_CONFIG ]]; then
     fi
 fi
 
-rpm-ostree install "$BLING_DIRECTORY"/rpms/ublue-update*.rpm
+rpm-ostree install ublue-update


### PR DESCRIPTION
this enables f39 support on custom images with ublue-update, by using the COPR instead of the OCI image