### PR TITLE
fix(default-flatpaks): Set BLING_DIRECTORY fallback value

### DIFF
--- a/modules/default-flatpaks/default-flatpaks.sh
+++ b/modules/default-flatpaks/default-flatpaks.sh
@@ -3,6 +3,8 @@
 # Tell build process to exit if there are any errors.
 set -oue pipefail
 
+BLING_DIRECTORY="/tmp/bling"
+
 cp -r "$BLING_DIRECTORY"/files/usr/bin/system-flatpak-setup /usr/bin/system-flatpak-setup
 cp -r "$BLING_DIRECTORY"/files/usr/bin/user-flatpak-setup /usr/bin/user-flatpak-setup
 cp -r "$BLING_DIRECTORY"/files/usr/lib/systemd/system/system-flatpak-setup.service /usr/lib/systemd/system/system-flatpak-setup.service

--- a/modules/default-flatpaks/default-flatpaks.sh
+++ b/modules/default-flatpaks/default-flatpaks.sh
@@ -3,7 +3,7 @@
 # Tell build process to exit if there are any errors.
 set -oue pipefail
 
-BLING_DIRECTORY="/tmp/bling"
+BLING_DIRECTORY="${BLING_DIRECTORY:-"/tmp/bling"}"
 
 cp -r "$BLING_DIRECTORY"/files/usr/bin/system-flatpak-setup /usr/bin/system-flatpak-setup
 cp -r "$BLING_DIRECTORY"/files/usr/bin/user-flatpak-setup /usr/bin/user-flatpak-setup


### PR DESCRIPTION
Should fix the issue brought up in Discord:

```
/tmp/modules/default-flatpaks/default-flatpaks.sh: line 6: BLING_DIRECTORY: unbound variable
```