### PR TITLE
feat: copr build for ublue-os-wallpapers

### DIFF
--- a/build/backgrounds/rpkg.conf
+++ b/build/backgrounds/rpkg.conf
@@ -1,0 +1,2 @@
+[rpkg]
+user_macros = "${git_props:root}/build/backgrounds/rpkg.macros"

--- a/build/backgrounds/rpkg.macros
+++ b/build/backgrounds/rpkg.macros
@@ -1,0 +1,7 @@
+function backgrounds_version {
+    if [ "$GITHUB_REF_NAME" = "" ]; then
+        echo "1.0.0+$(git rev-parse --short HEAD)"
+    else
+        echo "$GITHUB_REF_NAME" 
+    fi
+}

--- a/build/backgrounds/ublue-os-wallpapers.spec
+++ b/build/backgrounds/ublue-os-wallpapers.spec
@@ -1,20 +1,21 @@
 Name:		ublue-os-wallpapers
 Vendor:		ublue-os
-Version:	0.1
+Version:	{{{ backgrounds_version }}}	
 Release:	1%{?dist}
-Summary:	Wallpapers for Ublue OS
+Summary:	Wallpapers for Universal Blue OSes 
 License:	Apache-2.0
-URL:		https://github.com/ublue-os/bling
+URL:		https://github.com/%{vendor}/%{name}
 BuildArch:	noarch
-Source0:	%{NAME}.tar.gz 
+VCS:           {{{ git_dir_vcs }}}
+Source:        {{{ git_dir_pack }}}
+
+%global sub_name %{lua:t=string.gsub(rpm.expand("%{NAME}"), "^ublue%-", ""); print(t)}
 
 %description
 Collection of wallpapers for the Universal Blue operating systems
 
 %prep
-%setup -q -c
-
-%build
+{{{ git_dir_setup_macro }}}
 
 %install
 mkdir -p -m0755 \


### PR DESCRIPTION
By building and distributing the Ublue-Wallpapers package through COPR we make sure people have a stable and reliable way to get the RPMs for it. Maybe replacing the previous `/rpm` copying thing with this could be the best course of action.
