### PR TITLE
fix(default-flatpaks): Activate user-flatpak-setup after network-onli…

### DIFF
--- a/files/usr/lib/systemd/user/user-flatpak-setup.service
+++ b/files/usr/lib/systemd/user/user-flatpak-setup.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=Configure Flatpaks for current user
-Requires=xdg-desktop-autostart.target
+Wants=network-online.target
+After=network-online.target
 
 [Service]
 Type=simple


### PR DESCRIPTION
…ne.target

Based on findings here: https://github.com/ublue-os/bluefin/issues/575#issuecomment-1801237111

It seems that having `Requires=xdg-desktop-autostart.target` was causing problems. I commented out that line in `user-flatpak-setup.service` on my image and rebooted, and was able to open links in Firefox just fine again.

This PR replaces that line with `Wants=network-online.target` and `After=network-online.target`, which also matches `system-flatpak-setup.service`. I've tested these changes in a VM, and it seems to still work as before (but without the aforementioned bug).