### PR TITLE
feat(default-flatpaks): Better handle multiple uses of module

### DIFF
--- a/modules/default-flatpaks/README.md
+++ b/modules/default-flatpaks/README.md
@@ -20,7 +20,7 @@ Flatpak setup can be run again by removing `/etc/ublue-os/system-flatpak-configu
 
 This module stores the Flatpak remote configuration and Flatpak install/remove lists in `/etc/flatpak/`. There are two subdirectories, `user` and `system` corresponding with the install level of the Flatpaks and repositories. Each directory has text files containing the IDs of flatpaks to `install` and `remove`, plus a `repo-info.yml` containing the details of the Flatpak repository.
 
-## Example configuration
+## Example configurations
 
 ```yaml
 type: default-flatpaks
@@ -37,4 +37,17 @@ system:
 # as long as one of the repo- fields is present
 user:
   repo-name: flathub
+```
+
+```yaml
+# Assuming that the above example is called first in a recipe,
+# a subsequent usage might look like this:
+type: default-flatpaks
+system:
+  install:
+    - org.kde.kdenlive
+user:
+  # repo-name will overwrite the previously-configured repo-name for the user remote
+  repo-name: flathub-user
+  repo-title: "Flathub (User)
 ```

--- a/modules/default-flatpaks/README.md
+++ b/modules/default-flatpaks/README.md
@@ -1,6 +1,6 @@
 # `default-flatpaks` module for startingpoint
 
-The `default-flatpaks` module can be used to install flatpaks from a configurable remote on first boot. This module first removes the Fedora Flatpaks remote and Flatpaks that come pre-installed in Fedora. A Flatpak remote is configured the first time the module is used, and subsequent usages of the module will install flatpaks to the same remote. If no Flatpak remote is specified, the module will default to using Flathub.
+The `default-flatpaks` module can be used to install flatpaks from a configurable remote on first boot. This module first removes the Fedora Flatpaks remote and Flatpaks that come pre-installed in Fedora. A Flatpak remote is configured the first time the module is used, but it can be re-configured in subsequent usages of the module. If no Flatpak remote is specified, the module will default to using Flathub.
 
 Flatpaks can either be installed system-wide or per-user, though per-user flatpaks will be installed for every user on a system. Previously-installed flatpaks can also be removed.
 

--- a/modules/default-flatpaks/README.md
+++ b/modules/default-flatpaks/README.md
@@ -44,6 +44,8 @@ user:
 # a subsequent usage might look like this:
 type: default-flatpaks
 system:
+  # If the repo-* fields are omitted, the configured repo will
+  # use the previous configuration. Otherwise, it defaults to Flathub.
   install:
     - org.kde.kdenlive
 user:

--- a/modules/default-flatpaks/default-flatpaks.sh
+++ b/modules/default-flatpaks/default-flatpaks.sh
@@ -43,6 +43,9 @@ repo-url: "$REPO_URL"
 repo-name: "$REPO_NAME"
 repo-title: "$REPO_TITLE"
 EOF
+
+        # Show results of repo configuration
+        cat $REPO_INFO
     fi
 }
 

--- a/modules/default-flatpaks/default-flatpaks.sh
+++ b/modules/default-flatpaks/default-flatpaks.sh
@@ -19,6 +19,7 @@ configure_flatpak_repo () {
 
     # Checks pre-configured repo info, if exists
     if [[ -f $REPO_INFO ]]; then
+        echo "Existing $INSTALL_LEVEL configuration found:"
         cat $REPO_INFO
         CONFIG_URL=$(yq ".repo-url" "$REPO_INFO")
         CONFIG_NAME=$(yq ".repo-name" "$REPO_INFO")


### PR DESCRIPTION
This PR does the following:
- Better handling of multiple uses of the module
  - If repo-url, -name, or -title are specified in a subsequent use of the module, the respective new config will now overwrite the old instead of being ignored
- Both services are always enabled even if configuration isn't present
  - This fixes an issue where, if someone only enabled a user Flatpak remote, Fedora system flatpaks wouldn't be removed
- Adds more output during repo configuration to help with debugging

Changes were tested in a fresh VM with various configurations of the module, including:
- Only configuring a user repo and Flatpak installs
- Using default repo configuration in first module usage, then changing it in subsequent usages
- Configuring the repos in the first usage, then adding to Flatpak install list in subsequent usages