### PR TITLE
fix: make `laptop` work without `justfiles`

### DIFF
--- a/modules/bling/installers/laptop.sh
+++ b/modules/bling/installers/laptop.sh
@@ -13,6 +13,7 @@ fi
 systemctl enable tlp
 systemctl enable fprintd
 mkdir -p /usr/etc/tlp.d
+mkdir -p /usr/share/ublue-os/just/bling/
 cp -r "$BLING_DIRECTORY"/files/laptop/usr/etc/tlp.d/* /usr/etc/tlp.d/
 cp -r "$BLING_DIRECTORY"/files/laptop/usr/share/ublue-os/just/bling/* /usr/share/ublue-os/just/bling/
 sed -i 's@enabled=1@enabled=0@g' /etc/yum.repos.d/_copr_ublue-os_staging.repo


### PR DESCRIPTION
Make sure /usr/share/ublue-os/just/bling exists in case we're using
`laptop` without `justfiles`