### PR TITLE
fix: Revert "fix(default-flatpaks): Don't install packages that are al…

### DIFF
--- a/files/usr/bin/system-flatpak-setup
+++ b/files/usr/bin/system-flatpak-setup
@@ -52,30 +52,22 @@ if [[ ! $REPO_TITLE == "null" ]]; then
   flatpak remote-modify --system $REPO_NAME --title="$REPO_TITLE"
 fi
 
-# Installed flatpaks
+# Lists of flatpaks
 FLATPAK_LIST=$(flatpak list --columns=application)
-
-# Flatpak list files
-INSTALL_LIST_FILE=$(cat /etc/flatpak/system/install)
-REMOVE_LIST_FILE=$(cat /etc/flatpak/system/remove)
+INSTALL_LIST=$(cat /etc/flatpak/system/install)
+REMOVE_LIST=$(cat /etc/flatpak/system/remove)
 
 # Install flatpaks in list
-if [[ -f $INSTALL_LIST_FILE ]]; then
-  INSTALL_LIST=$(echo $FLATPAK_LIST | grep -vf - $INSTALL_LIST_FILE)
-  if [[ -n $INSTALL_LIST ]]; then
-    if ! flatpak install --system --noninteractive $REPO_NAME ${INSTALL_LIST[@]}; then
-      # Exit on error
-      exit 1
-    fi
+if [[ -n $INSTALL_LIST ]]; then
+  if ! flatpak install --system --noninteractive $REPO_NAME ${INSTALL_LIST[@]}; then
+    # Exit on error
+    exit 1
   fi
 fi
 
 # Remove flatpaks in list
-if [[ -f $REMOVE_LIST_FILE ]]; then
-  REMOVE_LIST=$(echo $FLATPAK_LIST | grep -f - $REMOVE_LIST_FILE)
-  if [[ -n $REMOVE_LIST ]]; then
-    flatpak remove --system --noninteractive ${REMOVE_LIST[@]}
-  fi
+if [[ -n $REMOVE_LIST ]]; then
+  flatpak remove --system --noninteractive ${REMOVE_LIST[@]}
 fi
 
 notify-send "Flatpak Installer" "Finished installing system flatpaks" --app-name="Flatpak Installer" -u NORMAL

--- a/files/usr/bin/user-flatpak-setup
+++ b/files/usr/bin/user-flatpak-setup
@@ -34,30 +34,22 @@ if [[ ! $REPO_TITLE == "null" ]]; then
   flatpak remote-modify --user $REPO_NAME --title="$REPO_TITLE"
 fi
 
-# Installed flatpaks
+# Lists of flatpaks
 FLATPAK_LIST=$(flatpak list --columns=application)
-
-# Flatpak list files
-INSTALL_LIST_FILE=$(cat /etc/flatpak/user/install)
-REMOVE_LIST_FILE=$(cat /etc/flatpak/user/remove)
+INSTALL_LIST=$(cat /etc/flatpak/user/install)
+REMOVE_LIST=$(cat /etc/flatpak/user/remove)
 
 # Install flatpaks in list
-if [[ -f $INSTALL_LIST_FILE ]]; then
-  INSTALL_LIST=$(echo $FLATPAK_LIST | grep -vf - $INSTALL_LIST_FILE)
-  if [[ -n $INSTALL_LIST ]]; then
-    if ! flatpak install --user --noninteractive $REPO_NAME ${INSTALL_LIST[@]}; then
-      # Exit on error
-      exit 1
-    fi
+if [[ -n $INSTALL_LIST ]]; then
+  if ! flatpak install --user --noninteractive $REPO_NAME ${INSTALL_LIST[@]}; then
+    # Exit on error
+    exit 1
   fi
 fi
 
 # Remove flatpaks in list
-if [[ -f $REMOVE_LIST_FILE ]]; then
-  REMOVE_LIST=$(echo $FLATPAK_LIST | grep -f - $REMOVE_LIST_FILE)
-  if [[ -n $REMOVE_LIST ]]; then
-    flatpak remove --user --noninteractive ${REMOVE_LIST[@]}
-  fi
+if [[ -n $REMOVE_LIST ]]; then
+  flatpak remove --user --noninteractive $flatpak ${REMOVE_LIST[@]}
 fi
 
 notify-send "Flatpak Installer" "Finished installing user flatpaks" --app-name="Flatpak Installer" -u NORMAL


### PR DESCRIPTION
…ready present or remove packages that aren't there"

This reverts commit 0e971385358e1a29b0d5b26710968d3a9de88dc4.

Causes flatpak setup service to report that flatpaks are configured, even when they're not.