### PR TITLE
fix(default-flatpaks): Install & uninstall flatpaks on every boot

### DIFF
--- a/files/usr/bin/system-flatpak-setup
+++ b/files/usr/bin/system-flatpak-setup
@@ -1,18 +1,7 @@
 #!/usr/bin/env bash
 
-# Script Version
-VER=1
-VER_FILE="/etc/ublue-os/system-flatpak-configured"
-VER_RAN=$(cat $VER_FILE)
-
-# Run script if updated
-if [[ -f $VER_FILE && $VER = $VER_RAN ]]; then
-  echo "Flatpak setup v$VER has already ran. Exiting..."
-  exit 0
-fi
-
 # Opt out of and remove Fedora's flatpak repo
-if grep -qz 'fedora' <<< $(flatpak remotes); then
+if grep -qz 'fedora' <<< "$(flatpak remotes)"; then
   /usr/bin/gnome-software --quit
   /usr/lib/fedora-third-party/fedora-third-party-opt-out
   /usr/bin/fedora-third-party disable
@@ -21,11 +10,11 @@ if grep -qz 'fedora' <<< $(flatpak remotes); then
 
   # Remove flatpak apps from origin fedora
   FEDORA_FLATPAKS=$(flatpak list --app --columns=application,origin | grep -w 'fedora' | awk '{print $1}')
-  flatpak remove --system --noninteractive ${FEDORA_FLATPAKS[@]}
+  flatpak remove --system --noninteractive "${FEDORA_FLATPAKS[@]}"
 
   # Remove flatpak runtimes from origin fedora
   FEDORA_FLATPAKS=$(flatpak list --runtime --columns=application,arch,branch,origin | grep -w 'fedora' | awk '{print $1"/"$2"/"$3}')
-  flatpak remove --system --noninteractive ${FEDORA_FLATPAKS[@]}
+  flatpak remove --system --noninteractive "${FEDORA_FLATPAKS[@]}"
 fi
 
 REPO_INFO="/etc/flatpak/system/repo-info.yml"
@@ -36,43 +25,50 @@ REPO_TITLE=$(yq '.repo-title' $REPO_INFO)
 # Set up system-wide Flatpak repository
 if [[ ! $REPO_URL == "null" && ! $REPO_NAME == "null" ]]; then
   echo "Adding system-wide remote $REPO_NAME from $REPO_URL"
-  flatpak remote-add --if-not-exists --system $REPO_NAME $REPO_URL
+  flatpak remote-add --if-not-exists --system "$REPO_NAME" "$REPO_URL"
 fi
 
 # If configured remote is flathub, enable it here.
 # Flathub is already installed on Fedora, but not enabled by default,
 # so the above command won't add it again
 if [[ $REPO_NAME == "flathub" ]]; then
-  flatpak remote-modify --system $REPO_NAME --enable
+  flatpak remote-modify --system "$REPO_NAME" --enable
 fi
 
 # Change repository title to configured title, if not null
 if [[ ! $REPO_TITLE == "null" ]]; then
   echo "Setting title $REPO_TITLE for remote $REPO_NAME"
-  flatpak remote-modify --system $REPO_NAME --title="$REPO_TITLE"
+  flatpak remote-modify --system "$REPO_NAME" --title="$REPO_TITLE"
 fi
 
-# Lists of flatpaks
+# Installed flatpaks
 FLATPAK_LIST=$(flatpak list --columns=application)
-INSTALL_LIST=$(cat /etc/flatpak/system/install)
-REMOVE_LIST=$(cat /etc/flatpak/system/remove)
+
+# Flatpak list files
+INSTALL_LIST_FILE="/etc/flatpak/system/install"
+REMOVE_LIST_FILE="/etc/flatpak/system/remove"
 
 # Install flatpaks in list
-if [[ -n $INSTALL_LIST ]]; then
-  if ! flatpak install --system --noninteractive $REPO_NAME ${INSTALL_LIST[@]}; then
-    # Exit on error
-    exit 1
+if [[ -f $INSTALL_LIST_FILE ]]; then
+  if [[ -n $FLATPAK_LIST ]]; then
+    INSTALL_LIST=$(echo "$FLATPAK_LIST" | grep -o -vf "$INSTALL_LIST_FILE")
+  else
+    INSTALL_LIST=$(cat $INSTALL_LIST_FILE)
+  fi
+  if [[ -n $INSTALL_LIST ]]; then
+    if ! flatpak install --system --noninteractive "$REPO_NAME" "${INSTALL_LIST[@]}"; then
+      # Exit on error
+      exit 1
+    fi  
   fi
 fi
 
 # Remove flatpaks in list
-if [[ -n $REMOVE_LIST ]]; then
-  flatpak remove --system --noninteractive ${REMOVE_LIST[@]}
+if [[ -f $REMOVE_LIST_FILE ]]; then
+  REMOVE_LIST=$(echo "$FLATPAK_LIST" | grep -o -f "$REMOVE_LIST_FILE")
+  if [[ -n $REMOVE_LIST ]]; then
+    flatpak uninstall --system --noninteractive "${REMOVE_LIST[@]}"
+  fi
 fi
 
 notify-send "Flatpak Installer" "Finished installing system flatpaks" --app-name="Flatpak Installer" -u NORMAL
-
-# Prevent future executions
-echo "Writing state file"
-mkdir -p /etc/ublue-os
-echo $VER > $VER_FILE

--- a/files/usr/bin/system-flatpak-setup
+++ b/files/usr/bin/system-flatpak-setup
@@ -24,8 +24,8 @@ REPO_TITLE=$(yq '.repo-title' $REPO_INFO)
 
 # Set up system-wide Flatpak repository
 if [[ ! $REPO_URL == "null" && ! $REPO_NAME == "null" ]]; then
-  echo "Adding system-wide remote $REPO_NAME from $REPO_URL"
   flatpak remote-add --if-not-exists --system "$REPO_NAME" "$REPO_URL"
+  echo "Adding system-wide remote $REPO_NAME from $REPO_URL"  
 fi
 
 # If configured remote is flathub, enable it here.
@@ -37,8 +37,8 @@ fi
 
 # Change repository title to configured title, if not null
 if [[ ! $REPO_TITLE == "null" ]]; then
-  echo "Setting title $REPO_TITLE for remote $REPO_NAME"
   flatpak remote-modify --system "$REPO_NAME" --title="$REPO_TITLE"
+  echo "Setting title $REPO_TITLE for remote $REPO_NAME"  
 fi
 
 # Installed flatpaks

--- a/files/usr/bin/system-flatpak-setup
+++ b/files/usr/bin/system-flatpak-setup
@@ -56,10 +56,8 @@ if [[ -f $INSTALL_LIST_FILE ]]; then
     INSTALL_LIST=$(cat $INSTALL_LIST_FILE)
   fi
   if [[ -n $INSTALL_LIST ]]; then
-    if ! flatpak install --system --noninteractive "$REPO_NAME" ${INSTALL_LIST[@]}; then
-      # Exit on error
-      exit 1
-    fi  
+    flatpak install --system --noninteractive "$REPO_NAME" ${INSTALL_LIST[@]}
+    notify-send "Flatpak Installer" "Finished install of system flatpaks" --app-name="Flatpak Installer" -u NORMAL
   fi
 fi
 
@@ -68,7 +66,8 @@ if [[ -f $REMOVE_LIST_FILE ]]; then
   REMOVE_LIST=$(echo "$FLATPAK_LIST" | grep -o -f - "$REMOVE_LIST_FILE")
   if [[ -n $REMOVE_LIST ]]; then
     flatpak uninstall --system --noninteractive ${REMOVE_LIST[@]}
+    notify-send "Flatpak Installer" "Finished uninstall of system flatpaks" --app-name="Flatpak Installer" -u NORMAL
   fi
 fi
 
-notify-send "Flatpak Installer" "Finished installing system flatpaks" --app-name="Flatpak Installer" -u NORMAL
+

--- a/files/usr/bin/system-flatpak-setup
+++ b/files/usr/bin/system-flatpak-setup
@@ -51,7 +51,7 @@ REMOVE_LIST_FILE="/etc/flatpak/system/remove"
 # Install flatpaks in list
 if [[ -f $INSTALL_LIST_FILE ]]; then
   if [[ -n $FLATPAK_LIST ]]; then
-    INSTALL_LIST=$(echo "$FLATPAK_LIST" | grep -o -vf "$INSTALL_LIST_FILE")
+    INSTALL_LIST=$(echo "$FLATPAK_LIST" | grep -vf - "$INSTALL_LIST_FILE")
   else
     INSTALL_LIST=$(cat $INSTALL_LIST_FILE)
   fi
@@ -65,7 +65,7 @@ fi
 
 # Remove flatpaks in list
 if [[ -f $REMOVE_LIST_FILE ]]; then
-  REMOVE_LIST=$(echo "$FLATPAK_LIST" | grep -o -f "$REMOVE_LIST_FILE")
+  REMOVE_LIST=$(echo "$FLATPAK_LIST" | grep -o -f - "$REMOVE_LIST_FILE")
   if [[ -n $REMOVE_LIST ]]; then
     flatpak uninstall --system --noninteractive "${REMOVE_LIST[@]}"
   fi

--- a/files/usr/bin/system-flatpak-setup
+++ b/files/usr/bin/system-flatpak-setup
@@ -10,11 +10,11 @@ if grep -qz 'fedora' <<< "$(flatpak remotes)"; then
 
   # Remove flatpak apps from origin fedora
   FEDORA_FLATPAKS=$(flatpak list --app --columns=application,origin | grep -w 'fedora' | awk '{print $1}')
-  flatpak remove --system --noninteractive "${FEDORA_FLATPAKS[@]}"
+  flatpak remove --system --noninteractive ${FEDORA_FLATPAKS[@]}
 
   # Remove flatpak runtimes from origin fedora
   FEDORA_FLATPAKS=$(flatpak list --runtime --columns=application,arch,branch,origin | grep -w 'fedora' | awk '{print $1"/"$2"/"$3}')
-  flatpak remove --system --noninteractive "${FEDORA_FLATPAKS[@]}"
+  flatpak remove --system --noninteractive ${FEDORA_FLATPAKS[@]}
 fi
 
 REPO_INFO="/etc/flatpak/system/repo-info.yml"
@@ -56,7 +56,7 @@ if [[ -f $INSTALL_LIST_FILE ]]; then
     INSTALL_LIST=$(cat $INSTALL_LIST_FILE)
   fi
   if [[ -n $INSTALL_LIST ]]; then
-    if ! flatpak install --system --noninteractive "$REPO_NAME" "${INSTALL_LIST[@]}"; then
+    if ! flatpak install --system --noninteractive "$REPO_NAME" ${INSTALL_LIST[@]}; then
       # Exit on error
       exit 1
     fi  
@@ -67,7 +67,7 @@ fi
 if [[ -f $REMOVE_LIST_FILE ]]; then
   REMOVE_LIST=$(echo "$FLATPAK_LIST" | grep -o -f - "$REMOVE_LIST_FILE")
   if [[ -n $REMOVE_LIST ]]; then
-    flatpak uninstall --system --noninteractive "${REMOVE_LIST[@]}"
+    flatpak uninstall --system --noninteractive ${REMOVE_LIST[@]}
   fi
 fi
 

--- a/files/usr/bin/user-flatpak-setup
+++ b/files/usr/bin/user-flatpak-setup
@@ -38,10 +38,8 @@ if [[ -f $INSTALL_LIST_FILE ]]; then
     INSTALL_LIST=$(cat $INSTALL_LIST_FILE)
   fi
   if [[ -n $INSTALL_LIST ]]; then
-    if ! flatpak install --user --noninteractive "$REPO_NAME" ${INSTALL_LIST[@]}; then
-      # Exit on error
-      exit 1
-    fi  
+    flatpak install --user --noninteractive "$REPO_NAME" ${INSTALL_LIST[@]}
+    notify-send "Flatpak Installer" "Finished install of user flatpaks" --app-name="Flatpak Installer" -u NORMAL
   fi
 fi
 
@@ -50,7 +48,6 @@ if [[ -f $REMOVE_LIST_FILE ]]; then
   REMOVE_LIST=$(echo "$FLATPAK_LIST" | grep -o -f - "$REMOVE_LIST_FILE")
   if [[ -n $REMOVE_LIST ]]; then
     flatpak uninstall --user --noninteractive ${REMOVE_LIST[@]}
+    notify-send "Flatpak Installer" "Finished uninstall of user flatpaks" --app-name="Flatpak Installer" -u NORMAL
   fi  
 fi
-
-notify-send "Flatpak Installer" "Finished installing user flatpaks" --app-name="Flatpak Installer" -u NORMAL

--- a/files/usr/bin/user-flatpak-setup
+++ b/files/usr/bin/user-flatpak-setup
@@ -38,7 +38,7 @@ if [[ -f $INSTALL_LIST_FILE ]]; then
     INSTALL_LIST=$(cat $INSTALL_LIST_FILE)
   fi
   if [[ -n $INSTALL_LIST ]]; then
-    if ! flatpak install --user --noninteractive "$REPO_NAME" "${INSTALL_LIST[@]}"; then
+    if ! flatpak install --user --noninteractive "$REPO_NAME" ${INSTALL_LIST[@]}; then
       # Exit on error
       exit 1
     fi  
@@ -49,7 +49,7 @@ fi
 if [[ -f $REMOVE_LIST_FILE ]]; then
   REMOVE_LIST=$(echo "$FLATPAK_LIST" | grep -o -f - "$REMOVE_LIST_FILE")
   if [[ -n $REMOVE_LIST ]]; then
-    flatpak uninstall --user --noninteractive "$flatpak" "${REMOVE_LIST[@]}"
+    flatpak uninstall --user --noninteractive "$flatpak" ${REMOVE_LIST[@]}
   fi  
 fi
 

--- a/files/usr/bin/user-flatpak-setup
+++ b/files/usr/bin/user-flatpak-setup
@@ -33,7 +33,7 @@ REMOVE_LIST_FILE="/etc/flatpak/user/remove"
 # Install flatpaks in list
 if [[ -f $INSTALL_LIST_FILE ]]; then
   if [[ -n $FLATPAK_LIST ]]; then
-    INSTALL_LIST=$(echo "$FLATPAK_LIST" | grep -o -vf "$INSTALL_LIST_FILE")
+    INSTALL_LIST=$(echo "$FLATPAK_LIST" | grep -vf - "$INSTALL_LIST_FILE")
   else
     INSTALL_LIST=$(cat $INSTALL_LIST_FILE)
   fi
@@ -47,7 +47,7 @@ fi
 
 # Remove flatpaks in list
 if [[ -f $REMOVE_LIST_FILE ]]; then
-  REMOVE_LIST=$(echo "$FLATPAK_LIST" | grep -o -f "$REMOVE_LIST_FILE")
+  REMOVE_LIST=$(echo "$FLATPAK_LIST" | grep -o -f - "$REMOVE_LIST_FILE")
   if [[ -n $REMOVE_LIST ]]; then
     flatpak uninstall --user --noninteractive "$flatpak" "${REMOVE_LIST[@]}"
   fi  

--- a/files/usr/bin/user-flatpak-setup
+++ b/files/usr/bin/user-flatpak-setup
@@ -49,7 +49,7 @@ fi
 if [[ -f $REMOVE_LIST_FILE ]]; then
   REMOVE_LIST=$(echo "$FLATPAK_LIST" | grep -o -f - "$REMOVE_LIST_FILE")
   if [[ -n $REMOVE_LIST ]]; then
-    flatpak uninstall --user --noninteractive "$flatpak" ${REMOVE_LIST[@]}
+    flatpak uninstall --user --noninteractive ${REMOVE_LIST[@]}
   fi  
 fi
 

--- a/files/usr/bin/user-flatpak-setup
+++ b/files/usr/bin/user-flatpak-setup
@@ -13,14 +13,14 @@ REPO_TITLE=$(yq '.repo-title' $REPO_INFO)
 
 # Set up per-user Flatpak repository
 if [[ ! $REPO_URL == "null" && ! $REPO_NAME == "null" ]]; then
-  echo "Adding remote $REPO_NAME from $REPO_URL"
   flatpak remote-add --if-not-exists --user "$REPO_NAME" "$REPO_URL"
+  echo "Adding remote $REPO_NAME from $REPO_URL"  
 fi
 
 # Change repository title to configured title, if not null
 if [[ ! $REPO_TITLE == "null" ]]; then
-  echo "Setting title $REPO_TITLE for remote $REPO_NAME"
   flatpak remote-modify --user "$REPO_NAME" --title="$REPO_TITLE"
+  echo "Setting title $REPO_TITLE for remote $REPO_NAME"  
 fi
 
 # Installed flatpaks

--- a/files/usr/bin/user-flatpak-setup
+++ b/files/usr/bin/user-flatpak-setup
@@ -1,18 +1,7 @@
 #!/usr/bin/env bash
 
-# Script Version
-VER=1
-VER_FILE="$HOME/.config/ublue-os/user-flatpak-configured"
-VER_RAN=$(cat $VER_FILE)
-
-# Run script if updated
-if [[ -f $VER_FILE && $VER = $VER_RAN ]]; then
-  echo "Flatpak setup v$VER has already ran. Exiting..."
-  exit 0
-fi
-
 # Remove Fedora's flatpak repo, if it exists
-if grep -qz 'fedora' <<< $(flatpak remotes); then
+if grep -qz 'fedora' <<< "$(flatpak remotes)"; then
   flatpak remote-delete --user fedora --force
   flatpak remote-delete --user fedora-testing --force
 fi
@@ -25,36 +14,43 @@ REPO_TITLE=$(yq '.repo-title' $REPO_INFO)
 # Set up per-user Flatpak repository
 if [[ ! $REPO_URL == "null" && ! $REPO_NAME == "null" ]]; then
   echo "Adding remote $REPO_NAME from $REPO_URL"
-  flatpak remote-add --if-not-exists --user $REPO_NAME $REPO_URL
+  flatpak remote-add --if-not-exists --user "$REPO_NAME" "$REPO_URL"
 fi
 
 # Change repository title to configured title, if not null
 if [[ ! $REPO_TITLE == "null" ]]; then
   echo "Setting title $REPO_TITLE for remote $REPO_NAME"
-  flatpak remote-modify --user $REPO_NAME --title="$REPO_TITLE"
+  flatpak remote-modify --user "$REPO_NAME" --title="$REPO_TITLE"
 fi
 
-# Lists of flatpaks
+# Installed flatpaks
 FLATPAK_LIST=$(flatpak list --columns=application)
-INSTALL_LIST=$(cat /etc/flatpak/user/install)
-REMOVE_LIST=$(cat /etc/flatpak/user/remove)
+
+# Flatpak list files
+INSTALL_LIST_FILE="/etc/flatpak/user/install"
+REMOVE_LIST_FILE="/etc/flatpak/user/remove"
 
 # Install flatpaks in list
-if [[ -n $INSTALL_LIST ]]; then
-  if ! flatpak install --user --noninteractive $REPO_NAME ${INSTALL_LIST[@]}; then
-    # Exit on error
-    exit 1
+if [[ -f $INSTALL_LIST_FILE ]]; then
+  if [[ -n $FLATPAK_LIST ]]; then
+    INSTALL_LIST=$(echo "$FLATPAK_LIST" | grep -o -vf "$INSTALL_LIST_FILE")
+  else
+    INSTALL_LIST=$(cat $INSTALL_LIST_FILE)
+  fi
+  if [[ -n $INSTALL_LIST ]]; then
+    if ! flatpak install --user --noninteractive "$REPO_NAME" "${INSTALL_LIST[@]}"; then
+      # Exit on error
+      exit 1
+    fi  
   fi
 fi
 
 # Remove flatpaks in list
-if [[ -n $REMOVE_LIST ]]; then
-  flatpak remove --user --noninteractive $flatpak ${REMOVE_LIST[@]}
+if [[ -f $REMOVE_LIST_FILE ]]; then
+  REMOVE_LIST=$(echo "$FLATPAK_LIST" | grep -o -f "$REMOVE_LIST_FILE")
+  if [[ -n $REMOVE_LIST ]]; then
+    flatpak uninstall --user --noninteractive "$flatpak" "${REMOVE_LIST[@]}"
+  fi  
 fi
 
 notify-send "Flatpak Installer" "Finished installing user flatpaks" --app-name="Flatpak Installer" -u NORMAL
-
-# Prevent future executions
-echo "Writing state file"
-mkdir -p $HOME/.config/ublue-os/
-echo $VER > $VER_FILE

--- a/modules/default-flatpaks/README.md
+++ b/modules/default-flatpaks/README.md
@@ -9,7 +9,7 @@ The module uses the following scripts to handle flatpak setup:
 - `/usr/bin/system-flatpak-setup`
 - `/usr/bin/user-flatpak-setup`
 
-The scripts are run on every boot and login by these services:
+The scripts are run on every boot by these services:
 
 - `/usr/lib/systemd/system/system-flatpak-setup.service`
 - `/usr/lib/systemd/user/user-flatpak-setup-service`

--- a/modules/default-flatpaks/README.md
+++ b/modules/default-flatpaks/README.md
@@ -1,6 +1,6 @@
 # `default-flatpaks` module for startingpoint
 
-The `default-flatpaks` module can be used to install or uninstall flatpaks from a configurable remote on every boot. This module first removes the Fedora Flatpaks remote and Flatpaks that come pre-installed in Fedora. A Flatpak remote is configured the first time the module is used, but it can be re-configured in subsequent usages of the module. If no Flatpak remote is specified, the module will default to using Flathub.
+The `default-flatpaks` module can be used to install or uninstall flatpaks from a configurable remote on every boot. It skips that operation if no changes are detected. This module first removes the Fedora Flatpaks remote and Flatpaks that come pre-installed in Fedora. A Flatpak remote is configured the first time the module is used, but it can be re-configured in subsequent usages of the module. If no Flatpak remote is specified, the module will default to using Flathub.
 
 Flatpaks can either be installed system-wide or per-user, though per-user flatpaks will be installed for every user on a system. Previously-installed flatpaks can also be removed.
 

--- a/modules/default-flatpaks/README.md
+++ b/modules/default-flatpaks/README.md
@@ -1,6 +1,6 @@
 # `default-flatpaks` module for startingpoint
 
-The `default-flatpaks` module can be used to install flatpaks from a configurable remote on first boot. This module first removes the Fedora Flatpaks remote and Flatpaks that come pre-installed in Fedora. A Flatpak remote is configured the first time the module is used, but it can be re-configured in subsequent usages of the module. If no Flatpak remote is specified, the module will default to using Flathub.
+The `default-flatpaks` module can be used to install or uninstall flatpaks from a configurable remote on every boot. This module first removes the Fedora Flatpaks remote and Flatpaks that come pre-installed in Fedora. A Flatpak remote is configured the first time the module is used, but it can be re-configured in subsequent usages of the module. If no Flatpak remote is specified, the module will default to using Flathub.
 
 Flatpaks can either be installed system-wide or per-user, though per-user flatpaks will be installed for every user on a system. Previously-installed flatpaks can also be removed.
 
@@ -9,14 +9,12 @@ The module uses the following scripts to handle flatpak setup:
 - `/usr/bin/system-flatpak-setup`
 - `/usr/bin/user-flatpak-setup`
 
-The scripts are run on first boot and login by these services:
+The scripts are run on every boot and login by these services:
 
 - `/usr/lib/systemd/system/system-flatpak-setup.service`
 - `/usr/lib/systemd/user/user-flatpak-setup-service`
 
-`system-flatpak-setup` checks the flatpak repo information and install/remove lists created by the module. It also checks for the existence of `/etc/ublue-os/system-flatpak-configured` before running. `user-flatpak-setup` functions the same for user flatpaks, but checks for `$HOME/.config/ublue-os/user-flatpak-configured` instead.
-
-Flatpak setup can be run again by removing `/etc/ublue-os/system-flatpak-configured` for system-wide flatpaks, or `$HOME/.config/ublue-os/user-flatpak-configured` for user flatpaks.
+`system-flatpak-setup` checks the flatpak repo information and install/remove lists created by the module. `user-flatpak-setup` functions the same for user flatpaks.
 
 This module stores the Flatpak remote configuration and Flatpak install/remove lists in `/etc/flatpak/`. There are two subdirectories, `user` and `system` corresponding with the install level of the Flatpaks and repositories. Each directory has text files containing the IDs of flatpaks to `install` and `remove`, plus a `repo-info.yml` containing the details of the Flatpak repository.
 
@@ -32,7 +30,7 @@ system:
   install:
     - org.gnome.Loupe
   remove:
-    - org.gnome.eog
+    - org.gnome.eog # When you have the same package name in both install & remove, remove will take the advantage
 # A flatpak repo can also be added without having to install flatpaks,
 # as long as one of the repo- fields is present
 user:

--- a/modules/default-flatpaks/README.md
+++ b/modules/default-flatpaks/README.md
@@ -30,7 +30,7 @@ system:
   install:
     - org.gnome.Loupe
   remove:
-    - org.gnome.eog # When you have the same package name in both install & remove, remove will take the advantage
+    - org.gnome.eog
 # A flatpak repo can also be added without having to install flatpaks,
 # as long as one of the repo- fields is present
 user:


### PR DESCRIPTION
This allows us to ditch the state file concept, which only allows us to run flatpak-setup once. After that, you need to manually delete the state file (system & user-flatpak-configured) if you want to have new changes from flatpak-setup.

This is not ideal.

We do not have the luxury of Bazzite, which allows you to change the version of the setup in setup service to automatically start it again (that's what they do).

Instead, we will install & uninstall only those flatpaks which are not on the list, ditching the need to have version checking (Thanks to @EyeCantCU for changes). 

When there are no updates, flatpak-setup service automatically skips that process & exits.

The only process that always runs without skipping on every boot is adding flatpak remote & changing repository title if you did that in recipe.

Take a note that adding flatpak remote has --if-not-exists flag, so it does nothing if your repo stays the same.
If you decide to change the repo name or repo link to new one again, currently, you will have to delete the old repo manually yourself.
Changing repo title overwrites always (which means you can change repo title any time without worrying about above stuff).

I incorporated some shell formatting fixes, thanks to shellcheck.net.