### PR TITLE
feat(default-flatpaks): Add info about which flatpaks are installed

### DIFF
--- a/files/usr/bin/system-flatpak-setup
+++ b/files/usr/bin/system-flatpak-setup
@@ -60,7 +60,7 @@ if [[ -f $INSTALL_LIST_FILE ]]; then
   fi
   if [[ -n $INSTALL_LIST ]]; then
     flatpak install --system --noninteractive "$REPO_NAME" ${INSTALL_LIST[@]}
-    if [[ $NOTIFICATIONS == "$true" ]]; then
+    if [[ $NOTIFICATIONS == "true" ]]; then
       notify-send "Flatpak Installer" "Finished install of system flatpaks:\n$INSTALL_LIST" --app-name="Flatpak Installer" -u NORMAL
     fi
   fi
@@ -71,7 +71,7 @@ if [[ -f $REMOVE_LIST_FILE ]]; then
   REMOVE_LIST=$(echo "$FLATPAK_LIST" | grep -o -f - "$REMOVE_LIST_FILE")
   if [[ -n $REMOVE_LIST ]]; then
     flatpak uninstall --system --noninteractive ${REMOVE_LIST[@]}
-    if [[ $NOTIFICATIONS == "$true" ]]; then
+    if [[ $NOTIFICATIONS == "true" ]]; then
       notify-send "Flatpak Installer" "Finished uninstall of system flatpaks:\n$REMOVE_LIST" --app-name="Flatpak Installer" -u NORMAL
     fi
   fi

--- a/files/usr/bin/system-flatpak-setup
+++ b/files/usr/bin/system-flatpak-setup
@@ -60,7 +60,7 @@ if [[ -f $INSTALL_LIST_FILE ]]; then
   fi
   if [[ -n $INSTALL_LIST ]]; then
     flatpak install --system --noninteractive "$REPO_NAME" ${INSTALL_LIST[@]}
-    if [[ $NOTIFICATIONS == 1 ]]; then
+    if [[ $NOTIFICATIONS == "$true" ]]; then
       notify-send "Flatpak Installer" "Finished install of system flatpaks:\n$INSTALL_LIST" --app-name="Flatpak Installer" -u NORMAL
     fi
   fi
@@ -71,7 +71,7 @@ if [[ -f $REMOVE_LIST_FILE ]]; then
   REMOVE_LIST=$(echo "$FLATPAK_LIST" | grep -o -f - "$REMOVE_LIST_FILE")
   if [[ -n $REMOVE_LIST ]]; then
     flatpak uninstall --system --noninteractive ${REMOVE_LIST[@]}
-    if [[ $NOTIFICATIONS == 1 ]]; then
+    if [[ $NOTIFICATIONS == "$true" ]]; then
       notify-send "Flatpak Installer" "Finished uninstall of system flatpaks:\n$REMOVE_LIST" --app-name="Flatpak Installer" -u NORMAL
     fi
   fi

--- a/files/usr/bin/system-flatpak-setup
+++ b/files/usr/bin/system-flatpak-setup
@@ -41,6 +41,9 @@ if [[ ! $REPO_TITLE == "null" ]]; then
   echo "Setting title $REPO_TITLE for remote $REPO_NAME"  
 fi
 
+# Notifications config
+NOTIFICATIONS=$(cat /etc/flatpak/notifications)
+
 # Installed flatpaks
 FLATPAK_LIST=$(flatpak list --columns=application)
 
@@ -57,7 +60,9 @@ if [[ -f $INSTALL_LIST_FILE ]]; then
   fi
   if [[ -n $INSTALL_LIST ]]; then
     flatpak install --system --noninteractive "$REPO_NAME" ${INSTALL_LIST[@]}
-    notify-send "Flatpak Installer" "Finished install of system flatpaks" --app-name="Flatpak Installer" -u NORMAL
+    if [[ $NOTIFICATIONS == 1 ]]; then
+      notify-send "Flatpak Installer" "Finished install of system flatpaks:\n$INSTALL_LIST" --app-name="Flatpak Installer" -u NORMAL
+    fi
   fi
 fi
 
@@ -66,8 +71,8 @@ if [[ -f $REMOVE_LIST_FILE ]]; then
   REMOVE_LIST=$(echo "$FLATPAK_LIST" | grep -o -f - "$REMOVE_LIST_FILE")
   if [[ -n $REMOVE_LIST ]]; then
     flatpak uninstall --system --noninteractive ${REMOVE_LIST[@]}
-    notify-send "Flatpak Installer" "Finished uninstall of system flatpaks" --app-name="Flatpak Installer" -u NORMAL
+    if [[ $NOTIFICATIONS == 1 ]]; then
+      notify-send "Flatpak Installer" "Finished uninstall of system flatpaks:\n$REMOVE_LIST" --app-name="Flatpak Installer" -u NORMAL
+    fi
   fi
 fi
-
-

--- a/files/usr/bin/user-flatpak-setup
+++ b/files/usr/bin/user-flatpak-setup
@@ -23,6 +23,9 @@ if [[ ! $REPO_TITLE == "null" ]]; then
   echo "Setting title $REPO_TITLE for remote $REPO_NAME"  
 fi
 
+# Notifications config
+NOTIFICATIONS=$(cat /etc/flatpak/notifications)
+
 # Installed flatpaks
 FLATPAK_LIST=$(flatpak list --columns=application)
 
@@ -39,7 +42,9 @@ if [[ -f $INSTALL_LIST_FILE ]]; then
   fi
   if [[ -n $INSTALL_LIST ]]; then
     flatpak install --user --noninteractive "$REPO_NAME" ${INSTALL_LIST[@]}
-    notify-send "Flatpak Installer" "Finished install of user flatpaks" --app-name="Flatpak Installer" -u NORMAL
+    if [[ $NOTIFICATIONS == 1 ]]; then
+      notify-send "Flatpak Installer" "Finished install of user flatpaks:\n$INSTALL_LIST" --app-name="Flatpak Installer" -u NORMAL
+    fi  
   fi
 fi
 
@@ -48,6 +53,8 @@ if [[ -f $REMOVE_LIST_FILE ]]; then
   REMOVE_LIST=$(echo "$FLATPAK_LIST" | grep -o -f - "$REMOVE_LIST_FILE")
   if [[ -n $REMOVE_LIST ]]; then
     flatpak uninstall --user --noninteractive ${REMOVE_LIST[@]}
-    notify-send "Flatpak Installer" "Finished uninstall of user flatpaks" --app-name="Flatpak Installer" -u NORMAL
+    if [[ $NOTIFICATIONS == 1 ]]; then    
+      notify-send "Flatpak Installer" "Finished uninstall of user flatpaks:\n$REMOVE_LIST" --app-name="Flatpak Installer" -u NORMAL
+    fi  
   fi  
 fi

--- a/files/usr/bin/user-flatpak-setup
+++ b/files/usr/bin/user-flatpak-setup
@@ -42,7 +42,7 @@ if [[ -f $INSTALL_LIST_FILE ]]; then
   fi
   if [[ -n $INSTALL_LIST ]]; then
     flatpak install --user --noninteractive "$REPO_NAME" ${INSTALL_LIST[@]}
-    if [[ $NOTIFICATIONS == 1 ]]; then
+    if [[ $NOTIFICATIONS == "$true" ]]; then
       notify-send "Flatpak Installer" "Finished install of user flatpaks:\n$INSTALL_LIST" --app-name="Flatpak Installer" -u NORMAL
     fi  
   fi
@@ -53,7 +53,7 @@ if [[ -f $REMOVE_LIST_FILE ]]; then
   REMOVE_LIST=$(echo "$FLATPAK_LIST" | grep -o -f - "$REMOVE_LIST_FILE")
   if [[ -n $REMOVE_LIST ]]; then
     flatpak uninstall --user --noninteractive ${REMOVE_LIST[@]}
-    if [[ $NOTIFICATIONS == 1 ]]; then    
+    if [[ $NOTIFICATIONS == "$true" ]]; then    
       notify-send "Flatpak Installer" "Finished uninstall of user flatpaks:\n$REMOVE_LIST" --app-name="Flatpak Installer" -u NORMAL
     fi  
   fi  

--- a/files/usr/bin/user-flatpak-setup
+++ b/files/usr/bin/user-flatpak-setup
@@ -42,7 +42,7 @@ if [[ -f $INSTALL_LIST_FILE ]]; then
   fi
   if [[ -n $INSTALL_LIST ]]; then
     flatpak install --user --noninteractive "$REPO_NAME" ${INSTALL_LIST[@]}
-    if [[ $NOTIFICATIONS == "$true" ]]; then
+    if [[ $NOTIFICATIONS == "true" ]]; then
       notify-send "Flatpak Installer" "Finished install of user flatpaks:\n$INSTALL_LIST" --app-name="Flatpak Installer" -u NORMAL
     fi  
   fi
@@ -53,7 +53,7 @@ if [[ -f $REMOVE_LIST_FILE ]]; then
   REMOVE_LIST=$(echo "$FLATPAK_LIST" | grep -o -f - "$REMOVE_LIST_FILE")
   if [[ -n $REMOVE_LIST ]]; then
     flatpak uninstall --user --noninteractive ${REMOVE_LIST[@]}
-    if [[ $NOTIFICATIONS == "$true" ]]; then    
+    if [[ $NOTIFICATIONS == "true" ]]; then    
       notify-send "Flatpak Installer" "Finished uninstall of user flatpaks:\n$REMOVE_LIST" --app-name="Flatpak Installer" -u NORMAL
     fi  
   fi  

--- a/modules/default-flatpaks/README.md
+++ b/modules/default-flatpaks/README.md
@@ -18,22 +18,15 @@ The scripts are run on every boot by these services:
 
 This module stores the Flatpak remote configuration and Flatpak install/remove lists in `/etc/flatpak/`. There are two subdirectories, `user` and `system` corresponding with the install level of the Flatpaks and repositories. Each directory has text files containing the IDs of flatpaks to `install` and `remove`, plus a `repo-info.yml` containing the details of the Flatpak repository.
 
-This module also supports disabling & enabling notifications. Currently, it enables notifications by default.
-
-If you want to configure notifications, you have to configure them in post-install (either with a just command or a classic terminal command):
-
-Disable notifications:
-
-`echo '0' | sudo tee /etc/flatpak/notifications`
-
-Enable notifications:
-
-`echo '1' | sudo tee /etc/flatpak/notifications`
+This module also supports disabling & enabling notifications.
 
 ## Example configurations
 
 ```yaml
 type: default-flatpaks
+notifications:
+  # Send notification after install/uninstall is finished (true/false)
+  notify: true
 system:
   # If no repo information is specified, Flathub will be used by default
   repo-url: https://dl.flathub.org/repo/flathub.flatpakrepo

--- a/modules/default-flatpaks/README.md
+++ b/modules/default-flatpaks/README.md
@@ -18,6 +18,18 @@ The scripts are run on every boot by these services:
 
 This module stores the Flatpak remote configuration and Flatpak install/remove lists in `/etc/flatpak/`. There are two subdirectories, `user` and `system` corresponding with the install level of the Flatpaks and repositories. Each directory has text files containing the IDs of flatpaks to `install` and `remove`, plus a `repo-info.yml` containing the details of the Flatpak repository.
 
+This module also supports disabling & enabling notifications. Currently, it enables notifications by default.
+
+If you want to configure notifications, you have to configure them in post-install (either with a just command or a classic terminal command):
+
+Disable notifications:
+
+`echo '0' | sudo tee /etc/flatpak/notifications`
+
+Enable notifications:
+
+`echo '1' | sudo tee /etc/flatpak/notifications`
+
 ## Example configurations
 
 ```yaml

--- a/modules/default-flatpaks/README.md
+++ b/modules/default-flatpaks/README.md
@@ -24,9 +24,7 @@ This module also supports disabling & enabling notifications.
 
 ```yaml
 type: default-flatpaks
-notifications:
-  # Send notification after install/uninstall is finished (true/false)
-  notify: true
+notify: true   # Send notification after install/uninstall is finished (true/false)
 system:
   # If no repo information is specified, Flathub will be used by default
   repo-url: https://dl.flathub.org/repo/flathub.flatpakrepo

--- a/modules/default-flatpaks/default-flatpaks.sh
+++ b/modules/default-flatpaks/default-flatpaks.sh
@@ -120,7 +120,6 @@ if [[ ! $(echo "$1" | yq -I=0 ".user") == "null" ]]; then
 fi
 
 echo "Configuring default-flatpaks notifications"
-yq ".notify" "$CONFIG_FILE"
 NOTIFICATIONS=$(yq ".notify" "$CONFIG_FILE")
 NOTIFICATIONS_CONFIG_FILE="/usr/etc/flatpak/notifications"
 echo ""$NOTIFICATIONS"" > "$NOTIFICATIONS_CONFIG_FILE"

--- a/modules/default-flatpaks/default-flatpaks.sh
+++ b/modules/default-flatpaks/default-flatpaks.sh
@@ -119,7 +119,7 @@ if [[ ! $(echo "$1" | yq -I=0 ".user") == "null" ]]; then
     configure_lists "$1" "user"
 fi
 
-echo "Enabling default-flatpaks notifications"
+echo "Configuring default-flatpaks notifications"
 yq ".notify" "$CONFIG_FILE"
 NOTIFICATIONS=$(yq ".notify" "$CONFIG_FILE")
 NOTIFICATIONS_CONFIG_FILE="/usr/etc/flatpak/notifications"

--- a/modules/default-flatpaks/default-flatpaks.sh
+++ b/modules/default-flatpaks/default-flatpaks.sh
@@ -122,4 +122,4 @@ fi
 echo "Configuring default-flatpaks notifications"
 NOTIFICATIONS=$(yq ".notify" "$CONFIG_FILE")
 NOTIFICATIONS_CONFIG_FILE="/usr/etc/flatpak/notifications"
-echo ""$NOTIFICATIONS"" > "$NOTIFICATIONS_CONFIG_FILE"
+echo "$NOTIFICATIONS" > "$NOTIFICATIONS_CONFIG_FILE"

--- a/modules/default-flatpaks/default-flatpaks.sh
+++ b/modules/default-flatpaks/default-flatpaks.sh
@@ -120,5 +120,7 @@ if [[ ! $(echo "$1" | yq -I=0 ".user") == "null" ]]; then
 fi
 
 echo "Enabling default-flatpaks notifications"
-NOTIFICATIONS_CONFIG="/usr/etc/flatpak/notifications"
-echo "1" > "$NOTIFICATIONS_CONFIG"
+yq ".notify" "$CONFIG_FILE"
+NOTIFICATIONS=$(yq ".notify" "$CONFIG_FILE")
+NOTIFICATIONS_CONFIG_FILE="/usr/etc/flatpak/notifications"
+echo ""$NOTIFICATIONS"" > "$NOTIFICATIONS_CONFIG_FILE"

--- a/modules/default-flatpaks/default-flatpaks.sh
+++ b/modules/default-flatpaks/default-flatpaks.sh
@@ -118,3 +118,7 @@ if [[ ! $(echo "$1" | yq -I=0 ".user") == "null" ]]; then
     configure_flatpak_repo "$1" "user"
     configure_lists "$1" "user"
 fi
+
+echo "Enabling default-flatpaks notifications"
+NOTIFICATIONS_CONFIG="/usr/etc/flatpak/notifications"
+echo "1" > "$NOTIFICATIONS_CONFIG"


### PR DESCRIPTION
...& uninstalled in notification. Also implement notification enable/disable config support.

Only supports up to 5 flatpak entries (when hovered on mouse), as 6 lines are the limit for the expanded notification on Gnome. Gnome does not support expanded notifications in notification center.

![Screenshot from 2023-12-21 01-38-07](https://github.com/ublue-os/bling/assets/65243233/01b60b21-f36c-49ee-bc3a-649fe2534f55)
![Screenshot from 2023-12-21 01-37-53](https://github.com/ublue-os/bling/assets/65243233/f6874c2f-fc8f-4b9c-bb10-228b2f7bf3fe)

Interestingly, when using [Expandable Notifications](https://extensions.gnome.org/extension/4463/expandable-notifications/) Gnome extension, it supports up to 16 flatpak entries (17 lines) in notification center when expanded.

![Screenshot from 2023-12-21 01-39-04](https://github.com/ublue-os/bling/assets/65243233/69aa3fe0-e563-4e5c-82db-65ddea2e5acd)
![Screenshot from 2023-12-21 01-38-36](https://github.com/ublue-os/bling/assets/65243233/fc23bb80-25d6-493a-ac81-4aaa925975c3)

I don't know how is the situation on other DE's regarding notifications line support.

Took some idea from myself here:
https://github.com/ublue-os/bling/pull/83#discussion_r1432744685