### PR TITLE
fix(default-flatpaks): Missing notification for system flatpaks

### DIFF
--- a/files/usr/bin/system-flatpak-presetup
+++ b/files/usr/bin/system-flatpak-presetup
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+
+# Opt out of and remove Fedora's flatpak repo
+if grep -qz 'fedora' <<< "$(flatpak remotes)"; then
+  /usr/bin/gnome-software --quit
+  /usr/lib/fedora-third-party/fedora-third-party-opt-out
+  /usr/bin/fedora-third-party disable
+  flatpak remote-delete fedora --force
+  flatpak remote-delete fedora-testing --force
+
+  # Remove flatpak apps from origin fedora
+  FEDORA_FLATPAKS=$(flatpak list --app --columns=application,origin | grep -w 'fedora' | awk '{print $1}')
+  flatpak remove --system --noninteractive ${FEDORA_FLATPAKS[@]}
+
+  # Remove flatpak runtimes from origin fedora
+  FEDORA_FLATPAKS=$(flatpak list --runtime --columns=application,arch,branch,origin | grep -w 'fedora' | awk '{print $1"/"$2"/"$3}')
+  flatpak remove --system --noninteractive ${FEDORA_FLATPAKS[@]}
+fi
+
+REPO_INFO="/etc/flatpak/system/repo-info.yml"
+REPO_URL=$(yq '.repo-url' $REPO_INFO)
+REPO_NAME=$(yq '.repo-name' $REPO_INFO)
+REPO_TITLE=$(yq '.repo-title' $REPO_INFO)
+
+# Set up system-wide Flatpak repository
+if [[ ! $REPO_URL == "null" && ! $REPO_NAME == "null" ]]; then
+  flatpak remote-add --if-not-exists --system "$REPO_NAME" "$REPO_URL"
+  echo "Adding system-wide remote $REPO_NAME from $REPO_URL"  
+fi
+
+# If configured remote is flathub, enable it here.
+# Flathub is already installed on Fedora, but not enabled by default,
+# so the above command won't add it again
+if [[ $REPO_NAME == "flathub" ]]; then
+  flatpak remote-modify --system "$REPO_NAME" --enable
+fi
+
+# Change repository title to configured title, if not null
+if [[ ! $REPO_TITLE == "null" ]]; then
+  flatpak remote-modify --system "$REPO_NAME" --title="$REPO_TITLE"
+  echo "Setting title $REPO_TITLE for remote $REPO_NAME"  
+fi

--- a/files/usr/bin/system-flatpak-setup
+++ b/files/usr/bin/system-flatpak-setup
@@ -1,45 +1,7 @@
 #!/usr/bin/env bash
 
-# Opt out of and remove Fedora's flatpak repo
-if grep -qz 'fedora' <<< "$(flatpak remotes)"; then
-  /usr/bin/gnome-software --quit
-  /usr/lib/fedora-third-party/fedora-third-party-opt-out
-  /usr/bin/fedora-third-party disable
-  flatpak remote-delete fedora --force
-  flatpak remote-delete fedora-testing --force
-
-  # Remove flatpak apps from origin fedora
-  FEDORA_FLATPAKS=$(flatpak list --app --columns=application,origin | grep -w 'fedora' | awk '{print $1}')
-  flatpak remove --system --noninteractive ${FEDORA_FLATPAKS[@]}
-
-  # Remove flatpak runtimes from origin fedora
-  FEDORA_FLATPAKS=$(flatpak list --runtime --columns=application,arch,branch,origin | grep -w 'fedora' | awk '{print $1"/"$2"/"$3}')
-  flatpak remove --system --noninteractive ${FEDORA_FLATPAKS[@]}
-fi
-
 REPO_INFO="/etc/flatpak/system/repo-info.yml"
-REPO_URL=$(yq '.repo-url' $REPO_INFO)
 REPO_NAME=$(yq '.repo-name' $REPO_INFO)
-REPO_TITLE=$(yq '.repo-title' $REPO_INFO)
-
-# Set up system-wide Flatpak repository
-if [[ ! $REPO_URL == "null" && ! $REPO_NAME == "null" ]]; then
-  flatpak remote-add --if-not-exists --system "$REPO_NAME" "$REPO_URL"
-  echo "Adding system-wide remote $REPO_NAME from $REPO_URL"  
-fi
-
-# If configured remote is flathub, enable it here.
-# Flathub is already installed on Fedora, but not enabled by default,
-# so the above command won't add it again
-if [[ $REPO_NAME == "flathub" ]]; then
-  flatpak remote-modify --system "$REPO_NAME" --enable
-fi
-
-# Change repository title to configured title, if not null
-if [[ ! $REPO_TITLE == "null" ]]; then
-  flatpak remote-modify --system "$REPO_NAME" --title="$REPO_TITLE"
-  echo "Setting title $REPO_TITLE for remote $REPO_NAME"  
-fi
 
 # Notifications config
 NOTIFICATIONS=$(cat /etc/flatpak/notifications)

--- a/files/usr/lib/systemd/system/system-flatpak-presetup.service
+++ b/files/usr/lib/systemd/system/system-flatpak-presetup.service
@@ -5,7 +5,7 @@ After=network-online.target
 
 [Service]
 Type=oneshot
-ExecStart=/usr/bin/system-flatpak-setup
+ExecStart=/usr/bin/system-flatpak-presetup
 Restart=on-failure
 RestartSec=30
 StartLimitInterval=0

--- a/files/usr/lib/systemd/user/system-flatpak-setup.service
+++ b/files/usr/lib/systemd/user/system-flatpak-setup.service
@@ -1,11 +1,11 @@
 [Unit]
-Description=Configure Flatpaks for current user
+Description=Configure Flatpaks for the system
 Wants=network-online.target
-After=system-flatpak-setup.service
+After=system-flatpak-presetup.service
 
 [Service]
 Type=simple
-ExecStart=/usr/bin/user-flatpak-setup
+ExecStart=/usr/bin/system-flatpak-setup
 Restart=on-failure
 RestartSec=30
 StartLimitInterval=0

--- a/modules/default-flatpaks/README.md
+++ b/modules/default-flatpaks/README.md
@@ -34,7 +34,6 @@ system:
   repo-title: "Flathub (system-wide)" # Optional; this sets the remote's user-facing name in graphical frontends like GNOME Software
   install:
     - org.gnome.Loupe
-    - org.winehq.Wine//stable-23.08 # This is an example of flatpak which has multiple versions in selection (flatpak//version)
   remove:
     - org.gnome.eog
 # A flatpak repo can also be added without having to install flatpaks,

--- a/modules/default-flatpaks/README.md
+++ b/modules/default-flatpaks/README.md
@@ -6,19 +6,21 @@ Flatpaks can either be installed system-wide or per-user, though per-user flatpa
 
 The module uses the following scripts to handle flatpak setup:
 
+- `/usr/bin/system-flatpak-presetup`
 - `/usr/bin/system-flatpak-setup`
 - `/usr/bin/user-flatpak-setup`
 
 The scripts are run on every boot by these services:
 
+- `/usr/lib/systemd/system/system-flatpak-presetup.service`
 - `/usr/lib/systemd/system/system-flatpak-setup.service`
 - `/usr/lib/systemd/user/user-flatpak-setup-service`
 
-`system-flatpak-setup` checks the flatpak repo information and install/remove lists created by the module. `user-flatpak-setup` functions the same for user flatpaks.
+`system-flatpak-presetup` uninstalls Fedora flatpaks & replaces Fedora repos with your system repos (needs root, hence why it's presetup). `system-flatpak-setup` checks the flatpak install/remove lists created by the module & performs the install/uninstall operation according to that. `user-flatpak-setup` functions the same for user flatpaks, with additional "user" replacement repo operation.
 
 This module stores the Flatpak remote configuration and Flatpak install/remove lists in `/etc/flatpak/`. There are two subdirectories, `user` and `system` corresponding with the install level of the Flatpaks and repositories. Each directory has text files containing the IDs of flatpaks to `install` and `remove`, plus a `repo-info.yml` containing the details of the Flatpak repository.
 
-This module also supports disabling & enabling notifications.
+This module also supports disabling & enabling notifications indicating success of install/uninstall of flatpaks.
 
 ## Example configurations
 

--- a/modules/default-flatpaks/README.md
+++ b/modules/default-flatpaks/README.md
@@ -20,7 +20,7 @@ The scripts are run on every boot by these services:
 
 This module stores the Flatpak remote configuration and Flatpak install/remove lists in `/etc/flatpak/`. There are two subdirectories, `user` and `system` corresponding with the install level of the Flatpaks and repositories. Each directory has text files containing the IDs of flatpaks to `install` and `remove`, plus a `repo-info.yml` containing the details of the Flatpak repository.
 
-This module also supports disabling & enabling notifications indicating success of install/uninstall of flatpaks.
+This module also supports disabling & enabling notifications.
 
 ## Example configurations
 

--- a/modules/default-flatpaks/README.md
+++ b/modules/default-flatpaks/README.md
@@ -34,6 +34,7 @@ system:
   repo-title: "Flathub (system-wide)" # Optional; this sets the remote's user-facing name in graphical frontends like GNOME Software
   install:
     - org.gnome.Loupe
+    - org.winehq.Wine//stable-23.08 # This is an example of flatpak which has multiple versions in selection (flatpak//version)
   remove:
     - org.gnome.eog
 # A flatpak repo can also be added without having to install flatpaks,

--- a/modules/default-flatpaks/default-flatpaks.sh
+++ b/modules/default-flatpaks/default-flatpaks.sh
@@ -5,9 +5,11 @@ set -oue pipefail
 
 BLING_DIRECTORY="${BLING_DIRECTORY:-"/tmp/bling"}"
 
+cp -r "$BLING_DIRECTORY"/files/usr/bin/system-flatpak-presetup /usr/bin/system-flatpak-presetup
 cp -r "$BLING_DIRECTORY"/files/usr/bin/system-flatpak-setup /usr/bin/system-flatpak-setup
 cp -r "$BLING_DIRECTORY"/files/usr/bin/user-flatpak-setup /usr/bin/user-flatpak-setup
-cp -r "$BLING_DIRECTORY"/files/usr/lib/systemd/system/system-flatpak-setup.service /usr/lib/systemd/system/system-flatpak-setup.service
+cp -r "$BLING_DIRECTORY"/files/usr/lib/systemd/system/system-flatpak-presetup.service /usr/lib/systemd/system/system-flatpak-presetup.service
+cp -r "$BLING_DIRECTORY"/files/usr/lib/systemd/user/system-flatpak-setup.service /usr/lib/systemd/user/system-flatpak-setup.service
 cp -r "$BLING_DIRECTORY"/files/usr/lib/systemd/user/user-flatpak-setup.service /usr/lib/systemd/user/user-flatpak-setup.service
 
 configure_flatpak_repo () {
@@ -104,7 +106,8 @@ configure_lists () {
 
 echo "Enabling flatpaks module"
 mkdir -p /usr/etc/flatpak/{system,user}
-systemctl enable -f system-flatpak-setup.service
+systemctl enable -f system-flatpak-presetup.service
+systemctl enable -f --global system-flatpak-setup.service
 systemctl enable -f --global user-flatpak-setup.service
 
 # Check that `system` is present before configuring


### PR DESCRIPTION
This approach, while more fragmented, it's cleaner, as there is a clearer separation of root & non-root operations done by flatpak-setup service. This should probably increase security too (but I'm not the expert to talk seriously about that). It also gets rid of some non-harming error for /var data, can't remember it fully.

I fiddled with getting correct DBUS session & exporting it as a temporary environment variable, but I failed in multiple cases. Notify-send requires this workaround when ran as root, hence why I looked into this approach.
But even If I succeeded with that, I think that this PR approach is better.

While it may be confusing for users that they have to type:

`systemctl status --user system-flatpak-setup`

instead of previous:

`systemctl status system-flatpak-setup`

It is something worth sacrificing for the important user-experience fix.