### PR TITLE
fix(default-flatpaks): False notification for "uninstalling" a flatpak

### DIFF
--- a/files/usr/bin/system-flatpak-setup
+++ b/files/usr/bin/system-flatpak-setup
@@ -7,7 +7,7 @@ REPO_NAME=$(yq '.repo-name' $REPO_INFO)
 NOTIFICATIONS=$(cat /etc/flatpak/notifications)
 
 # Installed flatpaks
-FLATPAK_LIST=$(flatpak list --columns=application)
+FLATPAK_LIST=$(flatpak list --system --columns=application)
 
 # Flatpak list files
 INSTALL_LIST_FILE="/etc/flatpak/system/install"

--- a/files/usr/bin/user-flatpak-setup
+++ b/files/usr/bin/user-flatpak-setup
@@ -27,7 +27,7 @@ fi
 NOTIFICATIONS=$(cat /etc/flatpak/notifications)
 
 # Installed flatpaks
-FLATPAK_LIST=$(flatpak list --columns=application)
+FLATPAK_LIST=$(flatpak list --user --columns=application)
 
 # Flatpak list files
 INSTALL_LIST_FILE="/etc/flatpak/user/install"


### PR DESCRIPTION
This is an edge usecase where this happens, I can give an example:

1. User sets that default-flatpaks uninstalls "Telegram" `system` flatpak. Default-flatpak does that job successfully.
2. Afterwards, he installs "Telegram" as `user` flatpak
3. False notification will appear on boot that "Telegram" `system` flatpak is uninstalled (reminder that "Telegram" is already uninstalled successfully in step 1).

I found out that you can set `--user` & `--system` flag when issuing flatpak column list of applications.

This change solves the problem.