### PR TITLE
fix: Fix flag ordering in `set` calls in scripts

### DIFF
--- a/modules/akmods/akmods.sh
+++ b/modules/akmods/akmods.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -oue pipefail
+set -euo pipefail
 
 function ENABLE_MULTIMEDIA_REPO {
   sed -i 's@enabled=0@enabled=1@g' /etc/yum.repos.d/_copr_ublue-os-akmods.repo && sed -i "0,/enabled/ s@enabled=0@enabled=1@g" /etc/yum.repos.d/negativo17-fedora-multimedia.repo;

--- a/modules/bling/bling.sh
+++ b/modules/bling/bling.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # Tell build process to exit if there are any errors.
-set -oue pipefail
+set -euo pipefail
 
 # Fetch bling COPR
 REPO="https://copr.fedorainfracloud.org/coprs/ublue-os/bling/repo/fedora-${OS_VERSION}/ublue-os-bling-fedora-${OS_VERSION}.repo"

--- a/modules/bling/installers/container-tools.sh
+++ b/modules/bling/installers/container-tools.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # Tell build process to exit if there are any errors.
-set -oue pipefail
+set -euo pipefail
 
 install -c -m 0755 "$BLING_DIRECTORY/files/usr/bin/docker-compose" "/usr/bin/docker-compose"
 install -c -m 0755 "$BLING_DIRECTORY/files/usr/bin/kind" "/usr/bin/kind"

--- a/modules/bling/installers/dconf-update-service.sh
+++ b/modules/bling/installers/dconf-update-service.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # Tell build process to exit if there are any errors.
-set -oue pipefail
+set -euo pipefail
 
 cp -r "$BLING_DIRECTORY/files/usr/lib/systemd/system/dconf-update.service" "/usr/lib/systemd/system/dconf-update.service"
 systemctl enable dconf-update.service

--- a/modules/bling/installers/devpod.sh
+++ b/modules/bling/installers/devpod.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
 # Tell build process to exit if there are any errors.
-set -oue pipefail
+set -euo pipefail
 
 rpm-ostree install "$BLING_DIRECTORY"/rpms/devpod*.rpm

--- a/modules/bling/installers/flatpaksync.sh
+++ b/modules/bling/installers/flatpaksync.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -oue pipefail
+set -euo pipefail
 
 SYSTEMD_USER_JOBS_DIR="/usr/lib/systemd/user/"
 

--- a/modules/bling/installers/fonts.sh
+++ b/modules/bling/installers/fonts.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
 # Tell build process to exit if there are any errors.
-set -oue pipefail
+set -euo pipefail
 
 echo "!!!!! The bling font installer has been deprecated in favor of the fonts module. This error-free message will be removed in a future version. !!!!! "

--- a/modules/bling/installers/gnome-vrr.sh
+++ b/modules/bling/installers/gnome-vrr.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # Tell build process to exit if there are any errors.
-set -oue pipefail
+set -euo pipefail
 
 wget -O "/etc/yum.repos.d/_copr_kylegospo-gnome-vrr.repo" "https://copr.fedorainfracloud.org/coprs/kylegospo/gnome-vrr/repo/fedora-${OS_VERSION}/kylegospo-gnome-vrr-fedora-${OS_VERSION}.repo"
 

--- a/modules/bling/installers/justfiles.sh
+++ b/modules/bling/installers/justfiles.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
 # Tell build process to exit if there are any errors.
-set -oue pipefail
+set -euo pipefail
 
 cp -r "$BLING_DIRECTORY"/files/usr/share/ublue-os/just/* "/usr/share/ublue-os/just"

--- a/modules/bling/installers/laptop.sh
+++ b/modules/bling/installers/laptop.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # Tell build process to exit if there are any errors.
-set -oue pipefail
+set -euo pipefail
 
 wget "https://copr.fedorainfracloud.org/coprs/ublue-os/staging/repo/fedora-$(rpm -E %fedora)/ublue-os-staging-fedora-$(rpm -E %fedora).repo" \
     -O "/etc/yum.repos.d/_copr_ublue-os_staging.repo"

--- a/modules/bling/installers/nix-installer.sh
+++ b/modules/bling/installers/nix-installer.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # Tell build process to exit if there are any errors.
-set -oue pipefail
+set -euo pipefail
 
 cp "$BLING_DIRECTORY/files/usr/bin/ublue-nix-install" "/usr/bin/ublue-nix-install"
 cp "$BLING_DIRECTORY/files/usr/bin/ublue-nix-uninstall" "/usr/bin/ublue-nix-uninstall"

--- a/modules/bling/installers/ublue-os-wallpapers.sh
+++ b/modules/bling/installers/ublue-os-wallpapers.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
 # Tell build process to exit if there are any errors.
-set -oue pipefail
+set -euo pipefail
 
 rpm-ostree install "$BLING_DIRECTORY"/rpms/ublue-os-wallpapers*.rpm

--- a/modules/bling/installers/ublue-update.sh
+++ b/modules/bling/installers/ublue-update.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # Tell build process to exit if there are any errors.
-set -oue pipefail
+set -euo pipefail
 
 get_config_value() {
     sed -n '/^'"$1"'=/{s/'"$1"'=//;p}' "$2"

--- a/modules/default-flatpaks/default-flatpaks.sh
+++ b/modules/default-flatpaks/default-flatpaks.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # Tell build process to exit if there are any errors.
-set -oue pipefail
+set -euo pipefail
 
 BLING_DIRECTORY="${BLING_DIRECTORY:-"/tmp/bling"}"
 

--- a/modules/files/files.sh
+++ b/modules/files/files.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # Tell build process to exit if there are any errors.
-set -oue pipefail
+set -euo pipefail
 
 get_yaml_array FILES '.files[]' "$1"
 

--- a/modules/fonts/download.sh
+++ b/modules/fonts/download.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -oue pipefail
+set -euo pipefail
 
 NAME=$1
 FORMAT=$2

--- a/modules/fonts/fonts.sh
+++ b/modules/fonts/fonts.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -oue pipefail
+set -euo pipefail
 
 export FONTS_MODULE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 

--- a/modules/fonts/sources/google-fonts.sh
+++ b/modules/fonts/sources/google-fonts.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -oue pipefail
+set -euo pipefail
 
 mapfile -t FONTS <<< "$@"
 URL="https://fonts.google.com/download?family="

--- a/modules/fonts/sources/nerd-fonts.sh
+++ b/modules/fonts/sources/nerd-fonts.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -oue pipefail
+set -euo pipefail
 
 mapfile -t FONTS <<< "$@"
 URL="https://github.com/ryanoasis/nerd-fonts/releases/latest/download/"

--- a/modules/rpm-ostree/rpm-ostree.sh
+++ b/modules/rpm-ostree/rpm-ostree.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # Tell build process to exit if there are any errors.
-set -oue pipefail
+set -euo pipefail
 
 # Pull in repos
 get_yaml_array REPOS '.repos[]' "$1"

--- a/modules/script/README.md
+++ b/modules/script/README.md
@@ -22,5 +22,5 @@ When creating a script, please make sure
     - `autorun.sh` only executes files that match `*.sh`.
 - ...it starts with a [shebang](<https://en.wikipedia.org/wiki/Shebang_(Unix)>) like `#!/usr/bin/env bash`.
     - This ensures the script is ran with the correct interpreter / shell.
-- ...it contains the command `set -oue pipefail` near the start.
+- ...it contains the command `set -euo pipefail` near the start.
     - This will make the image build fail if your script fails. If you do not care if your script works or not, you can omit this line.

--- a/modules/script/script.sh
+++ b/modules/script/script.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # Tell build process to exit if there are any errors.
-set -oue pipefail
+set -euo pipefail
 
 get_yaml_array SCRIPTS '.scripts[]' "$1"
 

--- a/modules/systemd/systemd.sh
+++ b/modules/systemd/systemd.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # Tell build process to exit if there are any errors.
-set -oue pipefail
+set -euo pipefail
 
 get_yaml_array ENABLED '.system.enabled[]' "$1"
 get_yaml_array DISABLED '.system.disabled[]' "$1"

--- a/modules/yafti/yafti.sh
+++ b/modules/yafti/yafti.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # Tell build process to exit if there are any errors.
-set -oue pipefail
+set -euo pipefail
 
 FIRSTBOOT_DATA="/usr/share/ublue-os/firstboot"
 FIRSTBOOT_SCRIPT="${FIRSTBOOT_DATA}/launcher/login-profile.sh"


### PR DESCRIPTION
The README for scripts has an incorrect use of the `set`. Where it says to use:

	set -oue pipefail

it should be:

	set -euo pipefail

since `pipefail` is an option consumed by `set -o`.

More information: https://www.gnu.org/software/bash/manual/html_node/The-Set-Builtin.html

I went ahead and did a repo-wide sed(1) call to change all instances of `set -oue pipefail` to `set -euo pipefail`.