### PR TITLE
fix(akmods): Xone installs conflicted "akmod-xone" package

### DIFF
--- a/modules/akmods/akmods.sh
+++ b/modules/akmods/akmods.sh
@@ -10,7 +10,7 @@ function DISABLE_MULTIMEDIA_REPO {
 }
 
 function SET_HIGHER_PRIORITY_AKMODS_REPO {
-echo "priority=90" >> /etc/yum.repos.d/_copr_ublue-os-akmods.repo
+  echo "priority=90" >> /etc/yum.repos.d/_copr_ublue-os-akmods.repo
 }
 
 get_yaml_array INSTALL '.install[]' "$1"

--- a/modules/akmods/akmods.sh
+++ b/modules/akmods/akmods.sh
@@ -2,11 +2,19 @@
 set -euo pipefail
 
 function ENABLE_MULTIMEDIA_REPO {
-  sed -i 's@enabled=0@enabled=1@g' /etc/yum.repos.d/_copr_ublue-os-akmods.repo && sed -i "0,/enabled/ s@enabled=0@enabled=1@g" /etc/yum.repos.d/negativo17-fedora-multimedia.repo;
+  sed -i 's@enabled=0@enabled=1@g' /etc/yum.repos.d/_copr_ublue-os-akmods.repo && sed -i "0,/enabled/ s@enabled=0@enabled=1@g" /etc/yum.repos.d/negativo17-fedora-multimedia.repo
 }
 
 function DISABLE_MULTIMEDIA_REPO {
-  sed -i 's@enabled=1@enabled=0@g' /etc/yum.repos.d/negativo17-fedora-multimedia.repo;
+  sed -i 's@enabled=1@enabled=0@g' /etc/yum.repos.d/negativo17-fedora-multimedia.repo
+}
+
+function SET_HIGHER_PRIORITY_AKMODS_REPO {
+echo "priority=90" >> /etc/yum.repos.d/_copr_ublue-os-akmods.repo
+}
+
+function REVERT_PRIORITY_TO_DEFAULT_AKMODS_REPO {
+sed -i 's/priority=90//' /etc/yum.repos.d/_copr_ublue-os-akmods.repo
 }
 
 get_yaml_array INSTALL '.install[]' "$1"
@@ -19,12 +27,16 @@ if [[ ${#INSTALL[@]} -gt 0 ]]; then
   echo "Installing akmods"
   echo "Installing: $(echo "${INSTALL[*]}" | tr -d '\n')"
   if [[ "$BASE_IMAGE" =~ "surface" ]]; then
+    SET_HIGHER_PRIORITY_AKMODS_REPO
     ENABLE_MULTIMEDIA_REPO
     rpm-ostree install kernel-surface-devel-matched $INSTALL_STR
     DISABLE_MULTIMEDIA_REPO
+    REVERT_PRIORITY_TO_DEFAULT_AKMODS_REPO
   else
+    SET_HIGHER_PRIORITY_AKMODS_REPO
     ENABLE_MULTIMEDIA_REPO
     rpm-ostree install kernel-devel-matched $INSTALL_STR
     DISABLE_MULTIMEDIA_REPO
+    REVERT_PRIORITY_TO_DEFAULT_AKMODS_REPO
   fi  
 fi    

--- a/modules/akmods/akmods.sh
+++ b/modules/akmods/akmods.sh
@@ -2,7 +2,8 @@
 set -euo pipefail
 
 function ENABLE_MULTIMEDIA_REPO {
-  sed -i 's@enabled=0@enabled=1@g' /etc/yum.repos.d/_copr_ublue-os-akmods.repo && sed -i "0,/enabled/ s@enabled=0@enabled=1@g" /etc/yum.repos.d/negativo17-fedora-multimedia.repo
+  sed -i 's@enabled=0@enabled=1@g' /etc/yum.repos.d/_copr_ublue-os-akmods.repo
+  sed -i "0,/enabled/ s@enabled=0@enabled=1@g" /etc/yum.repos.d/negativo17-fedora-multimedia.repo
 }
 
 function DISABLE_MULTIMEDIA_REPO {

--- a/modules/akmods/akmods.sh
+++ b/modules/akmods/akmods.sh
@@ -13,10 +13,6 @@ function SET_HIGHER_PRIORITY_AKMODS_REPO {
 echo "priority=90" >> /etc/yum.repos.d/_copr_ublue-os-akmods.repo
 }
 
-function REVERT_PRIORITY_TO_DEFAULT_AKMODS_REPO {
-sed -i 's/priority=90//' /etc/yum.repos.d/_copr_ublue-os-akmods.repo
-}
-
 get_yaml_array INSTALL '.install[]' "$1"
 
 INSTALL_PATH=("${INSTALL[@]/#/\/tmp/rpms/kmods/*}")
@@ -31,12 +27,10 @@ if [[ ${#INSTALL[@]} -gt 0 ]]; then
     ENABLE_MULTIMEDIA_REPO
     rpm-ostree install kernel-surface-devel-matched $INSTALL_STR
     DISABLE_MULTIMEDIA_REPO
-    REVERT_PRIORITY_TO_DEFAULT_AKMODS_REPO
   else
     SET_HIGHER_PRIORITY_AKMODS_REPO
     ENABLE_MULTIMEDIA_REPO
     rpm-ostree install kernel-devel-matched $INSTALL_STR
     DISABLE_MULTIMEDIA_REPO
-    REVERT_PRIORITY_TO_DEFAULT_AKMODS_REPO
   fi  
 fi    


### PR DESCRIPTION
This sets higher priority for `akmods repo` compared to `multimedia repo`, which should fix potential issues in the future for other akmods too.

Thanks to the debugging done here:
https://github.com/ublue-os/akmods/pull/116