### PR TITLE
fix: install topgrade in ublue-update.sh

### DIFF
--- a/modules/bling/installers/ublue-update.sh
+++ b/modules/bling/installers/ublue-update.sh
@@ -26,5 +26,6 @@ if [[ -f "$RPM_OSTREE_CONFIG" ]]; then
     fi
 fi
 systemctl disable rpm-ostreed-automatic.timer
-
+# topgrade is REQUIRED by ublue-update to install
+pip install topgrade
 rpm-ostree install ublue-update


### PR DESCRIPTION
`ublue-update` recently moved to `topgrade` for executing updates (https://github.com/ublue-os/ublue-update/pull/102). Because of this move, `ublue-update` needs `topgrade` to be installed in order to install the rpm: https://github.com/ublue-os/ublue-update/blob/main/ublue-update.spec