### PR TITLE
fix: Install topgrade to /usr

### DIFF
--- a/modules/bling/installers/ublue-update.sh
+++ b/modules/bling/installers/ublue-update.sh
@@ -27,5 +27,5 @@ if [[ -f "$RPM_OSTREE_CONFIG" ]]; then
 fi
 systemctl disable rpm-ostreed-automatic.timer
 # topgrade is REQUIRED by ublue-update to install
-pip install topgrade
+pip install --prefix=/usr topgrade
 rpm-ostree install ublue-update


### PR DESCRIPTION
Install topgrade to /usr since /usr/local doesn't exists when building ublue image