### PR TITLE
fix(ublue-update): Install 'python3-pip' if it's not already installed

### DIFF
--- a/modules/bling/installers/ublue-update.sh
+++ b/modules/bling/installers/ublue-update.sh
@@ -26,6 +26,12 @@ if [[ -f "$RPM_OSTREE_CONFIG" ]]; then
     fi
 fi
 systemctl disable rpm-ostreed-automatic.timer
+
+# Install python3-pip if it's not already installed
+if ! rpm -q python3-pip > /dev/null; then
+    rpm-ostree install python3-pip
+fi
+
 # topgrade is REQUIRED by ublue-update to install
 pip install --prefix=/usr topgrade
 rpm-ostree install ublue-update


### PR DESCRIPTION
If the package isn't installed by the user before this module starts, it fails with:

`/tmp/modules/bling/installers/ublue-update.sh: line 30: pip: command not found`

This ensures the package is installed.