### PR TITLE
feat: Add `gschema-overrides` module

### DIFF
--- a/modules/gschema-overrides/README.md
+++ b/modules/gschema-overrides/README.md
@@ -1,6 +1,7 @@
 # `gschema-overrides` module for BlueBuild
 
-The `gschema-overrides` module can be used for including system-setting overrides for Gnome/GTK-based desktop environments.
+The `gschema-overrides` module can be used for including system-setting overrides for GTK-based desktop environments.
+GTK-based desktop environments include Gnome, Cinnamon, MATE, Budgie & such.
 This module is similar to using `dconf` configuration, but is better because it doesn't require a systemd service & supports build-time troubleshooting.
 
 What does this module do?

--- a/modules/gschema-overrides/README.md
+++ b/modules/gschema-overrides/README.md
@@ -1,0 +1,36 @@
+# `gschema-overrides` module for startingpoint
+
+`Gschema-overrides` startingpoint module is used for including your system-setting overrides.
+If you heard about `dconf`, this is similar to it, but it's a much better & cleaner method of doing it.
+
+What does this module do?
+
+- It copies all content from `/usr/share/glib-2.0/schemas`, except existing gschema.overrides to avoid conflicts, into temporary test location.
+- It copies your gschema.overrides you provided in this module from `/usr/share/glib-2.0/schemas` into temporary test location.
+- It tests them for errors in temporary test location by using `glib-compile-schemas` with `--strict` flag. If errors are found, build will fail.
+- If test is passed successfully, compile gschema using `glib-compile-schemas` in `/usr/share/glib-2.0/schemas` to include your changes.
+
+Temporary test location is:
+
+`/tmp/bluebuild-schema-test`
+
+To use it, you need to include your gschema.override file(s) in this location:
+
+`/usr/share/glib-2.0/schemas`
+
+Then you need to include it in recipe file, like in example configuration.
+
+It is highly recommended to use `z0-` prefix or higher before your gschema.override name, to ensure that your changes are going to be applied.
+
+## Example configuration
+
+```yaml
+type: gschema-overrides
+include:
+  - z0-myoverride.gschema.override
+  - z0-myoverride2.gschema.override
+```
+
+For more information on best practices for editing `gschema.override` files & potentially combining them with `dconf`, here's some documentation:
+
+https://github.com/ublue-os/bling/issues/53#issuecomment-1915474038

--- a/modules/gschema-overrides/README.md
+++ b/modules/gschema-overrides/README.md
@@ -21,6 +21,7 @@ To use it, you need to include your gschema.override file(s) in this location:
 Then you need to include it in recipe file, like in example configuration.
 
 It is highly recommended to use `z0-` prefix or higher (`zz-` is the highest possible) before your gschema.override name, to ensure that your changes are going to be applied.
+
 Also don't forget to rename your file too with this or similar prefix in `/usr/share/glib-2.0/schemas`.
 
 ## Example configuration

--- a/modules/gschema-overrides/README.md
+++ b/modules/gschema-overrides/README.md
@@ -73,11 +73,13 @@ tap-to-click=true
   
   `gsettings list-recursively`
   
-  You should use this command everytime when you want to apply some setting,<br />
-  to be sure that it's listed
+  You should use this command everytime when you want to apply some setting override,<br />
+  to ensure that it's listed as available.
 
 **Gschema.override files don't support relocatable schemas & locking settings.**<br />
 For that functionality, you should use `dconf-update-service` module.
+
+Relocatable schemas are rare, so most users won't run into this scenario.
 
 ### Example of relocatable schemas
 ```

--- a/modules/gschema-overrides/README.md
+++ b/modules/gschema-overrides/README.md
@@ -20,9 +20,9 @@ To use it, you need to include your gschema.override file(s) in this location:
 
 Then you need to include it in recipe file, like in example configuration.
 
-It is highly recommended to use `z0-` prefix or higher (`zz-` is the highest possible) before your gschema.override name, to ensure that your changes are going to be applied.
+It is highly recommended to use `z0-` prefix before your gschema.override name, to ensure that your changes are going to be applied.
 
-Also don't forget to rename your file too with this or similar prefix in `/usr/share/glib-2.0/schemas`.
+Also don't forget to rename your file too with this prefix in `/usr/share/glib-2.0/schemas`.
 
 ## Example configuration
 

--- a/modules/gschema-overrides/README.md
+++ b/modules/gschema-overrides/README.md
@@ -1,7 +1,7 @@
-# `gschema-overrides` module for startingpoint
+# `gschema-overrides` module for BlueBuild
 
-`Gschema-overrides` startingpoint module is used for including your system-setting overrides.
-If you heard about `dconf`, this is similar to it, but it's a much better & cleaner method of doing it.
+The `gschema-overrides` module can be used for including system-setting overrides for Gnome-based desktop environments.
+This module is similar to using `dconf` configuration, but is better because it doesn't require a systemd service & supports build-time troubleshooting.
 
 What does this module do?
 

--- a/modules/gschema-overrides/README.md
+++ b/modules/gschema-overrides/README.md
@@ -20,7 +20,8 @@ To use it, you need to include your gschema.override file(s) in this location:
 
 Then you need to include it in recipe file, like in example configuration.
 
-It is highly recommended to use `z0-` prefix or higher before your gschema.override name, to ensure that your changes are going to be applied.
+It is highly recommended to use `z0-` prefix or higher (`zz-` is the highest possible) before your gschema.override name, to ensure that your changes are going to be applied.
+Also don't forget to rename your file too with this or similar prefix in `/usr/share/glib-2.0/schemas`.
 
 ## Example configuration
 

--- a/modules/gschema-overrides/README.md
+++ b/modules/gschema-overrides/README.md
@@ -15,15 +15,15 @@ Temporary test location is:
 
 `/tmp/bluebuild-schema-test`
 
-To use it, you need to include your gschema.override file(s) in this location:
+To use this module, you need to include your gschema.override file(s) in this location:
 
 `/usr/share/glib-2.0/schemas`
 
-Then you need to include it in recipe file, like in example configuration.
+Then you need to include those file(s) in recipe file, like in example configuration.
 
 It is highly recommended to use `z1-` prefix before your gschema.override name, to ensure that your changes are going to be applied.
 
-Also don't forget to rename your file too with this prefix in `/usr/share/glib-2.0/schemas`.
+Also don't forget to rename your file(s) too with this prefix in `/usr/share/glib-2.0/schemas`.
 
 ## Example configuration
 

--- a/modules/gschema-overrides/README.md
+++ b/modules/gschema-overrides/README.md
@@ -20,7 +20,7 @@ To use it, you need to include your gschema.override file(s) in this location:
 
 Then you need to include it in recipe file, like in example configuration.
 
-It is highly recommended to use `z0-` prefix before your gschema.override name, to ensure that your changes are going to be applied.
+It is highly recommended to use `z1-` prefix before your gschema.override name, to ensure that your changes are going to be applied.
 
 Also don't forget to rename your file too with this prefix in `/usr/share/glib-2.0/schemas`.
 
@@ -29,8 +29,8 @@ Also don't forget to rename your file too with this prefix in `/usr/share/glib-2
 ```yaml
 type: gschema-overrides
 include:
-  - z0-myoverride.gschema.override
-  - z0-myoverride2.gschema.override
+  - z1-myoverride.gschema.override
+  - z1-myoverride2.gschema.override
 ```
 
 For more information on best practices for editing `gschema.override` files & potentially combining them with `dconf`, here's some documentation:

--- a/modules/gschema-overrides/README.md
+++ b/modules/gschema-overrides/README.md
@@ -15,6 +15,8 @@ Temporary test location is:
 
 `/tmp/bluebuild-schema-test`
 
+# Usage
+
 To use this module, you need to include your gschema.override file(s) in this location:
 
 `/usr/share/glib-2.0/schemas`
@@ -25,7 +27,7 @@ It is highly recommended to use `z1-` prefix before your gschema.override name, 
 
 Also don't forget to rename your file(s) too with this prefix in `/usr/share/glib-2.0/schemas`.
 
-## Example configuration
+### Example configuration
 
 ```yaml
 type: gschema-overrides
@@ -34,6 +36,56 @@ include:
   - z1-myoverride2.gschema.override
 ```
 
-For more information on best practices for editing `gschema.override` files & potentially combining them with `dconf`, here's some documentation:
+# Editing gschema.override files
 
-https://github.com/ublue-os/bling/issues/53#issuecomment-1915474038
+Gschema.override files use `gsettings` keyfile format for settings output.
+
+### Example of gschema.override settings
+```
+[org.gnome.desktop.peripherals.touchpad]
+tap-to-click=true
+
+[org.gnome.settings-daemon.plugins.power]
+power-button-action='interactive'
+
+[org.gnome.mutter]
+check-alive-timeout=uint32 20000
+
+[org.gnome.shell.extensions.blur-my-shell]
+sigma=5
+```
+
+### Example of gschema.override lockscreen settings (Gnome)
+```
+[org.gnome.desktop.peripherals.touchpad:GNOME-Greeter]
+tap-to-click=true
+```
+
+- To gather setting change after you input the command, use this:
+
+  `dconf watch /`
+
+  When you change some setting toggle or option when this command is active,<br />
+  you will notice that command will output the key for the changed setting,<br />
+  which you can use & write into gschema.override file in the format shown in example above.
+
+- To gather current & available settings on booted system, you can use this command:
+  
+  `gsettings list-recursively`
+  
+  You should use this command everytime when you want to apply some setting,<br />
+  to be sure that it's listed
+
+**Gschema.override files don't support relocatable schemas & locking settings.**<br />
+For that functionality, you should use `dconf-update-service` module.
+
+### Example of relocatable schemas
+```
+gsettings format:
+[org.gnome.desktop.app-folders.folder:/org/gnome/desktop/app-folders/folders/Utilities/]
+[org.gnome.settings-daemon.plugins.media-keys.custom-keybinding:/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom0/]
+
+dconf format:
+[org/gnome/desktop/app-folders/folders/Utilities]
+[org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom0]
+```

--- a/modules/gschema-overrides/README.md
+++ b/modules/gschema-overrides/README.md
@@ -1,6 +1,6 @@
 # `gschema-overrides` module for BlueBuild
 
-The `gschema-overrides` module can be used for including system-setting overrides for Gnome-based desktop environments.
+The `gschema-overrides` module can be used for including system-setting overrides for Gnome/GTK-based desktop environments.
 This module is similar to using `dconf` configuration, but is better because it doesn't require a systemd service & supports build-time troubleshooting.
 
 What does this module do?

--- a/modules/gschema-overrides/README.md
+++ b/modules/gschema-overrides/README.md
@@ -15,7 +15,7 @@ Temporary test location is:
 
 `/tmp/bluebuild-schema-test`
 
-# Usage
+## Usage
 
 To use this module, you need to include your gschema.override file(s) in this location:
 
@@ -36,7 +36,7 @@ include:
   - z1-myoverride2.gschema.override
 ```
 
-# Editing gschema.override files
+## Editing gschema.override files
 
 Gschema.override files use `gsettings` keyfile format for settings output.
 
@@ -65,18 +65,18 @@ tap-to-click=true
 
   `dconf watch /`
 
-  When you change some setting toggle or option when this command is active,<br />
-  you will notice that command will output the key for the changed setting,<br />
+  When you change some setting toggle or option when this command is active,   
+  you will notice that command will output the key for the changed setting,   
   which you can use & write into gschema.override file in the format shown in example above.
 
 - To gather current & available settings on booted system, you can use this command:
   
   `gsettings list-recursively`
   
-  You should use this command everytime when you want to apply some setting override,<br />
+  You should use this command everytime when you want to apply some setting override,   
   to ensure that it's listed as available.
 
-**Gschema.override files don't support relocatable schemas & locking settings.**<br />
+**Gschema.override files don't support relocatable schemas & locking settings.**   
 For that functionality, you should use `dconf-update-service` module.
 
 Relocatable schemas are rare, so most users won't run into this scenario.

--- a/modules/gschema-overrides/gschema-overrides.sh
+++ b/modules/gschema-overrides/gschema-overrides.sh
@@ -7,6 +7,7 @@ get_yaml_array INCLUDE '.include[]' "$1"
 schema_test_location="/tmp/bluebuild-schema-test"
 schema_location="/usr/share/glib-2.0/schemas"
 gschema_extension=false
+most_preferred_override=$(find "$schema_location" -type f -name "*.gschema.override" | tail -n1 | xargs -I {} basename {})
 
 echo "Installing gschema-overrides module"
 
@@ -28,6 +29,9 @@ if [[ ${#INCLUDE[@]} -gt 0 ]]; then
     fi  
   done
 fi
+
+printf "Most preferred gschema-override is:\n" "%s\n" "$most_preferred_override"
+echo "If your gschema-override is not listed as most preferred, you should adjust filename prefix"
 
 # Apply gschema-override when all conditions above are satisfied
 if [[ ${#INCLUDE[@]} -gt 0 ]] && $gschema_extension; then

--- a/modules/gschema-overrides/gschema-overrides.sh
+++ b/modules/gschema-overrides/gschema-overrides.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+get_yaml_array INCLUDE '.include[]' "$1"
+
+schema_test_location="/tmp/bluebuild-schema-test"
+schema_location="/usr/share/glib-2.0/schemas"
+gschema_extension=false
+
+echo "Installing gschema-overrides module"
+
+# Abort build if file in module is not included
+if [[ ${#INCLUDE[@]} == 0 ]]; then
+  echo "Module failed because gschema-overrides aren't included into the module."
+  exit 1
+fi
+
+# Abort build if included file does not have .gschema.override extension
+if [[ ${#INCLUDE[@]} -gt 0 ]]; then
+  for file in "${INCLUDE[@]}"; do
+    file="${file//$'\n'/}"
+    if [[ $file == *.gschema.override ]]; then
+      gschema_extension=true
+    else  
+      echo "Module failed because included files in module don't have .gschema.override extension."
+      exit 1
+    fi  
+  done
+fi
+
+# Apply gschema-override when all conditions above are satisfied
+if [[ ${#INCLUDE[@]} -gt 0 ]] && $gschema_extension; then
+  printf "Applying the following gschema-overrides:\n"
+  for file in "${INCLUDE[@]}"; do
+    file="${file//$'\n'/}"
+    printf "%s\n" "$file"
+  done
+  mkdir -p "$schema_test_location" "$schema_location"
+  find "$schema_location" -type f ! -name "*.gschema.override" -exec cp {} "$schema_test_location" \;
+  for file in "${INCLUDE[@]}"; do
+    file_path="${schema_location}/${file//$'\n'/}"
+    cp "$file_path" "$schema_test_location"
+  done
+  echo "Running error-checking test for your gschema-overrides. If test fails, build also fails."
+  glib-compile-schemas --strict "$schema_test_location"
+  echo "Compiling gschema to include your changes with gschema-override"
+  glib-compile-schemas "$schema_location" &>/dev/null
+fi

--- a/modules/gschema-overrides/gschema-overrides.sh
+++ b/modules/gschema-overrides/gschema-overrides.sh
@@ -7,7 +7,6 @@ get_yaml_array INCLUDE '.include[]' "$1"
 schema_test_location="/tmp/bluebuild-schema-test"
 schema_location="/usr/share/glib-2.0/schemas"
 gschema_extension=false
-most_preferred_override=$(find "$schema_location" -type f -name "*.gschema.override" | tail -n1 | xargs -I {} basename {})
 
 echo "Installing gschema-overrides module"
 
@@ -29,9 +28,6 @@ if [[ ${#INCLUDE[@]} -gt 0 ]]; then
     fi  
   done
 fi
-
-printf "Most preferred gschema-override is:\n" "%s\n" "$most_preferred_override"
-echo "If your gschema-override is not listed as most preferred, you should adjust filename prefix"
 
 # Apply gschema-override when all conditions above are satisfied
 if [[ ${#INCLUDE[@]} -gt 0 ]] && $gschema_extension; then


### PR DESCRIPTION
This module should mostly replace `dconf-service-update` entry in bling, as a more cleaner & better solution.

Biggest advantage is that it fails on build if errors are found.

More details in README.