### PR TITLE
feat: add signing module to replace `signing.sh`

### DIFF
--- a/modules/signing/README.md
+++ b/modules/signing/README.md
@@ -1,3 +1,3 @@
-# [`signing`] Module for Startingpoint
+# `signing` Module for Startingpoint
 
-The `signing` module is used to install the required signing policies for cosign image verification with [`rpm-ostree`](https://github.com/coreos/rpm-ostree) and [`bootc`](https://github.com/containers/bootc). This is the successor to the `signing.sh` module that allows for basing off of non-ublue fedora base OCI images.
+The `signing` module is used to install the required signing policies for cosign image verification with [`rpm-ostree`](https://github.com/coreos/rpm-ostree) and [`bootc`](https://github.com/containers/bootc). This module is the successor to the signing.sh script that previously existed in the template, and it allows for basing off of non-Universal-Blue Fedora base images.

--- a/modules/signing/README.md
+++ b/modules/signing/README.md
@@ -1,16 +1,3 @@
-# [`yafti`](https://github.com/ublue-os/yafti) Module for Startingpoint
+# [`signing`] Module for Startingpoint
 
-The `yafti` module can be used to install `yafti` and set it up to run on first boot. Also `yafti`'s dependencies, `python3-pip` and `libadwaita` are installed.
-
-Optionally, a list of Flatpak names and IDs can be included under `custom-flatpaks:`. These will be enabled by default under their own section on the Flatpak installation screen of `yafti`.
-
-A default version of the `yafti` configuration file, `yafti.yml`, is supplied by this module. To make your own, create the file at `/usr/share/ublue-os/firstboot/yafti.yml`. The default version of the file can be found [here](https://github.com/ublue-os/bling/blob/main/modules/yafti/yafti.yml).
-
-## Example configuration
-
-```yaml
-type: yafti
-custom-flatpaks:
-    - Celluloid: io.github.celluloid_player.Celluloid
-    - Krita: org.kde.krita
-```
+The `signing` module is used to install the required signing policies for cosign image verification with [`rpm-ostree`](https://github.com/coreos/rpm-ostree) and [`bootc`](https://github.com/containers/bootc). This is the successor to the `signing.sh` module that allows for basing off of non-ublue fedora base OCI images.

--- a/modules/signing/README.md
+++ b/modules/signing/README.md
@@ -1,0 +1,16 @@
+# [`yafti`](https://github.com/ublue-os/yafti) Module for Startingpoint
+
+The `yafti` module can be used to install `yafti` and set it up to run on first boot. Also `yafti`'s dependencies, `python3-pip` and `libadwaita` are installed.
+
+Optionally, a list of Flatpak names and IDs can be included under `custom-flatpaks:`. These will be enabled by default under their own section on the Flatpak installation screen of `yafti`.
+
+A default version of the `yafti` configuration file, `yafti.yml`, is supplied by this module. To make your own, create the file at `/usr/share/ublue-os/firstboot/yafti.yml`. The default version of the file can be found [here](https://github.com/ublue-os/bling/blob/main/modules/yafti/yafti.yml).
+
+## Example configuration
+
+```yaml
+type: yafti
+custom-flatpaks:
+    - Celluloid: io.github.celluloid_player.Celluloid
+    - Krita: org.kde.krita
+```

--- a/modules/signing/image-info.json
+++ b/modules/signing/image-info.json
@@ -1,6 +1,6 @@
 {
     "image-ref": "IMAGE_REF",
     "image-tag": "latest",
-    "image-vendor": "blue-build",
+    "image-vendor": "bluebuild",
     "fedora-version": "FEDORA_MAJOR_VERSION"
 }

--- a/modules/signing/image-info.json
+++ b/modules/signing/image-info.json
@@ -1,0 +1,6 @@
+{
+    "image-ref": "IMAGE_REF",
+    "image-tag": "latest",
+    "image-vendor": "blue-build",
+    "fedora-version": "FEDORA_MAJOR_VERSION"
+}

--- a/modules/signing/policy.json
+++ b/modules/signing/policy.json
@@ -1,0 +1,86 @@
+{
+    "default": [
+        {
+            "type": "reject"
+        }
+    ],
+    "transports": {
+        "docker": {
+            "registry.access.redhat.com": [
+                {
+                    "type": "signedBy",
+                    "keyType": "GPGKeys",
+                    "keyPath": "/etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release"
+                }
+            ],
+            "registry.redhat.io": [
+                {
+                    "type": "signedBy",
+                    "keyType": "GPGKeys",
+                    "keyPath": "/etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release"
+                }
+            ],
+           "": [
+                {
+                    "type": "insecureAcceptAnything"
+                }
+            ]
+        },
+        "docker-daemon": {
+            "": [
+                {
+                    "type": "insecureAcceptAnything"
+                }
+            ]
+        },
+        "atomic": {
+            "": [
+                {
+                    "type": "insecureAcceptAnything"
+                }
+            ]
+        },
+        "containers-storage": {
+            "": [
+                {
+                    "type": "insecureAcceptAnything"
+                }
+            ]
+        },
+        "dir": {
+            "": [
+                {
+                    "type": "insecureAcceptAnything"
+                }
+            ]
+        },
+        "oci": {
+            "": [
+                {
+                    "type": "insecureAcceptAnything"
+                }
+            ]
+        },
+        "oci-archive": {
+            "": [
+                {
+                    "type": "insecureAcceptAnything"
+                }
+            ]
+        },
+        "docker-archive": {
+            "": [
+                {
+                    "type": "insecureAcceptAnything"
+                }
+            ]
+        },
+        "tarball": {
+            "": [
+                {
+                    "type": "insecureAcceptAnything"
+                }
+            ]
+        }
+    }
+}

--- a/modules/signing/registry-config.yaml
+++ b/modules/signing/registry-config.yaml
@@ -1,0 +1,3 @@
+docker:
+  ghcr.io/IMAGENAME:
+    use-sigstore-attachments: true

--- a/modules/signing/signing.sh
+++ b/modules/signing/signing.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+
+# Tell build process to exit if there are any errors.
+set -oue pipefail
+
+CONTAINER_DIR="/usr/etc/containers"
+MODULE_DIRECTORY="${MODULE_DIRECTORY:-"/tmp/modules"}"
+
+echo "Setting up container signing in policy.json and cosign.yaml for $IMAGE_NAME"
+echo "Registry to write: $IMAGE_REGISTRY"
+
+if ! [ -d "$CONTAINER_DIR"]; then
+    mkdir -p "$CONTAINER_DIR"
+fi
+
+if ! [ -d $CONTAINER_DIR/registries.d]; then
+   mkdir -p "$CONTAINER_DIR/registries.d"
+fi
+
+if ! [ -d "/usr/etc/pki/containers"]; then
+    mkdir -p "/usr/etc/pki/containers"
+fi
+
+if ! [ -f "$CONTAINER_DIR/policy.json"]; then
+    cp "$MODULE_DIRECTORY/signing/policy.json" "$CONTAINER_DIR/policy.json"
+fi
+
+
+mv /usr/share/ublue-os/cosign.pub "$CONTAINER_DIR/$IMAGE_NAME".pub
+
+# Edits the container policy inplace
+FILE=/usr/etc/containers/policy.json
+
+yq -i -o=j '.transports.docker |=
+    {"'"$IMAGE_REGISTRY"'/'"$IMAGE_NAME"'": [
+            {
+                "type": "sigstoreSigned",
+                "keyPath": "/usr/etc/pki/containers/'"$IMAGE_NAME"'.pub",
+                "signedIdentity": {
+                    "type": "matchRepository"
+                }
+            }
+        ]
+    }
++ .' "$FILE"
+
+# Sets image-info.json used by ublue-update for auto-rebase workaround for offline ISOs and auto image signing.
+IMAGE_REF="ostree-image-signed:docker://$IMAGE_REGISTRY/$IMAGE_NAME"
+printf '{\n"image-ref": "'"$IMAGE_REF"'",\n"image-tag": "latest"\n}' > /usr/share/ublue-os/image-info.json
+
+
+mv "$MODULE_DIRECTORY/signing/registry-config.yaml" "$CONTAINER_DIR/registries.d/$IMAGE_NAME.yaml"
+sed -i "s ghcr.io/IMAGENAME $IMAGE_REGISTRY g" "$CONTAINER_DIR/registries.d/$IMAGE_NAME.yaml"

--- a/modules/signing/signing.sh
+++ b/modules/signing/signing.sh
@@ -13,7 +13,7 @@ if ! [ -d "$CONTAINER_DIR"]; then
     mkdir -p "$CONTAINER_DIR"
 fi
 
-if ! [ -d $CONTAINER_DIR/registries.d]; then
+if ! [ -d $CONTAINER_DIR/registries.d ]; then
    mkdir -p "$CONTAINER_DIR/registries.d"
 fi
 

--- a/modules/signing/signing.sh
+++ b/modules/signing/signing.sh
@@ -9,7 +9,7 @@ MODULE_DIRECTORY="${MODULE_DIRECTORY:-"/tmp/modules"}"
 echo "Setting up container signing in policy.json and cosign.yaml for $IMAGE_NAME"
 echo "Registry to write: $IMAGE_REGISTRY"
 
-if ! [ -d "$CONTAINER_DIR"]; then
+if ! [ -d "$CONTAINER_DIR" ]; then
     mkdir -p "$CONTAINER_DIR"
 fi
 
@@ -17,11 +17,11 @@ if ! [ -d $CONTAINER_DIR/registries.d ]; then
    mkdir -p "$CONTAINER_DIR/registries.d"
 fi
 
-if ! [ -d "/usr/etc/pki/containers"]; then
+if ! [ -d "/usr/etc/pki/containers" ]; then
     mkdir -p "/usr/etc/pki/containers"
 fi
 
-if ! [ -f "$CONTAINER_DIR/policy.json"]; then
+if ! [ -f "$CONTAINER_DIR/policy.json" ]; then
     cp "$MODULE_DIRECTORY/signing/policy.json" "$CONTAINER_DIR/policy.json"
 fi
 
@@ -46,7 +46,7 @@ yq -i -o=j '.transports.docker |=
 
 # Sets image-info.json used by ublue-update for auto-rebase workaround for offline ISOs and auto image signing.
 IMAGE_REF="ostree-image-signed:docker://$IMAGE_REGISTRY/$IMAGE_NAME"
-printf '{\n"image-ref": "'"$IMAGE_REF"'",\n"image-tag": "latest"\n}' > /usr/share/ublue-os/image-info.json
+printf '{\n"image-ref": "%s",\n"image-tag": "latest"\n}' "$IMAGE_REF" > /usr/share/ublue-os/image-info.json
 
 
 mv "$MODULE_DIRECTORY/signing/registry-config.yaml" "$CONTAINER_DIR/registries.d/$IMAGE_NAME.yaml"


### PR DESCRIPTION
This PR adds a signing module to replace the script `signing.sh` in [startingpoint](https://github.com/ublue-os/startingpoint) and [template](https://github.com/blue-build/template). 
I haven't tested it yet, so testing is welcome. I will probably get this tested tommorrow if I have time.