### PR TITLE
fix(files): Ensure that parent dot files & folders are copied

### DIFF
--- a/modules/files/files.sh
+++ b/modules/files/files.sh
@@ -18,16 +18,16 @@ if [[ ${#FILES[@]} -gt 0 ]]; then
                 mkdir -p "$DEST"
             fi
             echo "Copying $FILE to $DEST"
-            cp -r "$FILE"/* $DEST
-            rm "$DEST"/.gitkeep
+            cp -rf "$FILE"/* $DEST
+            rm -f "$DEST"/.gitkeep
         elif [ -f "$FILE" ]; then
             DEST_DIR=$(dirname "$DEST")
             if [ ! -d "$DEST_DIR" ]; then
                 mkdir -p "$DEST_DIR"
             fi
             echo "Copying $FILE to $DEST"
-            cp $FILE $DEST
-            rm "$DEST"/.gitkeep
+            cp -f $FILE $DEST
+            rm -f "$DEST"/.gitkeep
         else
             echo "File or Directory $FILE Does Not Exist in $CONFIG_DIRECTORY/files"
             exit 1

--- a/modules/files/files.sh
+++ b/modules/files/files.sh
@@ -19,6 +19,7 @@ if [[ ${#FILES[@]} -gt 0 ]]; then
             fi
             echo "Copying $FILE to $DEST"
             cp -r "$FILE"/* $DEST
+            rm "$DEST"/.gitkeep
         elif [ -f "$FILE" ]; then
             DEST_DIR=$(dirname "$DEST")
             if [ ! -d "$DEST_DIR" ]; then
@@ -26,6 +27,7 @@ if [[ ${#FILES[@]} -gt 0 ]]; then
             fi
             echo "Copying $FILE to $DEST"
             cp $FILE $DEST
+            rm "$DEST"/.gitkeep
         else
             echo "File or Directory $FILE Does Not Exist in $CONFIG_DIRECTORY/files"
             exit 1

--- a/modules/files/files.sh
+++ b/modules/files/files.sh
@@ -8,6 +8,7 @@ get_yaml_array FILES '.files[]' "$1"
 cd "$CONFIG_DIRECTORY/files"
 
 if [[ ${#FILES[@]} -gt 0 ]]; then
+    shopt -s dotglob
     echo "Adding files to image"
     for pair in "${FILES[@]}"; do
         FILE="$PWD/$(echo $pair | yq 'to_entries | .[0].key')"
@@ -25,6 +26,7 @@ if [[ ${#FILES[@]} -gt 0 ]]; then
             fi
             echo "Copying $FILE to $DEST"
             cp $FILE $DEST
+            shopt -u dotglob
         else
             echo "File or Directory $FILE Does Not Exist in $CONFIG_DIRECTORY/files"
             exit 1

--- a/modules/files/files.sh
+++ b/modules/files/files.sh
@@ -6,9 +6,9 @@ set -euo pipefail
 get_yaml_array FILES '.files[]' "$1"
 
 cd "$CONFIG_DIRECTORY/files"
+shopt -s dotglob
 
 if [[ ${#FILES[@]} -gt 0 ]]; then
-    shopt -s dotglob
     echo "Adding files to image"
     for pair in "${FILES[@]}"; do
         FILE="$PWD/$(echo $pair | yq 'to_entries | .[0].key')"
@@ -26,10 +26,11 @@ if [[ ${#FILES[@]} -gt 0 ]]; then
             fi
             echo "Copying $FILE to $DEST"
             cp $FILE $DEST
-            shopt -u dotglob
         else
             echo "File or Directory $FILE Does Not Exist in $CONFIG_DIRECTORY/files"
             exit 1
         fi
     done
 fi
+
+shopt -u dotglob


### PR DESCRIPTION
Enable dotglob when copying folders/files, disable when it's finished.