### PR TITLE
fix(gschema-overrides): Get rid of `files` module dependency

### DIFF
--- a/modules/gschema-overrides/README.md
+++ b/modules/gschema-overrides/README.md
@@ -7,9 +7,10 @@ This module is similar to using `dconf` configuration, but is better because it 
 What does this module do?
 
 - It copies all content from `/usr/share/glib-2.0/schemas`, except existing gschema.overrides to avoid conflicts, into temporary test location.
-- It copies your gschema.overrides you provided in this module from `/usr/share/glib-2.0/schemas` into temporary test location.
+- It copies your gschema.overrides you provided in this module from `/config/gschema-overrides` into temporary test location.
 - It tests them for errors in temporary test location by using `glib-compile-schemas` with `--strict` flag. If errors are found, build will fail.
-- If test is passed successfully, compile gschema using `glib-compile-schemas` in `/usr/share/glib-2.0/schemas` to include your changes.
+- If test is passed successfully, it copies your gschema.overrides to `/usr/share/glib-2.0/schemas`.
+- It compiles gschema using `glib-compile-schemas` in `/usr/share/glib-2.0/schemas` location to include your changes.
 
 Temporary test location is:
 
@@ -17,15 +18,15 @@ Temporary test location is:
 
 ## Usage
 
-To use this module, you need to include your gschema.override file(s) in this location:
+To use this module, you need to include your gschema.override file(s) in this location (make folder if it doesn't exist):
 
-`/usr/share/glib-2.0/schemas`
+`/config/gschema-overrides`
 
 Then you need to include those file(s) in recipe file, like in example configuration.
 
 It is highly recommended to use `z1-` prefix before your gschema.override name, to ensure that your changes are going to be applied.
 
-Also don't forget to rename your file(s) too with this prefix in `/usr/share/glib-2.0/schemas`.
+Also don't forget to rename your file(s) too with this prefix in `/config/gschema-overrides`.
 
 ## Creating gschema.override files
 

--- a/modules/gschema-overrides/README.md
+++ b/modules/gschema-overrides/README.md
@@ -24,7 +24,7 @@ To use this module, you need to include your gschema.override file(s) in this lo
 
 Then you need to include those file(s) in recipe file, like in example configuration.
 
-It is highly recommended to use `z1-` prefix before your gschema.override name, to ensure that your changes are going to be applied.
+It is highly recommended to use `zz1-` prefix before your gschema.override name, to ensure that your changes are going to be applied.
 
 Also don't forget to rename your file(s) too with this prefix in `config/gschema-overrides`.
 

--- a/modules/gschema-overrides/README.md
+++ b/modules/gschema-overrides/README.md
@@ -7,7 +7,7 @@ This module is similar to using `dconf` configuration, but is better because it 
 What does this module do?
 
 - It copies all content from `/usr/share/glib-2.0/schemas`, except existing gschema.overrides to avoid conflicts, into temporary test location.
-- It copies your gschema.overrides you provided in this module from `/config/gschema-overrides` into temporary test location.
+- It copies your gschema.overrides you provided in this module from `config/gschema-overrides` into temporary test location.
 - It tests them for errors in temporary test location by using `glib-compile-schemas` with `--strict` flag. If errors are found, build will fail.
 - If test is passed successfully, it copies your gschema.overrides to `/usr/share/glib-2.0/schemas`.
 - It compiles gschema using `glib-compile-schemas` in `/usr/share/glib-2.0/schemas` location to include your changes.
@@ -20,13 +20,13 @@ Temporary test location is:
 
 To use this module, you need to include your gschema.override file(s) in this location (make folder if it doesn't exist):
 
-`/config/gschema-overrides`
+`config/gschema-overrides`
 
 Then you need to include those file(s) in recipe file, like in example configuration.
 
 It is highly recommended to use `z1-` prefix before your gschema.override name, to ensure that your changes are going to be applied.
 
-Also don't forget to rename your file(s) too with this prefix in `/config/gschema-overrides`.
+Also don't forget to rename your file(s) too with this prefix in `config/gschema-overrides`.
 
 ## Creating gschema.override files
 

--- a/modules/gschema-overrides/module.yml
+++ b/modules/gschema-overrides/module.yml
@@ -4,4 +4,4 @@ readme: https://raw.githubusercontent.com/ublue-os/bling/main/modules/gschema-ov
 example: |
   type: gschema-overrides
   include:
-    - z1-myoverride.gschema.override # test & compile the override file included in config/gschema-overrides/z1-myoverride.gschema.override
+    - zz1-myoverride.gschema.override # test & compile the override file included in config/gschema-overrides/zz1-myoverride.gschema.override

--- a/modules/gschema-overrides/module.yml
+++ b/modules/gschema-overrides/module.yml
@@ -4,4 +4,4 @@ readme: https://raw.githubusercontent.com/ublue-os/bling/main/modules/gschema-ov
 example: |
   type: gschema-overrides
   include:
-    - z1-myoverride.gschema.override # test & compile the override file /usr/share/glib-2.0/schemas/z1-myoverride.gschema.override
+    - z1-myoverride.gschema.override # test & compile the override file included in config/gschema-overrides/z1-myoverride.gschema.override


### PR DESCRIPTION
Gschema.override files are now placed in /config/gschema-override folder.