### PR TITLE
refactor(default-flatpaks): Switch to standardized BlueBuild location, implement useful docs into files & make flatpak detection + comparison more robust

### DIFF
--- a/modules/default-flatpaks/README.md
+++ b/modules/default-flatpaks/README.md
@@ -16,6 +16,18 @@ The scripts are run on every boot by these services:
 
 `system-flatpak-setup` uninstalls Fedora flatpaks, replaces Fedora repos with your repo choice, checks the Flatpak install/remove lists created by the module & performs the install/uninstall operation according to that. `user-flatpak-setup` does the same thing for user Flatpaks.
 
-This module stores the Flatpak remote configuration and Flatpak install/remove lists in `/etc/bluebuild/default-flatpaks/`. There are two subdirectories, `user` and `system` corresponding with the install level of the Flatpaks and repositories. Each directory has text files containing the IDs of flatpaks to `install` and `remove`, plus a `repo-info.yml` containing the details of the Flatpak repository.
+This module stores the Flatpak remote configuration and Flatpak install/remove lists in `/usr/share/bluebuild/default-flatpaks/`. There are two subdirectories, `user` and `system` corresponding with the install level of the Flatpaks and repositories. Each directory has text files containing the IDs of flatpaks to `install` and `remove`, plus a `repo-info.yml` containing the details of the Flatpak repository.
 
 This module also supports disabling & enabling notifications.
+
+## Live-user modification
+
+If live-user is not satisfied with default-flatpaks modifications done within the OS, he can do modifications located in this directory:
+
+`/etc/bluebuild/default-flatpaks/`
+
+User can install or uninstall flatpaks, along with option to configure notifications.
+
+Folder structure is same as mentioned in example, with `system` & `user` folders,  
+`install` & `remove` files containing explanation on how those should be modified & what they do  
+`notifications` file also contains this explanation for turning notifications on or off.

--- a/modules/default-flatpaks/README.md
+++ b/modules/default-flatpaks/README.md
@@ -22,12 +22,8 @@ This module also supports disabling & enabling notifications.
 
 ## Local modification
 
-If a local user is not satisfied with default Flatpak installations and removals in the image, it is possible to make modifications to the configuration located within this directory:
+If a local user is not satisfied with default Flatpak installations and removals in the image, it is possible for them to make modifications to the default configuration through the configuration files located within this directory:
 
 `/etc/bluebuild/default-flatpaks/`
 
-Through the configuration in that folder it is possible to install or uninstall Flatpaks and configure notifications.
-
-Folder structure is the same as talked about above, with `system` & `user` folders,  
-`install` & `remove` files containing explanation on how those should be modified & what they do. 
-The `notifications` file also contains this explanation for turning notifications on or off.
+Folder structure is the same as talked about above, with `system` & `user` folders, `install` & `remove` files containing explanation on how those should be modified & what they do. The `notifications` file also contains this explanation for turning notifications on or off.

--- a/modules/default-flatpaks/README.md
+++ b/modules/default-flatpaks/README.md
@@ -2,7 +2,7 @@
 
 The `default-flatpaks` module can be used to install or uninstall Flatpaks from a configurable remote on every boot. It skips that operation if no changes are detected. This module first removes the Fedora Flatpaks remote and Flatpaks that come pre-installed in Fedora. A Flatpak remote is configured the first time the module is used, but it can be re-configured in subsequent usages of the module. If no Flatpak remote is specified, the module will default to using Flathub.
 
-Flatpaks can either be installed system-wide or per-user. Per-user Flatpaks will be installed separetly for every user on a system. Previously-installed flatpaks can also be removed.
+Flatpaks can either be installed system-wide or per-user. Per-user Flatpaks will be installed separately for every user on a system. Previously-installed flatpaks can also be removed.
 
 The module uses the following scripts to handle flatpak setup:
 
@@ -14,8 +14,8 @@ The scripts are run on every boot by these services:
 - `/usr/lib/systemd/system/system-flatpak-setup.service`
 - `/usr/lib/systemd/user/user-flatpak-setup-service`
 
-`system-flatpak-setup` uninstalls Fedora flatpaks, replaces Fedora repos with your repo choice, checks the Flatpak install/remove lists created by the module & performs the install/uninstall operation according to that. `user-flatpak-setup` does the same things for user Flatpaks.
+`system-flatpak-setup` uninstalls Fedora flatpaks, replaces Fedora repos with your repo choice, checks the Flatpak install/remove lists created by the module & performs the install/uninstall operation according to that. `user-flatpak-setup` does the same thing for user Flatpaks.
 
-This module stores the Flatpak remote configuration and Flatpak install/remove lists in `/etc/flatpak/`. There are two subdirectories, `user` and `system` corresponding with the install level of the Flatpaks and repositories. Each directory has text files containing the IDs of flatpaks to `install` and `remove`, plus a `repo-info.yml` containing the details of the Flatpak repository.
+This module stores the Flatpak remote configuration and Flatpak install/remove lists in `/etc/bluebuild/default-flatpaks/`. There are two subdirectories, `user` and `system` corresponding with the install level of the Flatpaks and repositories. Each directory has text files containing the IDs of flatpaks to `install` and `remove`, plus a `repo-info.yml` containing the details of the Flatpak repository.
 
 This module also supports disabling & enabling notifications.

--- a/modules/default-flatpaks/README.md
+++ b/modules/default-flatpaks/README.md
@@ -20,14 +20,14 @@ This module stores the Flatpak remote configuration and Flatpak install/remove l
 
 This module also supports disabling & enabling notifications.
 
-## Live-user modification
+## Local modification
 
-If live-user is not satisfied with default-flatpaks modifications done within the OS, he can do modifications located in this directory:
+If a local user is not satisfied with default Flatpak installations and removals in the image, it is possible to make modifications to the configuration located within this directory:
 
 `/etc/bluebuild/default-flatpaks/`
 
-User can install or uninstall flatpaks, along with option to configure notifications.
+Through the configuration in that folder it is possible to install or uninstall Flatpaks and configure notifications.
 
-Folder structure is same as mentioned in example, with `system` & `user` folders,  
-`install` & `remove` files containing explanation on how those should be modified & what they do  
-`notifications` file also contains this explanation for turning notifications on or off.
+Folder structure is the same as talked about above, with `system` & `user` folders,  
+`install` & `remove` files containing explanation on how those should be modified & what they do. 
+The `notifications` file also contains this explanation for turning notifications on or off.

--- a/modules/default-flatpaks/config/notifications
+++ b/modules/default-flatpaks/config/notifications
@@ -1,3 +1,3 @@
-# This file utilizes maintainer's configuration for `notifications` used by `default-flatpaks` BlueBuild module.
+# This file contains the image's default configuration for `notifications` used by the the `default-flatpaks` module.
 # Possible values: true, false
 

--- a/modules/default-flatpaks/config/notifications
+++ b/modules/default-flatpaks/config/notifications
@@ -1,0 +1,3 @@
+# This file utilizes maintainer's configuration for `notifications` used by `default-flatpaks` BlueBuild module.
+# Possible values: true, false
+

--- a/modules/default-flatpaks/config/system/install
+++ b/modules/default-flatpaks/config/system/install
@@ -1,3 +1,2 @@
-# This file utilizes maintainer's configuration for `system flatpaks install` used by `default-flatpaks` BlueBuild module.
-# Flatpak ID format is used for inserting desired `system flatpaks install` entry.
-
+# This file contains the image's default configuration for `system flatpaks install` used by the `default-flatpaks` BlueBuild module.
+# This list uses the Flatpak ID format, with one ID per line.

--- a/modules/default-flatpaks/config/system/install
+++ b/modules/default-flatpaks/config/system/install
@@ -1,2 +1,3 @@
 # This file contains the image's default configuration for `system flatpaks install` used by the `default-flatpaks` BlueBuild module.
 # This list uses the Flatpak ID format, with one ID per line.
+

--- a/modules/default-flatpaks/config/system/install
+++ b/modules/default-flatpaks/config/system/install
@@ -1,0 +1,3 @@
+# This file utilizes maintainer's configuration for `system flatpaks install` used by `default-flatpaks` BlueBuild module.
+# Flatpak ID format is used for inserting desired `system flatpaks install` entry.
+

--- a/modules/default-flatpaks/config/system/remove
+++ b/modules/default-flatpaks/config/system/remove
@@ -1,3 +1,3 @@
-# This file utilizes maintainer's configuration for `system flatpaks removal` used by `default-flatpaks` BlueBuild module.
-# Flatpak ID format is used for inserting desired `system flatpaks removal` entry.
+# This file contains the image's default configuration for `system flatpaks removal` used by the `default-flatpaks` BlueBuild module.
+# This list uses the Flatpak ID format, with one ID per line.
 

--- a/modules/default-flatpaks/config/system/remove
+++ b/modules/default-flatpaks/config/system/remove
@@ -1,0 +1,3 @@
+# This file utilizes maintainer's configuration for `system flatpaks removal` used by `default-flatpaks` BlueBuild module.
+# Flatpak ID format is used for inserting desired `system flatpaks removal` entry.
+

--- a/modules/default-flatpaks/config/user/install
+++ b/modules/default-flatpaks/config/user/install
@@ -1,3 +1,3 @@
-# This file utilizes maintainer's configuration for `user flatpaks install` used by `default-flatpaks` BlueBuild module.
-# Flatpak ID format is used for inserting desired `user flatpaks install` entry.
+# This file contains the image's default configuration for `user flatpaks install` used by the `default-flatpaks` BlueBuild module.
+# This list uses the Flatpak ID format, with one ID per line.
 

--- a/modules/default-flatpaks/config/user/install
+++ b/modules/default-flatpaks/config/user/install
@@ -1,0 +1,3 @@
+# This file utilizes maintainer's configuration for `user flatpaks install` used by `default-flatpaks` BlueBuild module.
+# Flatpak ID format is used for inserting desired `user flatpaks install` entry.
+

--- a/modules/default-flatpaks/config/user/remove
+++ b/modules/default-flatpaks/config/user/remove
@@ -1,0 +1,3 @@
+# This file utilizes maintainer's configuration for `user flatpaks removal` used by `default-flatpaks` BlueBuild module.
+# Flatpak ID format is used for inserting desired `user flatpaks removal` entry.
+

--- a/modules/default-flatpaks/config/user/remove
+++ b/modules/default-flatpaks/config/user/remove
@@ -1,3 +1,3 @@
-# This file utilizes maintainer's configuration for `user flatpaks removal` used by `default-flatpaks` BlueBuild module.
-# Flatpak ID format is used for inserting desired `user flatpaks removal` entry.
+# This file contains the image's default configuration for `user flatpaks removal` used by the `default-flatpaks` BlueBuild module.
+# This list uses the Flatpak ID format, with one ID per line.
 

--- a/modules/default-flatpaks/default-flatpaks.sh
+++ b/modules/default-flatpaks/default-flatpaks.sh
@@ -125,7 +125,7 @@ fi
 echo "Configuring default-flatpaks notifications"
 NOTIFICATIONS=$(echo "$1" | yq -I=0 ".notify")
 CONFIG_NOTIFICATIONS="/usr/share/bluebuild/default-flatpaks/notifications"
-cp -r "$MODULE_DIRECTORY"/default-flatpaks/config/notifications "$NOTIFICATIONS_CONFIG_FILE"
+cp -r "$MODULE_DIRECTORY"/default-flatpaks/config/notifications "$CONFIG_NOTIFICATIONS"
 echo "$NOTIFICATIONS" >> "$CONFIG_NOTIFICATIONS"
 
 echo "Copying user modification template files"

--- a/modules/default-flatpaks/default-flatpaks.sh
+++ b/modules/default-flatpaks/default-flatpaks.sh
@@ -140,7 +140,6 @@ echo "$NOTIFICATIONS" >> "$NOTIFICATIONS_CONFIG_FILE"
 
 echo "Writing live-user modification files"
 
-mkdir -p /usr/etc/bluebuild/default-flatpaks
 mkdir -p /usr/etc/bluebuild/default-flatpaks/system
 mkdir -p /usr/etc/bluebuild/default-flatpaks/user
 

--- a/modules/default-flatpaks/default-flatpaks.sh
+++ b/modules/default-flatpaks/default-flatpaks.sh
@@ -88,7 +88,6 @@ configure_lists () {
         touch $INSTALL_LIST
         for flatpak in "${INSTALL[@]}"; do
             echo "Adding to $INSTALL_LEVEL flatpak installs: $(printf ${flatpak})"
-            echo 
             echo $flatpak >> $INSTALL_LIST
         done
     fi

--- a/modules/default-flatpaks/default-flatpaks.sh
+++ b/modules/default-flatpaks/default-flatpaks.sh
@@ -159,7 +159,7 @@ echo "# This file utilizes user's configuration for \`system flatpaks install\` 
 USER_REMOVE_SYSTEM_LIST="/usr/etc/bluebuild/default-flatpaks/system/remove"
 echo "# This file utilizes user's configuration for \`system flatpaks removal\` used by \`default-flatpaks\` BlueBuild module.
 # If this file is not modified, maintainer's configuration will be used instead (located in /usr/share/bluebuild/default-flatpaks/system/remove).
-# Specify the ID of \`system flatpaks\` in the list you want to install.
+# Specify the ID of \`system flatpaks\` in the list you want to remove.
 # Duplicated entries won't be used if located in maintainer's configuration.
 # Flatpak runtimes are not supported.
 # Here's an example on how to edit this file (ignore # symbol):

--- a/modules/default-flatpaks/default-flatpaks.sh
+++ b/modules/default-flatpaks/default-flatpaks.sh
@@ -140,6 +140,10 @@ echo "$NOTIFICATIONS" >> "$NOTIFICATIONS_CONFIG_FILE"
 
 echo "Writing live-user modification files"
 
+mkdir -p /usr/etc/bluebuild/default-flatpaks
+mkdir -p /usr/etc/bluebuild/default-flatpaks/system
+mkdir -p /usr/etc/bluebuild/default-flatpaks/user
+
 USER_INSTALL_SYSTEM_LIST="/usr/etc/bluebuild/default-flatpaks/system/install"
 echo "# This file utilizes user's configuration for \`system flatpaks install\` used by \`default-flatpaks\` BlueBuild module.
 # If this file is not modified, maintainer's configuration will be used instead (located in /usr/share/bluebuild/default-flatpaks/system/install).

--- a/modules/default-flatpaks/default-flatpaks.sh
+++ b/modules/default-flatpaks/default-flatpaks.sh
@@ -114,9 +114,9 @@ if [[ ! $(echo "$1" | yq -I=0 ".system") == "null" ]]; then
     system_install_list_doc="/usr/share/bluebuild/default-flatpaks/system/install"
     system_remove_list_doc="/usr/share/bluebuild/default-flatpaks/system/remove"
     echo -e "# This file utilizes maintainer's configuration for \`system flatpaks install\` used by \`default-flatpaks\` BlueBuild module.
-# Flatpak ID format is used for inserting desired \`system flatpaks install\` entry\n" > "$system_install_list_doc"
+# Flatpak ID format is used for inserting desired \`system flatpaks install\` entry.\n" > "$system_install_list_doc"
     echo -e "# This file utilizes maintainer's configuration for \`system flatpaks removal\` used by \`default-flatpaks\` BlueBuild module.
-# Flatpak ID format is used for inserting desired \`system flatpaks removal\` entry\n" > "$system_remove_list_doc"
+# Flatpak ID format is used for inserting desired \`system flatpaks removal\` entry.\n" > "$system_remove_list_doc"
     configure_lists "$1" "system"
 fi
 
@@ -126,9 +126,9 @@ if [[ ! $(echo "$1" | yq -I=0 ".user") == "null" ]]; then
     user_install_list_doc="/usr/share/bluebuild/default-flatpaks/user/install"
     user_remove_list_doc="/usr/share/bluebuild/default-flatpaks/user/remove"
     echo -e "# This file utilizes maintainer's configuration for \`user flatpaks install\` used by \`default-flatpaks\` BlueBuild module.
-# Flatpak ID format is used for inserting desired \`user flatpaks install\` entry\n" > "$user_install_list_doc"
+# Flatpak ID format is used for inserting desired \`user flatpaks install\` entry.\n" > "$user_install_list_doc"
     echo -e "# This file utilizes maintainer's configuration for \`user flatpaks removal\` used by \`default-flatpaks\` BlueBuild module.
-# Flatpak ID format is used for inserting desired \`user flatpaks removal\` entry\n" > "$user_remove_list_doc"    
+# Flatpak ID format is used for inserting desired \`user flatpaks removal\` entry.\n" > "$user_remove_list_doc"    
     configure_lists "$1" "user"
 fi
 

--- a/modules/default-flatpaks/default-flatpaks.sh
+++ b/modules/default-flatpaks/default-flatpaks.sh
@@ -13,7 +13,7 @@ cp -r "$MODULE_DIRECTORY"/default-flatpaks/user-flatpak-setup.service /usr/lib/s
 configure_flatpak_repo () {
     CONFIG_FILE=$1
     INSTALL_LEVEL=$2
-    REPO_INFO="/usr/etc/flatpak/$INSTALL_LEVEL/repo-info.yml"
+    REPO_INFO="/usr/etc/bluebuild/default-flatpaks/$INSTALL_LEVEL/repo-info.yml"
     get_yaml_array INSTALL ".$INSTALL_LEVEL.install[]" "$CONFIG_FILE"
 
 
@@ -78,8 +78,8 @@ EOF
 configure_lists () {
     CONFIG_FILE=$1
     INSTALL_LEVEL=$2
-    INSTALL_LIST="/usr/etc/flatpak/$INSTALL_LEVEL/install"
-    REMOVE_LIST="/usr/etc/flatpak/$INSTALL_LEVEL/remove"
+    INSTALL_LIST="/usr/etc/bluebuild/default-flatpaks/$INSTALL_LEVEL/install"
+    REMOVE_LIST="/usr/etc/bluebuild/default-flatpaks/$INSTALL_LEVEL/remove"
     get_yaml_array INSTALL ".$INSTALL_LEVEL.install[]" "$CONFIG_FILE"
     get_yaml_array REMOVE ".$INSTALL_LEVEL.remove[]" "$CONFIG_FILE"
 
@@ -103,7 +103,7 @@ configure_lists () {
 }
 
 echo "Enabling flatpaks module"
-mkdir -p /usr/etc/flatpak/{system,user}
+mkdir -p /usr/etc/bluebuild/default-flatpaks/{system,user}
 systemctl enable -f system-flatpak-setup.service
 systemctl enable -f --global user-flatpak-setup.service
 
@@ -121,5 +121,5 @@ fi
 
 echo "Configuring default-flatpaks notifications"
 NOTIFICATIONS=$(echo "$1" | yq -I=0 ".notify")
-NOTIFICATIONS_CONFIG_FILE="/usr/etc/flatpak/notifications"
+NOTIFICATIONS_CONFIG_FILE="/usr/etc/bluebuild/default-flatpaks/notifications"
 echo "$NOTIFICATIONS" > "$NOTIFICATIONS_CONFIG_FILE"

--- a/modules/default-flatpaks/system-flatpak-setup
+++ b/modules/default-flatpaks/system-flatpak-setup
@@ -63,7 +63,7 @@ INSTALL_LIST_FILE="/usr/share/bluebuild/default-flatpaks/system/install"
 REMOVE_LIST_FILE="/usr/share/bluebuild/default-flatpaks/system/remove"
 USER_INSTALL_LIST_FILE="/etc/bluebuild/default-flatpaks/system/install"
 USER_REMOVE_LIST_FILE="/etc/bluebuild/default-flatpaks/system/remove"
-# This accounts for the scenario when user sets the same package in install list that is in maintainer's remove list & vice-versa
+# Prefer user's install + remove list over maintainer's, in case when same flatpak ID is present in maintainer's install list + user's remove list & vice-versa
 # Also ignores words starting with # symbol, whitelines & duplicate entries
 MAINTAINER_INSTALL_LIST=$(comm -23 <(sort "$INSTALL_LIST_FILE") <(sort "$USER_REMOVE_LIST_FILE") | grep -v -E '^#|^$' | awk '!seen[$0]++')
 MAINTAINER_REMOVE_LIST=$(comm -23 <(sort "$REMOVE_LIST_FILE") <(sort "$USER_INSTALL_LIST_FILE") | grep -v -E '^#|^$' | awk '!seen[$0]++')

--- a/modules/default-flatpaks/system-flatpak-setup
+++ b/modules/default-flatpaks/system-flatpak-setup
@@ -17,7 +17,7 @@ if grep -qz 'fedora' <<< "$(flatpak remotes)"; then
   flatpak remove --system --noninteractive ${FEDORA_FLATPAKS[@]}
 fi
 
-REPO_INFO="/etc/bluebuild/default-flatpaks/system/repo-info.yml"
+REPO_INFO="/usr/share/bluebuild/default-flatpaks/system/repo-info.yml"
 REPO_URL=$(yq '.repo-url' $REPO_INFO)
 REPO_NAME=$(yq '.repo-name' $REPO_INFO)
 REPO_TITLE=$(yq '.repo-title' $REPO_INFO)
@@ -42,14 +42,30 @@ if [[ ! $REPO_TITLE == "null" ]]; then
 fi
 
 # Notifications config
-NOTIFICATIONS=$(cat /etc/bluebuild/default-flatpaks/notifications)
+NOTIFICATIONS_FILE="/usr/share/bluebuild/default-flatpaks/notifications"
+USER_NOTIFICATIONS_FILE="/etc/bluebuild/default-flatpaks/notifications"
+# Ignore words starting with # symbol, whitelines & duplicate entries for notifications config
+MAINTAINER_NOTIFICATIONS=$(cat "$NOTIFICATIONS_FILE" | grep -v -E '^#|^$' | awk '!seen[$0]++')
+USER_NOTIFICATIONS=$(cat "$USER_NOTIFICATIONS_FILE" | grep -v -E '^#|^$' | awk '!seen[$0]++')
+
+# If user modified notifications config, utilize user's configuration, otherwise maintainer's
+if [[ -n $USER_NOTIFICATIONS ]]; then
+  NOTIFICATIONS="$USER_NOTIFICATIONS"
+else
+  NOTIFICATIONS="$MAINTAINER_NOTIFICATIONS"
+fi  
 
 # Installed flatpaks
 FLATPAK_LIST=$(flatpak list --system --columns=application)
 
 # Flatpak list files
-INSTALL_LIST_FILE="/etc/bluebuild/default-flatpaks/system/install"
-REMOVE_LIST_FILE="/etc/bluebuild/default-flatpaks/system/remove"
+INSTALL_LIST_FILE="/usr/share/bluebuild/default-flatpaks/system/install"
+REMOVE_LIST_FILE="/usr/share/bluebuild/default-flatpaks/system/remove"
+USER_INSTALL_LIST_FILE="/etc/bluebuild/default-flatpaks/system/install"
+USER_REMOVE_LIST_FILE="/etc/bluebuild/default-flatpaks/system/remove"
+# Ignore words starting with # symbol, whitelines & duplicate entries for flatpak list files.
+COMBINED_INSTALL_LIST=$(cat "$INSTALL_LIST_FILE" "$USER_INSTALL_LIST_FILE" | grep -v -E '^#|^$' | awk '!seen[$0]++')
+COMBINED_REMOVE_LIST=$(cat "$REMOVE_LIST_FILE" "$USER_REMOVE_LIST_FILE" | grep -v -E '^#|^$' | awk '!seen[$0]++')
 
 function notify-send-pre-install {
      user_name=$(loginctl list-sessions --output=json | jq -r '.[].user')
@@ -84,11 +100,11 @@ function notify-send-uninstall {
 }
 
 # Install flatpaks in list
-if [[ -f $INSTALL_LIST_FILE ]]; then
+if [[ -f $INSTALL_LIST_FILE ]] || [[ -f $USER_INSTALL_LIST_FILE ]]; then
   if [[ -n $FLATPAK_LIST ]]; then
-    INSTALL_LIST=$(echo "$FLATPAK_LIST" | grep -vf - "$INSTALL_LIST_FILE")
+    INSTALL_LIST=$(comm -23 <(echo "$COMBINED_INSTALL_LIST" | sort) <(echo "$FLATPAK_LIST" | sort))
   else
-    INSTALL_LIST=$(cat $INSTALL_LIST_FILE)
+    INSTALL_LIST="$COMBINED_INSTALL_LIST"
   fi
   if [[ -n $INSTALL_LIST ]] && [[ ! $NOTIFICATIONS == "true" ]]; then
     flatpak install --system --noninteractive "$REPO_NAME" ${INSTALL_LIST[@]}
@@ -100,8 +116,8 @@ if [[ -f $INSTALL_LIST_FILE ]]; then
 fi
 
 # Remove flatpaks in list
-if [[ -f $REMOVE_LIST_FILE ]]; then
-  REMOVE_LIST=$(echo "$FLATPAK_LIST" | grep -o -f - "$REMOVE_LIST_FILE")
+if [[ -f $REMOVE_LIST_FILE ]] || [[ -f $USER_REMOVE_LIST_FILE ]]; then
+  REMOVE_LIST=$(comm -12 <(echo "$COMBINED_REMOVE_LIST" | sort) <(echo "$FLATPAK_LIST" | sort))
   if [[ -n $REMOVE_LIST ]] && [[ ! $NOTIFICATIONS == "true" ]]; then
     flatpak uninstall --system --noninteractive ${REMOVE_LIST[@]}
   elif [[ -n $REMOVE_LIST ]] && [[ $NOTIFICATIONS == "true" ]]; then

--- a/modules/default-flatpaks/system-flatpak-setup
+++ b/modules/default-flatpaks/system-flatpak-setup
@@ -68,9 +68,11 @@ COMBINED_INSTALL_PRELIST=$(cat "$INSTALL_LIST_FILE" "$USER_INSTALL_LIST_FILE" | 
 COMBINED_REMOVE_PRELIST=$(cat "$REMOVE_LIST_FILE" "$USER_REMOVE_LIST_FILE" | grep -v -E '^#|^$' | awk '!seen[$0]++')
 # Avoid install/remove loop scenario when you have duplicate entry in install & remove list at the same time
 # (from user's side, as maintainer's-side will be handled by the module itself in the future)
-# cat doesn't work, because this is not a file
-COMBINED_INSTALL_LIST=$(sort -u <(cat "$COMBINED_INSTALL_PRELIST" "$COMBINED_REMOVE_PRELIST")) #(exclude duplicates from "$COMBINED_REMOVE_PRELIST")
-COMBINED_REMOVE_LIST=$(sort -u <(cat "$COMBINED_REMOVE_PRELIST" "$COMBINED_INSTALL_PRELIST")) #(exclude duplicates from "$COMBINED_INSTALL_PRELIST")
+############################# Work in progress, for section below ####################################
+# It's needed to exclude duplicates from "$COMBINED_REMOVE_PRELIST", which match "$COMBINED_INSTALL_PRELIST"
+COMBINED_INSTALL_LIST=$(sort -u <(cat "$COMBINED_INSTALL_PRELIST" "$COMBINED_REMOVE_PRELIST"))
+# It's needed to exclude duplicates from "$COMBINED_INSTALL_PRELIST", which match "$COMBINED_REMOVE_PRELIST"
+COMBINED_REMOVE_LIST=$(sort -u <(cat "$COMBINED_REMOVE_PRELIST" "$COMBINED_INSTALL_PRELIST"))
 
 function notify-send-pre-install {
      user_name=$(loginctl list-sessions --output=json | jq -r '.[].user')

--- a/modules/default-flatpaks/system-flatpak-setup
+++ b/modules/default-flatpaks/system-flatpak-setup
@@ -63,15 +63,16 @@ INSTALL_LIST_FILE="/usr/share/bluebuild/default-flatpaks/system/install"
 REMOVE_LIST_FILE="/usr/share/bluebuild/default-flatpaks/system/remove"
 USER_INSTALL_LIST_FILE="/etc/bluebuild/default-flatpaks/system/install"
 USER_REMOVE_LIST_FILE="/etc/bluebuild/default-flatpaks/system/remove"
+# This accounts for the scenario when user sets the same package in install list that is in maintainer's remove list & vice-versa
+# Also ignores words starting with # symbol, whitelines & duplicate entries
+#
+##################### Work in progress! ############################
+#USER_INSTALL_LIST=$(grep -vf - "$USER_INSTALL_LIST_FILE" "$INSTALL_LIST_FILE" | grep -v -E '^#|^$' | awk '!seen[$0]++')
+#USER_REMOVE_LIST=$(grep -vf - "$USER_REMOVE_LIST_FILE" "$INSTALL_LIST_FILE" | grep -v -E '^#|^$' | awk '!seen[$0]++')
+#
 # Combine maintainer & user list. Ignore words starting with # symbol, whitelines & duplicate entries
-# This applies for: maintainer-install/user-install, maintainer-remove/user-remove duplicates.
-COMBINED_INSTALL_PRELIST=$(cat "$INSTALL_LIST_FILE" "$USER_INSTALL_LIST_FILE" | grep -v -E '^#|^$' | awk '!seen[$0]++')
-COMBINED_REMOVE_PRELIST=$(cat "$REMOVE_LIST_FILE" "$USER_REMOVE_LIST_FILE" | grep -v -E '^#|^$' | awk '!seen[$0]++')
-# Avoid install/remove loop scenario when you have duplicate entry in install + remove list at the same time (different from above)
-INSTALL_REMOVE_DIFF=$(comm -12 <(sort <(printf "%s\n" "${COMBINED_INSTALL_PRELIST[@]}")) <(sort <(printf "%s\n" "${COMBINED_REMOVE_PRELIST[@]}")))
-# Exclude install + remove duplicates from combined install & remove list
-COMBINED_INSTALL_LIST=$(awk 'NR==FNR{a[$0];next} !($0 in a)' <(echo "$INSTALL_REMOVE_DIFF") <(echo "$COMBINED_INSTALL_PRELIST"))
-COMBINED_REMOVE_LIST=$(awk 'NR==FNR{a[$0];next} !($0 in a)' <(echo "$INSTALL_REMOVE_DIFF") <(echo "$COMBINED_REMOVE_PRELIST"))
+COMBINED_INSTALL_LIST=$(cat "$INSTALL_LIST_FILE" | echo "$USER_INSTALL_LIST" | grep -v -E '^#|^$' | awk '!seen[$0]++')
+COMBINED_REMOVE_LIST=$(cat "$REMOVE_LIST_FILE" | echo "$USER_REMOVE_LIST" | grep -v -E '^#|^$' | awk '!seen[$0]++')
 
 function notify-send-pre-install {
      user_name=$(loginctl list-sessions --output=json | jq -r '.[].user')

--- a/modules/default-flatpaks/system-flatpak-setup
+++ b/modules/default-flatpaks/system-flatpak-setup
@@ -69,8 +69,8 @@ COMBINED_REMOVE_PRELIST=$(cat "$REMOVE_LIST_FILE" "$USER_REMOVE_LIST_FILE" | gre
 # Avoid install/remove loop scenario when you have duplicate entry in install & remove list at the same time
 # (from user's side, as maintainer's-side will be handled by the module itself in the future)
 # cat doesn't work, because this is not a file
-COMBINED_INSTALL_LIST=$(sort -u <(cat "$COMBINED_INSTALL_PRELIST" "$USER_REMOVE_LIST_FILE")) #(exclude duplicates from "$USER_REMOVE_LIST_FILE")
-COMBINED_REMOVE_LIST=$(sort -u <(cat "$COMBINED_REMOVE_PRELIST" "$USER_INSTALL_LIST_FILE")) #(exclude duplicates from "$USER_INSTALL_LIST_FILE")
+COMBINED_INSTALL_LIST=$(sort -u <(cat "$COMBINED_INSTALL_PRELIST" "$COMBINED_REMOVE_PRELIST")) #(exclude duplicates from "$COMBINED_REMOVE_PRELIST")
+COMBINED_REMOVE_LIST=$(sort -u <(cat "$COMBINED_REMOVE_PRELIST" "$COMBINED_INSTALL_PRELIST")) #(exclude duplicates from "$COMBINED_INSTALL_PRELIST")
 
 function notify-send-pre-install {
      user_name=$(loginctl list-sessions --output=json | jq -r '.[].user')

--- a/modules/default-flatpaks/system-flatpak-setup
+++ b/modules/default-flatpaks/system-flatpak-setup
@@ -64,8 +64,13 @@ REMOVE_LIST_FILE="/usr/share/bluebuild/default-flatpaks/system/remove"
 USER_INSTALL_LIST_FILE="/etc/bluebuild/default-flatpaks/system/install"
 USER_REMOVE_LIST_FILE="/etc/bluebuild/default-flatpaks/system/remove"
 # Ignore words starting with # symbol, whitelines & duplicate entries for flatpak list files.
-COMBINED_INSTALL_LIST=$(cat "$INSTALL_LIST_FILE" "$USER_INSTALL_LIST_FILE" | grep -v -E '^#|^$' | awk '!seen[$0]++')
-COMBINED_REMOVE_LIST=$(cat "$REMOVE_LIST_FILE" "$USER_REMOVE_LIST_FILE" | grep -v -E '^#|^$' | awk '!seen[$0]++')
+COMBINED_INSTALL_PRELIST=$(cat "$INSTALL_LIST_FILE" "$USER_INSTALL_LIST_FILE" | grep -v -E '^#|^$' | awk '!seen[$0]++')
+COMBINED_REMOVE_PRELIST=$(cat "$REMOVE_LIST_FILE" "$USER_REMOVE_LIST_FILE" | grep -v -E '^#|^$' | awk '!seen[$0]++')
+# Avoid install/remove loop scenario when you have duplicate entry in install & remove list at the same time
+# (from user's side, as maintainer's-side will be handled by the module itself in the future)
+# cat doesn't work, because this is not a file
+COMBINED_INSTALL_LIST=$(sort -u <(cat "$COMBINED_INSTALL_PRELIST" "$USER_REMOVE_LIST_FILE")) #(exclude duplicates from "$USER_REMOVE_LIST_FILE")
+COMBINED_REMOVE_LIST=$(sort -u <(cat "$COMBINED_REMOVE_PRELIST" "$USER_INSTALL_LIST_FILE")) #(exclude duplicates from "$USER_INSTALL_LIST_FILE")
 
 function notify-send-pre-install {
      user_name=$(loginctl list-sessions --output=json | jq -r '.[].user')

--- a/modules/default-flatpaks/system-flatpak-setup
+++ b/modules/default-flatpaks/system-flatpak-setup
@@ -65,14 +65,11 @@ USER_INSTALL_LIST_FILE="/etc/bluebuild/default-flatpaks/system/install"
 USER_REMOVE_LIST_FILE="/etc/bluebuild/default-flatpaks/system/remove"
 # This accounts for the scenario when user sets the same package in install list that is in maintainer's remove list & vice-versa
 # Also ignores words starting with # symbol, whitelines & duplicate entries
-#
-##################### Work in progress! ############################
-#USER_INSTALL_LIST=$(grep -vf - "$USER_INSTALL_LIST_FILE" "$INSTALL_LIST_FILE" | grep -v -E '^#|^$' | awk '!seen[$0]++')
-#USER_REMOVE_LIST=$(grep -vf - "$USER_REMOVE_LIST_FILE" "$INSTALL_LIST_FILE" | grep -v -E '^#|^$' | awk '!seen[$0]++')
-#
+MAINTAINER_INSTALL_LIST=$(comm -23 <(sort "$INSTALL_LIST_FILE") <(sort "$USER_REMOVE_LIST_FILE") | grep -v -E '^#|^$' | awk '!seen[$0]++')
+MAINTAINER_REMOVE_LIST=$(comm -23 <(sort "$REMOVE_LIST_FILE") <(sort "$USER_INSTALL_LIST_FILE") | grep -v -E '^#|^$' | awk '!seen[$0]++')
 # Combine maintainer & user list. Ignore words starting with # symbol, whitelines & duplicate entries
-COMBINED_INSTALL_LIST=$(cat "$INSTALL_LIST_FILE" | echo "$USER_INSTALL_LIST" | grep -v -E '^#|^$' | awk '!seen[$0]++')
-COMBINED_REMOVE_LIST=$(cat "$REMOVE_LIST_FILE" | echo "$USER_REMOVE_LIST" | grep -v -E '^#|^$' | awk '!seen[$0]++')
+COMBINED_INSTALL_LIST=$(cat <(echo "$MAINTAINER_INSTALL_LIST") "$USER_REMOVE_LIST_FILE" | grep -v -E '^#|^$' | awk '!seen[$0]++')
+COMBINED_REMOVE_LIST=$(cat <(echo "$MAINTAINER_REMOVE_LIST") "$USER_REMOVE_LIST_FILE" | grep -v -E '^#|^$' | awk '!seen[$0]++')
 
 function notify-send-pre-install {
      user_name=$(loginctl list-sessions --output=json | jq -r '.[].user')

--- a/modules/default-flatpaks/system-flatpak-setup
+++ b/modules/default-flatpaks/system-flatpak-setup
@@ -17,7 +17,7 @@ if grep -qz 'fedora' <<< "$(flatpak remotes)"; then
   flatpak remove --system --noninteractive ${FEDORA_FLATPAKS[@]}
 fi
 
-REPO_INFO="/etc/flatpak/system/repo-info.yml"
+REPO_INFO="/etc/bluebuild/default-flatpaks/system/repo-info.yml"
 REPO_URL=$(yq '.repo-url' $REPO_INFO)
 REPO_NAME=$(yq '.repo-name' $REPO_INFO)
 REPO_TITLE=$(yq '.repo-title' $REPO_INFO)
@@ -42,14 +42,14 @@ if [[ ! $REPO_TITLE == "null" ]]; then
 fi
 
 # Notifications config
-NOTIFICATIONS=$(cat /etc/flatpak/notifications)
+NOTIFICATIONS=$(cat /etc/bluebuild/default-flatpaks/notifications)
 
 # Installed flatpaks
 FLATPAK_LIST=$(flatpak list --system --columns=application)
 
 # Flatpak list files
-INSTALL_LIST_FILE="/etc/flatpak/system/install"
-REMOVE_LIST_FILE="/etc/flatpak/system/remove"
+INSTALL_LIST_FILE="/etc/bluebuild/default-flatpaks/system/install"
+REMOVE_LIST_FILE="/etc/bluebuild/default-flatpaks/system/remove"
 
 function notify-send-pre-install {
      user_name=$(loginctl list-sessions --output=json | jq -r '.[].user')

--- a/modules/default-flatpaks/system-flatpak-setup
+++ b/modules/default-flatpaks/system-flatpak-setup
@@ -63,16 +63,15 @@ INSTALL_LIST_FILE="/usr/share/bluebuild/default-flatpaks/system/install"
 REMOVE_LIST_FILE="/usr/share/bluebuild/default-flatpaks/system/remove"
 USER_INSTALL_LIST_FILE="/etc/bluebuild/default-flatpaks/system/install"
 USER_REMOVE_LIST_FILE="/etc/bluebuild/default-flatpaks/system/remove"
-# Ignore words starting with # symbol, whitelines & duplicate entries for flatpak list files.
+# Combine maintainer & user list. Ignore words starting with # symbol, whitelines & duplicate entries
+# This applies for: maintainer-install/user-install, maintainer-remove/user-remove duplicates.
 COMBINED_INSTALL_PRELIST=$(cat "$INSTALL_LIST_FILE" "$USER_INSTALL_LIST_FILE" | grep -v -E '^#|^$' | awk '!seen[$0]++')
 COMBINED_REMOVE_PRELIST=$(cat "$REMOVE_LIST_FILE" "$USER_REMOVE_LIST_FILE" | grep -v -E '^#|^$' | awk '!seen[$0]++')
-# Avoid install/remove loop scenario when you have duplicate entry in install & remove list at the same time
-# (from user's side, as maintainer's-side will be handled by the module itself in the future)
-############################# Work in progress, for section below ####################################
-# It's needed to exclude duplicates from "$COMBINED_REMOVE_PRELIST", which match "$COMBINED_INSTALL_PRELIST"
-COMBINED_INSTALL_LIST=$(sort -u <(cat "$COMBINED_INSTALL_PRELIST" "$COMBINED_REMOVE_PRELIST"))
-# It's needed to exclude duplicates from "$COMBINED_INSTALL_PRELIST", which match "$COMBINED_REMOVE_PRELIST"
-COMBINED_REMOVE_LIST=$(sort -u <(cat "$COMBINED_REMOVE_PRELIST" "$COMBINED_INSTALL_PRELIST"))
+# Avoid install/remove loop scenario when you have duplicate entry in install + remove list at the same time (different from above)
+INSTALL_REMOVE_DIFF=$(comm -12 <(sort <(printf "%s\n" "${COMBINED_INSTALL_PRELIST[@]}")) <(sort <(printf "%s\n" "${COMBINED_REMOVE_PRELIST[@]}")))
+# Exclude install + remove duplicates from combined install & remove list
+COMBINED_INSTALL_LIST=$(awk 'NR==FNR{a[$0];next} !($0 in a)' <(echo "$INSTALL_REMOVE_DIFF") <(echo "$COMBINED_INSTALL_PRELIST"))
+COMBINED_REMOVE_LIST=$(awk 'NR==FNR{a[$0];next} !($0 in a)' <(echo "$INSTALL_REMOVE_DIFF") <(echo "$COMBINED_REMOVE_PRELIST"))
 
 function notify-send-pre-install {
      user_name=$(loginctl list-sessions --output=json | jq -r '.[].user')

--- a/modules/default-flatpaks/system-flatpak-setup
+++ b/modules/default-flatpaks/system-flatpak-setup
@@ -68,7 +68,7 @@ USER_REMOVE_LIST_FILE="/etc/bluebuild/default-flatpaks/system/remove"
 MAINTAINER_INSTALL_LIST=$(comm -23 <(sort "$INSTALL_LIST_FILE") <(sort "$USER_REMOVE_LIST_FILE") | grep -v -E '^#|^$' | awk '!seen[$0]++')
 MAINTAINER_REMOVE_LIST=$(comm -23 <(sort "$REMOVE_LIST_FILE") <(sort "$USER_INSTALL_LIST_FILE") | grep -v -E '^#|^$' | awk '!seen[$0]++')
 # Combine maintainer & user list. Ignore words starting with # symbol, whitelines & duplicate entries
-COMBINED_INSTALL_LIST=$(cat <(echo "$MAINTAINER_INSTALL_LIST") "$USER_REMOVE_LIST_FILE" | grep -v -E '^#|^$' | awk '!seen[$0]++')
+COMBINED_INSTALL_LIST=$(cat <(echo "$MAINTAINER_INSTALL_LIST") "$USER_INSTALL_LIST_FILE" | grep -v -E '^#|^$' | awk '!seen[$0]++')
 COMBINED_REMOVE_LIST=$(cat <(echo "$MAINTAINER_REMOVE_LIST") "$USER_REMOVE_LIST_FILE" | grep -v -E '^#|^$' | awk '!seen[$0]++')
 
 function notify-send-pre-install {

--- a/modules/default-flatpaks/user-config/notifications
+++ b/modules/default-flatpaks/user-config/notifications
@@ -1,0 +1,6 @@
+# This file utilizes user's configuration for `notifications` used by `default-flatpaks` BlueBuild module.
+# If this file is not modified, maintainer's configuration will be used instead (located in /usr/share/bluebuild/default-flatpaks/notifications).
+# Possible values: true, false
+# Here's an example on how to edit this file (ignore # symbol):
+#
+# false

--- a/modules/default-flatpaks/user-config/notifications
+++ b/modules/default-flatpaks/user-config/notifications
@@ -1,5 +1,5 @@
-# This file utilizes user's configuration for `notifications` used by `default-flatpaks` BlueBuild module.
-# If this file is not modified, maintainer's configuration will be used instead (located in /usr/share/bluebuild/default-flatpaks/notifications).
+# This file can be used by the users for configuration of `notifications` used by the the `default-flatpaks` BlueBuild module.
+# If this file is not modified, the image's default configuration will be used instead (located in /usr/share/bluebuild/default-flatpaks/notifications).
 # Possible values: true, false
 # Here's an example on how to edit this file (ignore # symbol):
 #

--- a/modules/default-flatpaks/user-config/system/install
+++ b/modules/default-flatpaks/user-config/system/install
@@ -1,7 +1,7 @@
-# This file utilizes user's configuration for `system flatpaks install` used by `default-flatpaks` BlueBuild module.
-# If this file is not modified, maintainer's configuration will be used instead (located in /usr/share/bluebuild/default-flatpaks/system/install).
-# Specify the ID of `system flatpaks` in the list you want to install.
-# Duplicated entries won't be used if located in maintainer's configuration.
+# This file can be used by the users for configuration of `system flatpaks install` used by the `default-flatpaks` BlueBuild module.
+# If this file is not modified, the image's default configuration will be used instead (located in /usr/share/bluebuild/default-flatpaks/system/install).
+# This list uses the Flatpak ID format, with one ID per line.
+# Duplicated entries won't be used if located in the image's default configuration.
 # Flatpak runtimes are not supported.
 # Here's an example on how to edit this file (ignore # symbol):
 #

--- a/modules/default-flatpaks/user-config/system/install
+++ b/modules/default-flatpaks/user-config/system/install
@@ -1,0 +1,10 @@
+# This file utilizes user's configuration for `system flatpaks install` used by `default-flatpaks` BlueBuild module.
+# If this file is not modified, maintainer's configuration will be used instead (located in /usr/share/bluebuild/default-flatpaks/system/install).
+# Specify the ID of `system flatpaks` in the list you want to install.
+# Duplicated entries won't be used if located in maintainer's configuration.
+# Flatpak runtimes are not supported.
+# Here's an example on how to edit this file (ignore # symbol):
+#
+# org.gnome.Maps
+# org.gnome.TextEditor
+# org.telegram.desktop

--- a/modules/default-flatpaks/user-config/system/remove
+++ b/modules/default-flatpaks/user-config/system/remove
@@ -1,0 +1,10 @@
+# This file utilizes user's configuration for `system flatpaks removal` used by `default-flatpaks` BlueBuild module.
+# If this file is not modified, maintainer's configuration will be used instead (located in /usr/share/bluebuild/default-flatpaks/system/remove).
+# Specify the ID of `system flatpaks` in the list you want to remove.
+# Duplicated entries won't be used if located in maintainer's configuration.
+# Flatpak runtimes are not supported.
+# Here's an example on how to edit this file (ignore # symbol):
+#
+# org.gnome.Maps
+# org.gnome.TextEditor
+# org.telegram.desktop

--- a/modules/default-flatpaks/user-config/system/remove
+++ b/modules/default-flatpaks/user-config/system/remove
@@ -1,7 +1,7 @@
-# This file utilizes user's configuration for `system flatpaks removal` used by `default-flatpaks` BlueBuild module.
-# If this file is not modified, maintainer's configuration will be used instead (located in /usr/share/bluebuild/default-flatpaks/system/remove).
-# Specify the ID of `system flatpaks` in the list you want to remove.
-# Duplicated entries won't be used if located in maintainer's configuration.
+# This file can be used by the users for configuration for `system flatpaks removal` used by the `default-flatpaks` BlueBuild module.
+# If this file is not modified, the image's default configuration will be used instead (located in /usr/share/bluebuild/default-flatpaks/system/remove).
+# This list uses the Flatpak ID format, with one ID per line.
+# Duplicated entries won't be used if located the image's default configuration.
 # Flatpak runtimes are not supported.
 # Here's an example on how to edit this file (ignore # symbol):
 #

--- a/modules/default-flatpaks/user-config/user/install
+++ b/modules/default-flatpaks/user-config/user/install
@@ -1,7 +1,7 @@
-# This file utilizes user's configuration for `user flatpaks install` used by `default-flatpaks` BlueBuild module.
-# If this file is not modified, maintainer's configuration will be used instead (located in /usr/share/bluebuild/default-flatpaks/user/install).
-# Specify the ID of `user flatpaks` in the list you want to install.
-# Duplicated entries won't be used if located in maintainer's configuration.
+# This file can be used by the users for configuration of configuration for `user flatpaks install` used by the `default-flatpaks` BlueBuild module.
+# If this file is not modified, the image's default configuration will be used instead (located in /usr/share/bluebuild/default-flatpaks/user/install).
+# This list uses the Flatpak ID format, with one ID per line.
+# Duplicated entries won't be used if located in the image's default configuration.
 # Flatpak runtimes are not supported.
 # Here's an example on how to edit this file (ignore # symbol):
 #

--- a/modules/default-flatpaks/user-config/user/install
+++ b/modules/default-flatpaks/user-config/user/install
@@ -1,0 +1,10 @@
+# This file utilizes user's configuration for `user flatpaks install` used by `default-flatpaks` BlueBuild module.
+# If this file is not modified, maintainer's configuration will be used instead (located in /usr/share/bluebuild/default-flatpaks/user/install).
+# Specify the ID of `user flatpaks` in the list you want to install.
+# Duplicated entries won't be used if located in maintainer's configuration.
+# Flatpak runtimes are not supported.
+# Here's an example on how to edit this file (ignore # symbol):
+#
+# org.gnome.Maps
+# org.gnome.TextEditor
+# org.telegram.desktop

--- a/modules/default-flatpaks/user-config/user/remove
+++ b/modules/default-flatpaks/user-config/user/remove
@@ -1,0 +1,10 @@
+# This file utilizes user's configuration for `user flatpaks removal` used by `default-flatpaks` BlueBuild module.
+# If this file is not modified, maintainer's configuration will be used instead (located in /usr/share/bluebuild/default-flatpaks/user/remove).
+# Specify the ID of `user flatpaks` in the list you want to remove.
+# Duplicated entries won't be used if located in maintainer's configuration.
+# Flatpak runtimes are not supported.
+# Here's an example on how to edit this file (ignore # symbol):
+#
+# org.gnome.Maps
+# org.gnome.TextEditor
+# org.telegram.desktop

--- a/modules/default-flatpaks/user-config/user/remove
+++ b/modules/default-flatpaks/user-config/user/remove
@@ -1,7 +1,7 @@
-# This file utilizes user's configuration for `user flatpaks removal` used by `default-flatpaks` BlueBuild module.
-# If this file is not modified, maintainer's configuration will be used instead (located in /usr/share/bluebuild/default-flatpaks/user/remove).
-# Specify the ID of `user flatpaks` in the list you want to remove.
-# Duplicated entries won't be used if located in maintainer's configuration.
+# This file can be used by the users for configuration of `user flatpaks removal` used by the `default-flatpaks` BlueBuild module.
+# If this file is not modified, the image's default configuration will be used instead (located in /usr/share/bluebuild/default-flatpaks/user/remove).
+# This list uses the Flatpak ID format, with one ID per line.
+# Duplicated entries won't be used if located in the image's default configuration.
 # Flatpak runtimes are not supported.
 # Here's an example on how to edit this file (ignore # symbol):
 #

--- a/modules/default-flatpaks/user-flatpak-setup
+++ b/modules/default-flatpaks/user-flatpak-setup
@@ -46,8 +46,13 @@ REMOVE_LIST_FILE="/usr/share/bluebuild/default-flatpaks/user/remove"
 USER_INSTALL_LIST_FILE="/etc/bluebuild/default-flatpaks/user/install"
 USER_REMOVE_LIST_FILE="/etc/bluebuild/default-flatpaks/user/remove"
 # Ignore words starting with # symbol, whitelines & duplicate entries for flatpak list files.
-COMBINED_INSTALL_LIST=$(cat "$INSTALL_LIST_FILE" "$USER_INSTALL_LIST_FILE" | grep -v -E '^#|^$' | awk '!seen[$0]++')
-COMBINED_REMOVE_LIST=$(cat "$REMOVE_LIST_FILE" "$USER_REMOVE_LIST_FILE" | grep -v -E '^#|^$' | awk '!seen[$0]++')
+COMBINED_INSTALL_PRELIST=$(cat "$INSTALL_LIST_FILE" "$USER_INSTALL_LIST_FILE" | grep -v -E '^#|^$' | awk '!seen[$0]++')
+COMBINED_REMOVE_PRELIST=$(cat "$REMOVE_LIST_FILE" "$USER_REMOVE_LIST_FILE" | grep -v -E '^#|^$' | awk '!seen[$0]++')
+# Avoid install/remove loop scenario when you have duplicate entry in install & remove list at the same time
+# (from user's side, as maintainer's-side will be handled by the module itself in the future)
+# cat doesn't work, because this is not a file
+COMBINED_INSTALL_LIST=$(sort -u <(cat "$COMBINED_INSTALL_PRELIST" "$USER_REMOVE_LIST_FILE")) #(exclude duplicates from "$USER_REMOVE_LIST_FILE")
+COMBINED_REMOVE_LIST=$(sort -u <(cat "$COMBINED_REMOVE_PRELIST" "$USER_INSTALL_LIST_FILE")) #(exclude duplicates from "$USER_INSTALL_LIST_FILE")
 
 # Install flatpaks in list
 if [[ -f $INSTALL_LIST_FILE ]] || [[ -f $USER_INSTALL_LIST_FILE ]]; then

--- a/modules/default-flatpaks/user-flatpak-setup
+++ b/modules/default-flatpaks/user-flatpak-setup
@@ -45,7 +45,7 @@ INSTALL_LIST_FILE="/usr/share/bluebuild/default-flatpaks/user/install"
 REMOVE_LIST_FILE="/usr/share/bluebuild/default-flatpaks/user/remove"
 USER_INSTALL_LIST_FILE="/etc/bluebuild/default-flatpaks/user/install"
 USER_REMOVE_LIST_FILE="/etc/bluebuild/default-flatpaks/user/remove"
-# This accounts for the scenario when user sets the same package in install list that is in maintainer's remove list & vice-versa
+# Prefer user's install + remove list over maintainer's, in case when same flatpak ID is present in maintainer's install list + user's remove list & vice-versa
 # Also ignores words starting with # symbol, whitelines & duplicate entries
 MAINTAINER_INSTALL_LIST=$(comm -23 <(sort "$INSTALL_LIST_FILE") <(sort "$USER_REMOVE_LIST_FILE") | grep -v -E '^#|^$' | awk '!seen[$0]++')
 MAINTAINER_REMOVE_LIST=$(comm -23 <(sort "$REMOVE_LIST_FILE") <(sort "$USER_INSTALL_LIST_FILE") | grep -v -E '^#|^$' | awk '!seen[$0]++')

--- a/modules/default-flatpaks/user-flatpak-setup
+++ b/modules/default-flatpaks/user-flatpak-setup
@@ -50,7 +50,7 @@ USER_REMOVE_LIST_FILE="/etc/bluebuild/default-flatpaks/user/remove"
 MAINTAINER_INSTALL_LIST=$(comm -23 <(sort "$INSTALL_LIST_FILE") <(sort "$USER_REMOVE_LIST_FILE") | grep -v -E '^#|^$' | awk '!seen[$0]++')
 MAINTAINER_REMOVE_LIST=$(comm -23 <(sort "$REMOVE_LIST_FILE") <(sort "$USER_INSTALL_LIST_FILE") | grep -v -E '^#|^$' | awk '!seen[$0]++')
 # Combine maintainer & user list. Ignore words starting with # symbol, whitelines & duplicate entries
-COMBINED_INSTALL_LIST=$(cat <(echo "$MAINTAINER_INSTALL_LIST") "$USER_REMOVE_LIST_FILE" | grep -v -E '^#|^$' | awk '!seen[$0]++')
+COMBINED_INSTALL_LIST=$(cat <(echo "$MAINTAINER_INSTALL_LIST") "$USER_INSTALL_LIST_FILE" | grep -v -E '^#|^$' | awk '!seen[$0]++')
 COMBINED_REMOVE_LIST=$(cat <(echo "$MAINTAINER_REMOVE_LIST") "$USER_REMOVE_LIST_FILE" | grep -v -E '^#|^$' | awk '!seen[$0]++')
 
 # Install flatpaks in list

--- a/modules/default-flatpaks/user-flatpak-setup
+++ b/modules/default-flatpaks/user-flatpak-setup
@@ -45,15 +45,16 @@ INSTALL_LIST_FILE="/usr/share/bluebuild/default-flatpaks/user/install"
 REMOVE_LIST_FILE="/usr/share/bluebuild/default-flatpaks/user/remove"
 USER_INSTALL_LIST_FILE="/etc/bluebuild/default-flatpaks/user/install"
 USER_REMOVE_LIST_FILE="/etc/bluebuild/default-flatpaks/user/remove"
+# This accounts for the scenario when user sets the same package in install list that is in maintainer's remove list & vice-versa
+# Also ignores words starting with # symbol, whitelines & duplicate entries
+#
+##################### Work in progress! ############################
+#USER_INSTALL_LIST=$(grep -vf - "$USER_INSTALL_LIST_FILE" "$INSTALL_LIST_FILE" | grep -v -E '^#|^$' | awk '!seen[$0]++')
+#USER_REMOVE_LIST=$(grep -vf - "$USER_REMOVE_LIST_FILE" "$INSTALL_LIST_FILE" | grep -v -E '^#|^$' | awk '!seen[$0]++')
+#
 # Combine maintainer & user list. Ignore words starting with # symbol, whitelines & duplicate entries
-# This applies for: maintainer-install/user-install, maintainer-remove/user-remove duplicates.
-COMBINED_INSTALL_PRELIST=$(cat "$INSTALL_LIST_FILE" "$USER_INSTALL_LIST_FILE" | grep -v -E '^#|^$' | awk '!seen[$0]++')
-COMBINED_REMOVE_PRELIST=$(cat "$REMOVE_LIST_FILE" "$USER_REMOVE_LIST_FILE" | grep -v -E '^#|^$' | awk '!seen[$0]++')
-# Avoid install/remove loop scenario when you have duplicate entry in install + remove list at the same time (different from above)
-INSTALL_REMOVE_DIFF=$(comm -12 <(sort <(printf "%s\n" "${COMBINED_INSTALL_PRELIST[@]}")) <(sort <(printf "%s\n" "${COMBINED_REMOVE_PRELIST[@]}")))
-# Exclude install + remove duplicates from combined install & remove list
-COMBINED_INSTALL_LIST=$(awk 'NR==FNR{a[$0];next} !($0 in a)' <(echo "$INSTALL_REMOVE_DIFF") <(echo "$COMBINED_INSTALL_PRELIST"))
-COMBINED_REMOVE_LIST=$(awk 'NR==FNR{a[$0];next} !($0 in a)' <(echo "$INSTALL_REMOVE_DIFF") <(echo "$COMBINED_REMOVE_PRELIST"))
+COMBINED_INSTALL_LIST=$(cat "$INSTALL_LIST_FILE" | echo "$USER_INSTALL_LIST" | grep -v -E '^#|^$' | awk '!seen[$0]++')
+COMBINED_REMOVE_LIST=$(cat "$REMOVE_LIST_FILE" | echo "$USER_REMOVE_LIST" | grep -v -E '^#|^$' | awk '!seen[$0]++')
 
 # Install flatpaks in list
 if [[ -f $INSTALL_LIST_FILE ]] || [[ -f $USER_INSTALL_LIST_FILE ]]; then

--- a/modules/default-flatpaks/user-flatpak-setup
+++ b/modules/default-flatpaks/user-flatpak-setup
@@ -47,14 +47,11 @@ USER_INSTALL_LIST_FILE="/etc/bluebuild/default-flatpaks/user/install"
 USER_REMOVE_LIST_FILE="/etc/bluebuild/default-flatpaks/user/remove"
 # This accounts for the scenario when user sets the same package in install list that is in maintainer's remove list & vice-versa
 # Also ignores words starting with # symbol, whitelines & duplicate entries
-#
-##################### Work in progress! ############################
-#USER_INSTALL_LIST=$(grep -vf - "$USER_INSTALL_LIST_FILE" "$INSTALL_LIST_FILE" | grep -v -E '^#|^$' | awk '!seen[$0]++')
-#USER_REMOVE_LIST=$(grep -vf - "$USER_REMOVE_LIST_FILE" "$INSTALL_LIST_FILE" | grep -v -E '^#|^$' | awk '!seen[$0]++')
-#
+MAINTAINER_INSTALL_LIST=$(comm -23 <(sort "$INSTALL_LIST_FILE") <(sort "$USER_REMOVE_LIST_FILE") | grep -v -E '^#|^$' | awk '!seen[$0]++')
+MAINTAINER_REMOVE_LIST=$(comm -23 <(sort "$REMOVE_LIST_FILE") <(sort "$USER_INSTALL_LIST_FILE") | grep -v -E '^#|^$' | awk '!seen[$0]++')
 # Combine maintainer & user list. Ignore words starting with # symbol, whitelines & duplicate entries
-COMBINED_INSTALL_LIST=$(cat "$INSTALL_LIST_FILE" | echo "$USER_INSTALL_LIST" | grep -v -E '^#|^$' | awk '!seen[$0]++')
-COMBINED_REMOVE_LIST=$(cat "$REMOVE_LIST_FILE" | echo "$USER_REMOVE_LIST" | grep -v -E '^#|^$' | awk '!seen[$0]++')
+COMBINED_INSTALL_LIST=$(cat <(echo "$MAINTAINER_INSTALL_LIST") "$USER_REMOVE_LIST_FILE" | grep -v -E '^#|^$' | awk '!seen[$0]++')
+COMBINED_REMOVE_LIST=$(cat <(echo "$MAINTAINER_REMOVE_LIST") "$USER_REMOVE_LIST_FILE" | grep -v -E '^#|^$' | awk '!seen[$0]++')
 
 # Install flatpaks in list
 if [[ -f $INSTALL_LIST_FILE ]] || [[ -f $USER_INSTALL_LIST_FILE ]]; then

--- a/modules/default-flatpaks/user-flatpak-setup
+++ b/modules/default-flatpaks/user-flatpak-setup
@@ -50,9 +50,11 @@ COMBINED_INSTALL_PRELIST=$(cat "$INSTALL_LIST_FILE" "$USER_INSTALL_LIST_FILE" | 
 COMBINED_REMOVE_PRELIST=$(cat "$REMOVE_LIST_FILE" "$USER_REMOVE_LIST_FILE" | grep -v -E '^#|^$' | awk '!seen[$0]++')
 # Avoid install/remove loop scenario when you have duplicate entry in install & remove list at the same time
 # (from user's side, as maintainer's-side will be handled by the module itself in the future)
-# cat doesn't work, because this is not a file
-COMBINED_INSTALL_LIST=$(sort -u <(cat "$COMBINED_INSTALL_PRELIST" "$COMBINED_REMOVE_PRELIST")) #(exclude duplicates from "$COMBINED_REMOVE_PRELIST")
-COMBINED_REMOVE_LIST=$(sort -u <(cat "$COMBINED_REMOVE_PRELIST" "$COMBINED_INSTALL_PRELIST")) #(exclude duplicates from "$COMBINED_INSTALL_PRELIST")
+############################# Work in progress, for section below ####################################
+# It's needed to exclude duplicates from "$COMBINED_REMOVE_PRELIST", which match "$COMBINED_INSTALL_PRELIST"
+COMBINED_INSTALL_LIST=$(sort -u <(cat "$COMBINED_INSTALL_PRELIST" "$COMBINED_REMOVE_PRELIST"))
+# It's needed to exclude duplicates from "$COMBINED_INSTALL_PRELIST", which match "$COMBINED_REMOVE_PRELIST"
+COMBINED_REMOVE_LIST=$(sort -u <(cat "$COMBINED_REMOVE_PRELIST" "$COMBINED_INSTALL_PRELIST"))
 
 # Install flatpaks in list
 if [[ -f $INSTALL_LIST_FILE ]] || [[ -f $USER_INSTALL_LIST_FILE ]]; then

--- a/modules/default-flatpaks/user-flatpak-setup
+++ b/modules/default-flatpaks/user-flatpak-setup
@@ -51,8 +51,8 @@ COMBINED_REMOVE_PRELIST=$(cat "$REMOVE_LIST_FILE" "$USER_REMOVE_LIST_FILE" | gre
 # Avoid install/remove loop scenario when you have duplicate entry in install & remove list at the same time
 # (from user's side, as maintainer's-side will be handled by the module itself in the future)
 # cat doesn't work, because this is not a file
-COMBINED_INSTALL_LIST=$(sort -u <(cat "$COMBINED_INSTALL_PRELIST" "$USER_REMOVE_LIST_FILE")) #(exclude duplicates from "$USER_REMOVE_LIST_FILE")
-COMBINED_REMOVE_LIST=$(sort -u <(cat "$COMBINED_REMOVE_PRELIST" "$USER_INSTALL_LIST_FILE")) #(exclude duplicates from "$USER_INSTALL_LIST_FILE")
+COMBINED_INSTALL_LIST=$(sort -u <(cat "$COMBINED_INSTALL_PRELIST" "$COMBINED_REMOVE_PRELIST")) #(exclude duplicates from "$COMBINED_REMOVE_PRELIST")
+COMBINED_REMOVE_LIST=$(sort -u <(cat "$COMBINED_REMOVE_PRELIST" "$COMBINED_INSTALL_PRELIST")) #(exclude duplicates from "$COMBINED_INSTALL_PRELIST")
 
 # Install flatpaks in list
 if [[ -f $INSTALL_LIST_FILE ]] || [[ -f $USER_INSTALL_LIST_FILE ]]; then

--- a/modules/default-flatpaks/user-flatpak-setup
+++ b/modules/default-flatpaks/user-flatpak-setup
@@ -6,7 +6,7 @@ if grep -qz 'fedora' <<< "$(flatpak remotes)"; then
   flatpak remote-delete --user fedora-testing --force
 fi
 
-REPO_INFO="/etc/bluebuild/default-flatpaks/user/repo-info.yml"
+REPO_INFO="/usr/share/bluebuild/default-flatpaks/user/repo-info.yml"
 REPO_URL=$(yq '.repo-url' $REPO_INFO)
 REPO_NAME=$(yq '.repo-name' $REPO_INFO)
 REPO_TITLE=$(yq '.repo-title' $REPO_INFO)
@@ -24,21 +24,37 @@ if [[ ! $REPO_TITLE == "null" ]]; then
 fi
 
 # Notifications config
-NOTIFICATIONS=$(cat /etc/bluebuild/default-flatpaks/notifications)
+NOTIFICATIONS_FILE="/usr/share/bluebuild/default-flatpaks/notifications"
+USER_NOTIFICATIONS_FILE="/etc/bluebuild/default-flatpaks/notifications"
+# Ignore words starting with # symbol, whitelines & duplicate entries for notifications config
+MAINTAINER_NOTIFICATIONS=$(cat "$NOTIFICATIONS_FILE" | grep -v -E '^#|^$' | awk '!seen[$0]++')
+USER_NOTIFICATIONS=$(cat "$USER_NOTIFICATIONS_FILE" | grep -v -E '^#|^$' | awk '!seen[$0]++')
+
+# If user modified notifications config, utilize user's configuration, otherwise maintainer's
+if [[ -n $USER_NOTIFICATIONS ]]; then
+  NOTIFICATIONS="$USER_NOTIFICATIONS"
+else
+  NOTIFICATIONS="$MAINTAINER_NOTIFICATIONS"
+fi  
 
 # Installed flatpaks
 FLATPAK_LIST=$(flatpak list --user --columns=application)
 
 # Flatpak list files
-INSTALL_LIST_FILE="/etc/bluebuild/default-flatpaks/user/install"
-REMOVE_LIST_FILE="/etc/bluebuild/default-flatpaks/user/remove"
+INSTALL_LIST_FILE="/usr/share/bluebuild/default-flatpaks/user/install"
+REMOVE_LIST_FILE="/usr/share/bluebuild/default-flatpaks/user/remove"
+USER_INSTALL_LIST_FILE="/etc/bluebuild/default-flatpaks/user/install"
+USER_REMOVE_LIST_FILE="/etc/bluebuild/default-flatpaks/user/remove"
+# Ignore words starting with # symbol, whitelines & duplicate entries for flatpak list files.
+COMBINED_INSTALL_LIST=$(cat "$INSTALL_LIST_FILE" "$USER_INSTALL_LIST_FILE" | grep -v -E '^#|^$' | awk '!seen[$0]++')
+COMBINED_REMOVE_LIST=$(cat "$REMOVE_LIST_FILE" "$USER_REMOVE_LIST_FILE" | grep -v -E '^#|^$' | awk '!seen[$0]++')
 
 # Install flatpaks in list
-if [[ -f $INSTALL_LIST_FILE ]]; then
+if [[ -f $INSTALL_LIST_FILE ]] || [[ -f $USER_INSTALL_LIST_FILE ]]; then
   if [[ -n $FLATPAK_LIST ]]; then
-    INSTALL_LIST=$(echo "$FLATPAK_LIST" | grep -vf - "$INSTALL_LIST_FILE")
+    INSTALL_LIST=$(comm -23 <(echo "$COMBINED_INSTALL_LIST" | sort) <(echo "$FLATPAK_LIST" | sort))
   else
-    INSTALL_LIST=$(cat $INSTALL_LIST_FILE)
+    INSTALL_LIST="$COMBINED_INSTALL_LIST"
   fi
   if [[ -n $INSTALL_LIST ]] && [[ ! $NOTIFICATIONS == "true" ]]; then
     flatpak install --user --noninteractive "$REPO_NAME" ${INSTALL_LIST[@]}
@@ -50,8 +66,8 @@ if [[ -f $INSTALL_LIST_FILE ]]; then
 fi
 
 # Remove flatpaks in list
-if [[ -f $REMOVE_LIST_FILE ]]; then
-  REMOVE_LIST=$(echo "$FLATPAK_LIST" | grep -o -f - "$REMOVE_LIST_FILE")
+if [[ -f $REMOVE_LIST_FILE ]] || [[ -f $USER_REMOVE_LIST_FILE ]]; then
+  REMOVE_LIST=$(comm -12 <(echo "$COMBINED_REMOVE_LIST" | sort) <(echo "$FLATPAK_LIST" | sort))
   if [[ -n $REMOVE_LIST ]] && [[ ! $NOTIFICATIONS == "true" ]]; then
     flatpak uninstall --user --noninteractive ${REMOVE_LIST[@]}
   elif [[ -n $REMOVE_LIST ]] && [[ $NOTIFICATIONS == "true" ]]; then

--- a/modules/default-flatpaks/user-flatpak-setup
+++ b/modules/default-flatpaks/user-flatpak-setup
@@ -6,7 +6,7 @@ if grep -qz 'fedora' <<< "$(flatpak remotes)"; then
   flatpak remote-delete --user fedora-testing --force
 fi
 
-REPO_INFO="/etc/flatpak/user/repo-info.yml"
+REPO_INFO="/etc/bluebuild/default-flatpaks/user/repo-info.yml"
 REPO_URL=$(yq '.repo-url' $REPO_INFO)
 REPO_NAME=$(yq '.repo-name' $REPO_INFO)
 REPO_TITLE=$(yq '.repo-title' $REPO_INFO)
@@ -24,14 +24,14 @@ if [[ ! $REPO_TITLE == "null" ]]; then
 fi
 
 # Notifications config
-NOTIFICATIONS=$(cat /etc/flatpak/notifications)
+NOTIFICATIONS=$(cat /etc/bluebuild/default-flatpaks/notifications)
 
 # Installed flatpaks
 FLATPAK_LIST=$(flatpak list --user --columns=application)
 
 # Flatpak list files
-INSTALL_LIST_FILE="/etc/flatpak/user/install"
-REMOVE_LIST_FILE="/etc/flatpak/user/remove"
+INSTALL_LIST_FILE="/etc/bluebuild/default-flatpaks/user/install"
+REMOVE_LIST_FILE="/etc/bluebuild/default-flatpaks/user/remove"
 
 # Install flatpaks in list
 if [[ -f $INSTALL_LIST_FILE ]]; then

--- a/modules/default-flatpaks/user-flatpak-setup
+++ b/modules/default-flatpaks/user-flatpak-setup
@@ -45,16 +45,15 @@ INSTALL_LIST_FILE="/usr/share/bluebuild/default-flatpaks/user/install"
 REMOVE_LIST_FILE="/usr/share/bluebuild/default-flatpaks/user/remove"
 USER_INSTALL_LIST_FILE="/etc/bluebuild/default-flatpaks/user/install"
 USER_REMOVE_LIST_FILE="/etc/bluebuild/default-flatpaks/user/remove"
-# Ignore words starting with # symbol, whitelines & duplicate entries for flatpak list files.
+# Combine maintainer & user list. Ignore words starting with # symbol, whitelines & duplicate entries
+# This applies for: maintainer-install/user-install, maintainer-remove/user-remove duplicates.
 COMBINED_INSTALL_PRELIST=$(cat "$INSTALL_LIST_FILE" "$USER_INSTALL_LIST_FILE" | grep -v -E '^#|^$' | awk '!seen[$0]++')
 COMBINED_REMOVE_PRELIST=$(cat "$REMOVE_LIST_FILE" "$USER_REMOVE_LIST_FILE" | grep -v -E '^#|^$' | awk '!seen[$0]++')
-# Avoid install/remove loop scenario when you have duplicate entry in install & remove list at the same time
-# (from user's side, as maintainer's-side will be handled by the module itself in the future)
-############################# Work in progress, for section below ####################################
-# It's needed to exclude duplicates from "$COMBINED_REMOVE_PRELIST", which match "$COMBINED_INSTALL_PRELIST"
-COMBINED_INSTALL_LIST=$(sort -u <(cat "$COMBINED_INSTALL_PRELIST" "$COMBINED_REMOVE_PRELIST"))
-# It's needed to exclude duplicates from "$COMBINED_INSTALL_PRELIST", which match "$COMBINED_REMOVE_PRELIST"
-COMBINED_REMOVE_LIST=$(sort -u <(cat "$COMBINED_REMOVE_PRELIST" "$COMBINED_INSTALL_PRELIST"))
+# Avoid install/remove loop scenario when you have duplicate entry in install + remove list at the same time (different from above)
+INSTALL_REMOVE_DIFF=$(comm -12 <(sort <(printf "%s\n" "${COMBINED_INSTALL_PRELIST[@]}")) <(sort <(printf "%s\n" "${COMBINED_REMOVE_PRELIST[@]}")))
+# Exclude install + remove duplicates from combined install & remove list
+COMBINED_INSTALL_LIST=$(awk 'NR==FNR{a[$0];next} !($0 in a)' <(echo "$INSTALL_REMOVE_DIFF") <(echo "$COMBINED_INSTALL_PRELIST"))
+COMBINED_REMOVE_LIST=$(awk 'NR==FNR{a[$0];next} !($0 in a)' <(echo "$INSTALL_REMOVE_DIFF") <(echo "$COMBINED_REMOVE_PRELIST"))
 
 # Install flatpaks in list
 if [[ -f $INSTALL_LIST_FILE ]] || [[ -f $USER_INSTALL_LIST_FILE ]]; then


### PR DESCRIPTION
Use

`/usr/etc/bluebuild/default-flatpaks`

location instead of

`/usr/etc/flatpaks`

If possible, we should ideally use this location for system modifications:

`/usr/share/bluebuild/default-flatpaks`

While having user modifications in:

`/usr/etc/bluebuild/default-flatpaks`

But it needs to be figured out how the logic will work for separating system & user modifications this way.

I used this logic in unofficial `initramfs-setup` module & it works well, by merging both system & user files into 1 output.

However, this method can create duplicates if user specified it in it's modification, so I mentioned that user should look if the system entry has modifications they need. Perhaps, array diff can be done, which would circumvent this.