### PR TITLE
fix: copy public key to the right location

### DIFF
--- a/modules/signing/signing.sh
+++ b/modules/signing/signing.sh
@@ -30,7 +30,7 @@ if ! [ -f "/usr/share/ublue-os/image-info.json" ]; then
 fi
 
 
-mv "/usr/share/ublue-os/cosign.pub" "$CONTAINER_DIR/$IMAGE_NAME".pub
+cp "/usr/share/ublue-os/cosign.pub" "/usr/etc/pki/containers/$IMAGE_NAME.pub"
 
 POLICY_FILE="$CONTAINER_DIR/policy.json"
 IMAGE_INFO="/usr/share/ublue-os/image-info.json"


### PR DESCRIPTION
the signing module isn't functional currently because the public key was not copied to the proper location