### PR TITLE
fix(signing): Use `-euo` pipefail instead of `-oue`

### DIFF
--- a/modules/signing/signing.sh
+++ b/modules/signing/signing.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # Tell build process to exit if there are any errors.
-set -eou pipefail
+set -euo pipefail
 
 CONTAINER_DIR="/usr/etc/containers"
 MODULE_DIRECTORY="${MODULE_DIRECTORY:-"/tmp/modules"}"

--- a/modules/signing/signing.sh
+++ b/modules/signing/signing.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # Tell build process to exit if there are any errors.
-set -oue pipefail
+set -eou pipefail
 
 CONTAINER_DIR="/usr/etc/containers"
 MODULE_DIRECTORY="${MODULE_DIRECTORY:-"/tmp/modules"}"


### PR DESCRIPTION
-euo is the proper ordering for pipefail, as outlined here: https://github.com/ublue-os/bling/pull/99