### PR TITLE
chore(default-flatpaks): Obtain flatpak list of apps without runtimes

### DIFF
--- a/modules/default-flatpaks/system-flatpak-setup
+++ b/modules/default-flatpaks/system-flatpak-setup
@@ -56,7 +56,7 @@ else
 fi  
 
 # Installed flatpaks
-FLATPAK_LIST=$(flatpak list --system --columns=application)
+FLATPAK_LIST=$(flatpak list --system --app --columns=application)
 
 # Flatpak list files
 INSTALL_LIST_FILE="/usr/share/bluebuild/default-flatpaks/system/install"

--- a/modules/default-flatpaks/user-flatpak-setup
+++ b/modules/default-flatpaks/user-flatpak-setup
@@ -38,7 +38,7 @@ else
 fi  
 
 # Installed flatpaks
-FLATPAK_LIST=$(flatpak list --user --columns=application)
+FLATPAK_LIST=$(flatpak list --user --app --columns=application)
 
 # Flatpak list files
 INSTALL_LIST_FILE="/usr/share/bluebuild/default-flatpaks/user/install"


### PR DESCRIPTION
Since runtimes are not supported in our module, we don't need them in a flatpak list inside binaries.