### PR TITLE
[1password] Remove 1Password-KeyringHelper

### DIFF
--- a/modules/bling/installers/1password.sh
+++ b/modules/bling/installers/1password.sh
@@ -79,17 +79,10 @@ chmod 4755 /usr/lib/1Password/chrome-sandbox
 # Normal user group GIDs on Fedora are sequential starting
 # at 1000, so let's skip ahead and set to something higher.
 
-HELPER_PATH="/usr/lib/1Password/1Password-KeyringHelper"
-BROWSER_SUPPORT_PATH="/usr/lib/1Password/1Password-BrowserSupport"
-
-# Setup the Core App Integration helper binaries with the correct permissions and group
-chgrp "${GID_ONEPASSWORD}" "${HELPER_PATH}"
-# The binary requires setuid so it may interact with the Kernel keyring facilities
-chmod u+s "${HELPER_PATH}"
-chmod g+s "${HELPER_PATH}"
-
 # BrowserSupport binary needs setgid. This gives no extra permissions to the binary.
 # It only hardens it against environmental tampering.
+BROWSER_SUPPORT_PATH="/usr/lib/1Password/1Password-BrowserSupport"
+
 chgrp "${GID_ONEPASSWORD}" "${BROWSER_SUPPORT_PATH}"
 chmod g+s "${BROWSER_SUPPORT_PATH}"
 


### PR DESCRIPTION
Hi there! I've been giving ublue (specifically Bazzite) a shot and wanted to submit this PR :)

The `1Password-KeyringHelper` binary was removed in 1password 8.10.28, which came out today. This can be inspected through `rpm -ql` etc (Still setting up my ublue system and can't get a paste easily off of it, but on my Ubuntu system this is the output of `dpkg -L 1password` after the update to 8.10.28: https://gist.github.com/sunshowers/2b0450daae0dd6eea56e5b381d9b7693)

I've managed to deploy this script onto my ublue-derived system, and 1password system auth and browser integration works great!