### PR TITLE
feat: remove image-info handling from signing module

### DIFF
--- a/modules/signing/image-info.json
+++ b/modules/signing/image-info.json
@@ -1,6 +1,0 @@
-{
-    "image-ref": "IMAGE_REF",
-    "image-tag": "latest",
-    "image-vendor": "bluebuild",
-    "fedora-version": "FEDORA_MAJOR_VERSION"
-}

--- a/modules/signing/signing.sh
+++ b/modules/signing/signing.sh
@@ -42,7 +42,5 @@ yq -i -o=j '.transports.docker |=
     }
 + .' "$POLICY_FILE"
 
-IMAGE_REF="ostree-image-signed:docker://$IMAGE_REGISTRY/$IMAGE_NAME"
-
 mv "$MODULE_DIRECTORY/signing/registry-config.yaml" "$CONTAINER_DIR/registries.d/$IMAGE_NAME.yaml"
 sed -i "s ghcr.io/IMAGENAME $IMAGE_REGISTRY g" "$CONTAINER_DIR/registries.d/$IMAGE_NAME.yaml"

--- a/modules/signing/signing.sh
+++ b/modules/signing/signing.sh
@@ -25,15 +25,9 @@ if ! [ -f "$CONTAINER_DIR/policy.json" ]; then
     cp "$MODULE_DIRECTORY/signing/policy.json" "$CONTAINER_DIR/policy.json"
 fi
 
-if ! [ -f "/usr/share/ublue-os/image-info.json" ]; then
-    cp "$MODULE_DIRECTORY/signing/image-info.json" "/usr/share/ublue-os/image-info.json"
-fi
-
-
 cp "/usr/share/ublue-os/cosign.pub" "/usr/etc/pki/containers/$IMAGE_NAME.pub"
 
 POLICY_FILE="$CONTAINER_DIR/policy.json"
-IMAGE_INFO="/usr/share/ublue-os/image-info.json"
 
 yq -i -o=j '.transports.docker |=
     {"'"$IMAGE_REGISTRY"'/'"$IMAGE_NAME"'": [
@@ -49,8 +43,6 @@ yq -i -o=j '.transports.docker |=
 + .' "$POLICY_FILE"
 
 IMAGE_REF="ostree-image-signed:docker://$IMAGE_REGISTRY/$IMAGE_NAME"
-# Sets image-info.json used by ublue-update for auto-rebase workaround. Used by both bazzite and bluefin
-yq -i -o=j '.image-ref="'"$IMAGE_REF"'" | .fedora-version="'"$OS_VERSION"'"' "$IMAGE_INFO"
 
 mv "$MODULE_DIRECTORY/signing/registry-config.yaml" "$CONTAINER_DIR/registries.d/$IMAGE_NAME.yaml"
 sed -i "s ghcr.io/IMAGENAME $IMAGE_REGISTRY g" "$CONTAINER_DIR/registries.d/$IMAGE_NAME.yaml"


### PR DESCRIPTION
the `/usr/share/ublue-os/image-info.json` file shouldn't be touched when handling image signing, `ublue-update` no longer handles `image-ref` or automatically rebases the image.