### PR TITLE
docs: Improve documentation of relocatable schemas

### DIFF
--- a/modules/bling/README.md
+++ b/modules/bling/README.md
@@ -25,6 +25,6 @@ If you have configured the repository in the `$HOME/.config/flatpaksync/env` fil
 
 ### `dconf-update-service`
 
-The `dconf-update-service` submodule will automatically update changes you make to dconf. For an example of a dconf keyfile, see the [dconf custom defaults documentation](https://help.gnome.org/admin/system-admin-guide/stable/dconf-custom-defaults.html.en).
+The `dconf-update-service` submodule creates a systemd unit to automatically update changes you make to [dconf](https://wiki.gnome.org/Projects/dconf) in your custom image. For an example of a dconf keyfile, see the [dconf custom defaults documentation](https://help.gnome.org/admin/system-admin-guide/stable/dconf-custom-defaults.html.en).
 
 **Unlike the `gschema-overrides` module, dconf keyfiles are not checked at compile time**

--- a/modules/bling/README.md
+++ b/modules/bling/README.md
@@ -10,7 +10,7 @@ The bling to pull in is declared under `install:`, and the code for installing t
 
 The `flatpaksync` submodule can be used to synchronize a list of user Flatpaks with a git repository.
 
-Once the submodule is activated, you should create the file `$HOME/.config/flatpaksync/env` that sets the `GIT_REPO`  variable to the git URL of your repository. This repository can be empty, or a previous flatpaksync installation. The repository is automatically cloned into `/tmp/sync` for the synchronization. 
+Once the submodule is activated, you should create the file `$HOME/.config/flatpaksync/env` that sets the `GIT_REPO`  variable to the git URL of your repository. This repository can be empty, or a previous flatpaksync installation. The repository is automatically cloned into `/tmp/sync` for the synchronization.
 
 ```bash
 # ~/.config/flatpaksync/env
@@ -22,3 +22,9 @@ To initialize your Flatpaks from flatpaksync, simply run the `flatpakcheckout` c
 **It is important to note that this submodule will NOT enable Flathub. If your applications come from there, you will need to enable Flathub before running it.**
 
 If you have configured the repository in the `$HOME/.config/flatpaksync/env` file but already have the Flatpaks installed, simply create the `$HOME/.config/flatpaks.user.installed` file to inform the script that the installation is done and start the synchronization.
+
+### `dconf-update-service`
+
+The `dconf-update-service` submodule will automatically update changes you make to dconf. For an example of a dconf keyfile, see the [dconf custom defaults documentation](https://help.gnome.org/admin/system-admin-guide/stable/dconf-custom-defaults.html.en).
+
+**Unlike the `gschema-overrides` module, dconf keyfiles are not checked at compile time**

--- a/modules/gschema-overrides/README.md
+++ b/modules/gschema-overrides/README.md
@@ -65,22 +65,21 @@ tap-to-click=true
   
   `gsettings list-recursively`
   
-  You should use this command everytime when you want to apply some setting override,   
+  You should use this command everytime when you want to apply some setting override,
   to ensure that it's listed as available.
 
-**Gschema.override files don't support relocatable schemas & locking settings.**   
-For that functionality, you should use `dconf-update-service` module.
+**Gschema.override files don't support relocatable schemas & locking settings.**
 
-Relocatable schemas are rare, so most users won't run into this scenario.
+For that functionality, you should use the `bling` module with the `dconf-update-service` submodule.
+
+- To gather a list of relocatable schemas, use this command:
+
+  `gsettings list-relocatable-schemas`.
 
 ### Example of relocatable schemas
-gsettings format:
 ```
-[org.gnome.desktop.app-folders.folder:/org/gnome/desktop/app-folders/folders/Utilities/]
-[org.gnome.settings-daemon.plugins.media-keys.custom-keybinding:/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom0/]
-```
-dconf format:
-```
-[org/gnome/desktop/app-folders/folders/Utilities]
 [org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom0]
+binding='<Shift><Alt><Super>s'
+command='systemctl suspend'
+name='Suspend'
 ```

--- a/modules/gschema-overrides/README.md
+++ b/modules/gschema-overrides/README.md
@@ -70,7 +70,7 @@ tap-to-click=true
 
 **Gschema.override files don't support relocatable schemas & locking settings.**
 
-For that functionality, you should use the `bling` module with the `dconf-update-service` submodule.
+To add overrides for schemas not supported by gschema overrides, you can use the `dconf-update-service` from the `bling` module.
 
 - To gather a list of relocatable schemas, use this command:
 


### PR DESCRIPTION
Included more information on relocatable schemas and a link to the official GNOME dconf customization guide.   