### PR TITLE
feat: `gnome-extensions` module

### DIFF
--- a/modules/gnome-extensions/README.md
+++ b/modules/gnome-extensions/README.md
@@ -4,8 +4,8 @@ The `gnome-extensions` module can be used to install Gnome extensions inside sys
 
 This module is universally compatible with all distributions which ship Gnome, as it's not tied to specific distribution packaging format for installing extensions.  
 
-Every Gnome extension is compatible for installation.  
-Only rare intervention that might be needed is for extensions which require some additional system dependencies, like Pano. 
+Almost every Gnome extension is compatible for installation.  
+Only rare intervention that might be needed is for extensions which require some additional system dependencies, like Pano.   
 
 Thanks to https://extensions.gnome.org which provides end-releases of extensions as zips, it is very easy to maintain this module configuration.  
 The only maintenance is to bump the extension version when new Fedora/Gnome releases (around every 6 months).
@@ -25,3 +25,8 @@ or by simply downloading the zip file from https://extensions.gnome.org & than l
 
 You must assure that version of the extension is compatible with current Gnome version that your image is using.  
 You can easily see this information when downloading extension from https://extensions.gnome.org
+
+# Known Issues
+
+Some extensions like GSConnect may lack information in metadata.json, like lack of `uuid`, `settings-schema` or `shell-version` key,  
+which is necessary for the module to automatically install extension. Developer can easily fix this issue, so it's advised to inform him if this issue occured.

--- a/modules/gnome-extensions/README.md
+++ b/modules/gnome-extensions/README.md
@@ -19,9 +19,12 @@ What does this module do?
 
 # Usage
 
-To use this module, you need to input gettext-domain of the extension without @ symbol + the version of the extension in `.v%VERSION%` format.  
-You can see gettext-domain of the extension by looking at the extension repo inside metadata.json  
-or by simply downloading the zip file from https://extensions.gnome.org & than looking at the download URL part after `/extension-data/` & before `.v%VERSION%`.
+To use this module, you need to input gettext-domain of the extension without @ symbol + the version of the extension in `.v%VERSION%` format in module recipe.  
+But for some extensions, `.v%VERSION%` is parsed as the version of package in incremental numbering, instead of extension version in https://extensions.gnome.org URL.  
+So to be sure that you got the correct module input, follow the steps below.
 
-You must assure that version of the extension is compatible with current Gnome version that your image is using.  
-You can easily see this information when downloading extension from https://extensions.gnome.org
+How to gather correct module input:  
+1. Go to https://extensions.gnome.org
+2. Search for the extension that you want
+3. Select the matching Gnome shell version & extension version that you want to download
+4. When extension is downloaded, you get the info when you omit `.shell-extension.zip` suffix from the extension zip file-name

--- a/modules/gnome-extensions/README.md
+++ b/modules/gnome-extensions/README.md
@@ -7,7 +7,7 @@ This module is universally compatible with all distributions which ship Gnome, a
 Almost all Gnome extensions are compatible for installation.  
 Only rare intervention that might be needed is for extensions which require some additional system dependencies, like Pano.   
 
-Thanks to https://extensions.gnome.org which provides end-releases of extensions as zips, it is very easy to maintain this module configuration.  
+Thanks to https://extensions.gnome.org which provides releases of extensions as zips, it is very easy to maintain this module configuration.  
 The only maintenance is to bump the extension version when new Fedora/Gnome releases (around every 6 months).
 
 What does this module do?

--- a/modules/gnome-extensions/README.md
+++ b/modules/gnome-extensions/README.md
@@ -1,0 +1,24 @@
+# `gnome-extensions`
+
+The `gnome-extensions` module can be used to install Gnome extensions inside system directory.
+
+This module is universally compatible with all distributions which ship Gnome, as long as some extension doesn't require some additional dependency, like Pano.
+
+Thanks to https://extensions.gnome.org which provides end-releases of extensions as zips, it is very easy to maintain this module configuration.
+Basically the only maintenance is to bump the extension version when new Fedora/Gnome releases (around every 6 months).
+
+What does this module do?
+- It parses the gettext-domain that you inputted, along with the extension version
+- It downloads the extension directly from https://extensions.gnome.org
+- Downloaded extension archive is then extracted to temporary directory
+- All of its extracted files are copied to the appropriate final directories  
+  (`/usr/share/gnome-shell/extensions`, `/usr/share/glib-2.0/schemas`, & `/usr/share/locale`)
+
+# Usage
+
+To use this module, you need to input gettext-domain of the extension without @ symbol + the version of the extension in `.v%VERSION%` format.  
+You can see gettext-domain of the extension by looking at the extension repo inside metadata.json  
+or by simply downloading the zip file from https://extensions.gnome.org & than looking at the download URL part after `/extension-data/` & before `.v%VERSION%`.
+
+You must assure that version of the extension is compatible with current Gnome version that your image is using.  
+You can easily see this information when downloading extension from https://extensions.gnome.org

--- a/modules/gnome-extensions/README.md
+++ b/modules/gnome-extensions/README.md
@@ -23,7 +23,7 @@ To use this module, you need to input gettext-domain of the extension without @ 
 But for some extensions, `.v%VERSION%` is parsed as the version of package in incremental numbering, instead of extension version in https://extensions.gnome.org URL.  
 So to be sure that you got the correct module input, follow the steps below.
 
-How to gather correct module input:  
+How to install extensions using the module:  
 1. Go to https://extensions.gnome.org
 2. Search for the extension that you want to install and open its extension page
 3. Select the correct GNOME shell version & extension version from the dropdown

--- a/modules/gnome-extensions/README.md
+++ b/modules/gnome-extensions/README.md
@@ -28,5 +28,6 @@ You can easily see this information when downloading extension from https://exte
 
 # Known Issues
 
-Some extensions like GSConnect may lack information in metadata.json, like lack of `uuid`, `settings-schema` or `shell-version` key,  
+Some extensions may lack information in metadata.json, like lack of `uuid`, `settings-schema` or `shell-version` key,  
 which is necessary for the module to automatically install extension. Developer can easily fix this issue, so it's advised to inform him if this issue occured.
+As a safe-check, build will fail if any of those 3 keys are not present in extensions metadata.json file.

--- a/modules/gnome-extensions/README.md
+++ b/modules/gnome-extensions/README.md
@@ -25,6 +25,7 @@ So to be sure that you got the correct module input, follow the steps below.
 
 How to gather correct module input:  
 1. Go to https://extensions.gnome.org
-2. Search for the extension that you want
-3. Select the matching Gnome shell version & extension version that you want to download
-4. When extension is downloaded, you get the info when you omit `.shell-extension.zip` suffix from the extension zip file-name
+2. Search for the extension that you want to install and open its extension page
+3. Select the correct GNOME shell version & extension version from the dropdown
+   - The command `gnome-shell --version` can be used to get the GNOME version of a running system.
+4. When the download dialog for the extension comes up, copy everything but the `.shell-extension.zip` suffix from the filename into the `install:` array in this module's configuration.

--- a/modules/gnome-extensions/README.md
+++ b/modules/gnome-extensions/README.md
@@ -25,9 +25,3 @@ or by simply downloading the zip file from https://extensions.gnome.org & than l
 
 You must assure that version of the extension is compatible with current Gnome version that your image is using.  
 You can easily see this information when downloading extension from https://extensions.gnome.org
-
-# Known Issues
-
-Some extensions may lack information in metadata.json, like lack of `uuid`, `settings-schema` or `shell-version` key,  
-which is necessary for the module to automatically install extension. Developer can easily fix this issue, so it's advised to inform him if this issue occured.
-As a safe-check, build will fail if any of those 3 keys are not present in extensions metadata.json file.

--- a/modules/gnome-extensions/README.md
+++ b/modules/gnome-extensions/README.md
@@ -2,10 +2,13 @@
 
 The `gnome-extensions` module can be used to install Gnome extensions inside system directory.
 
-This module is universally compatible with all distributions which ship Gnome, as long as some extension doesn't require some additional dependency, like Pano.
+This module is universally compatible with all distributions which ship Gnome, as it's not tied to specific distribution packaging format for installing extensions.  
 
-Thanks to https://extensions.gnome.org which provides end-releases of extensions as zips, it is very easy to maintain this module configuration.
-Basically the only maintenance is to bump the extension version when new Fedora/Gnome releases (around every 6 months).
+Every Gnome extension is compatible for installation.  
+Only rare intervention that might be needed is for extensions which require some additional system dependencies, like Pano. 
+
+Thanks to https://extensions.gnome.org which provides end-releases of extensions as zips, it is very easy to maintain this module configuration.  
+The only maintenance is to bump the extension version when new Fedora/Gnome releases (around every 6 months).
 
 What does this module do?
 - It parses the gettext-domain that you inputted, along with the extension version

--- a/modules/gnome-extensions/README.md
+++ b/modules/gnome-extensions/README.md
@@ -4,7 +4,7 @@ The `gnome-extensions` module can be used to install Gnome extensions inside sys
 
 This module is universally compatible with all distributions which ship Gnome, as it's not tied to specific distribution packaging format for installing extensions.  
 
-Almost every Gnome extension is compatible for installation.  
+Most Gnome extensions are compatible for installation.  
 Only rare intervention that might be needed is for extensions which require some additional system dependencies, like Pano.   
 
 Thanks to https://extensions.gnome.org which provides end-releases of extensions as zips, it is very easy to maintain this module configuration.  

--- a/modules/gnome-extensions/README.md
+++ b/modules/gnome-extensions/README.md
@@ -2,16 +2,15 @@
 
 The `gnome-extensions` module can be used to install Gnome extensions inside system directory.
 
-This module is universally compatible with all distributions which ship Gnome, as it's not tied to specific distribution packaging format for installing extensions.  
+This module is universally compatible with all distributions which ship Gnome, as it's not tied to specific distribution packaging format for installing extensions.
 
-Almost all Gnome extensions are compatible for installation.  
-Only rare intervention that might be needed is for extensions which require some additional system dependencies, like Pano.   
+Almost all Gnome extensions are compatible for installation.
 
 Thanks to https://extensions.gnome.org which provides releases of extensions as zips, it is very easy to maintain this module configuration.  
 The only maintenance is to bump the extension version when new Fedora/Gnome releases (around every 6 months).
 
-What does this module do?
-- It parses the gettext-domain that you inputted, along with the extension version
+What does this module do?  
+- It parses the extension input from module recipe file, which is part of the download URL
 - It downloads the extension directly from https://extensions.gnome.org
 - Downloaded extension archive is then extracted to temporary directory
 - All of its extracted files are copied to the appropriate final directories  
@@ -25,3 +24,7 @@ How to install extensions using the module:
 3. Select the correct GNOME shell version & extension version from the dropdown
    - The command `gnome-shell --version` can be used to get the GNOME version of a running system.
 4. When the download dialog for the extension comes up, copy everything but the `.shell-extension.zip` suffix from the filename into the `install:` array in this module's configuration.
+
+Rarely, some extensions need additional system dependencies in order to function.  
+Those extensions usually note that case inside the extension description webpage.  
+The solution is to install the required dependencies by using `rpm-ostree` module before `gnome-extensions` module is ran.

--- a/modules/gnome-extensions/README.md
+++ b/modules/gnome-extensions/README.md
@@ -19,10 +19,6 @@ What does this module do?
 
 # Usage
 
-To use this module, you need to input gettext-domain of the extension without @ symbol + the version of the extension in `.v%VERSION%` format in module recipe.  
-But for some extensions, `.v%VERSION%` is parsed as the version of package in incremental numbering, instead of extension version in https://extensions.gnome.org URL.  
-So to be sure that you got the correct module input, follow the steps below.
-
 How to install extensions using the module:  
 1. Go to https://extensions.gnome.org
 2. Search for the extension that you want to install and open its extension page

--- a/modules/gnome-extensions/README.md
+++ b/modules/gnome-extensions/README.md
@@ -25,6 +25,6 @@ How to install extensions using the module:
    - The command `gnome-shell --version` can be used to get the GNOME version of a running system.
 4. When the download dialog for the extension comes up, copy everything but the `.shell-extension.zip` suffix from the filename into the `install:` array in this module's configuration.
 
-Rarely, some extensions need additional system dependencies in order to function.  
-Those extensions usually note that case inside the extension description webpage.  
-The solution is to install the required dependencies by using `rpm-ostree` module before `gnome-extensions` module is ran.
+An extension might need additional system dependencies in order to function.  
+In that case, you should install the required dependencies before the `gnome-extensions` module is ran.
+Information about the required dependencies (if any) are usually on the extension's page.  

--- a/modules/gnome-extensions/README.md
+++ b/modules/gnome-extensions/README.md
@@ -4,7 +4,7 @@ The `gnome-extensions` module can be used to install Gnome extensions inside sys
 
 This module is universally compatible with all distributions which ship Gnome, as it's not tied to specific distribution packaging format for installing extensions.  
 
-Most Gnome extensions are compatible for installation.  
+Almost all Gnome extensions are compatible for installation.  
 Only rare intervention that might be needed is for extensions which require some additional system dependencies, like Pano.   
 
 Thanks to https://extensions.gnome.org which provides end-releases of extensions as zips, it is very easy to maintain this module configuration.  

--- a/modules/gnome-extensions/gnome-extensions.sh
+++ b/modules/gnome-extensions/gnome-extensions.sh
@@ -31,39 +31,58 @@ if [[ ${#GETTEXT_DOMAIN[@]} -gt 0 ]]; then
       # If extension does not have the important key in metadata.json,
       # inform the user & fail the build
       if [[ "${UUID}" == "null" ]]; then
-        echo "ERROR: Extension ${EXTENSION_NAME} doesn't have 'uuid' key inside metadata.json"
+        echo "ERROR: Extension '${EXTENSION_NAME}' doesn't have 'uuid' key inside metadata.json"
         echo "You may inform the extension developer about this error, as he can fix it"
         exit 1
       fi
       if [[ "${EXT_GNOME_VER}" == "null" ]]; then
-        echo "ERROR: Extension ${EXTENSION_NAME} doesn't have 'shell-version' key inside metadata.json"
+        echo "ERROR: Extension '${EXTENSION_NAME}' doesn't have 'shell-version' key inside metadata.json"
         echo "You may inform the extension developer about this error, as he can fix it"
         exit 1
       fi      
       # Compare if extension is compatible with current Gnome version
       # If extension is not compatible, inform the user & fail the build
       if ! [[ "${EXT_GNOME_VER}" =~ "${GNOME_VER}" ]]; then
-        echo "ERROR: Extension ${EXTENSION_NAME} is not compatible with current Gnome v${GNOME_VER}!"
+        echo "ERROR: Extension '${EXTENSION_NAME}' is not compatible with current Gnome v${GNOME_VER}!"
         exit 1
       fi  
       # Install main extension files
       echo "Installing main extension files"
       install -d -m 0755 "/usr/share/gnome-shell/extensions/${UUID}/"
-      find "${TMP_DIR}" -mindepth 1 -maxdepth 1 ! -path "*locale*" ! -path "*schemas*" -exec cp -r {} "/usr/share/gnome-shell/extensions/${UUID}/" \;
+      find "${TMP_DIR}" -mindepth 1 -maxdepth 1 ! -path "*locale*" ! -path "*schemas*" ! -path "*icons*" -exec cp -r {} "/usr/share/gnome-shell/extensions/${UUID}/" \;
       find "/usr/share/gnome-shell/extensions/${UUID}" -type d -exec chmod 0755 {} +
       find "/usr/share/gnome-shell/extensions/${UUID}" -type f -exec chmod 0644 {} +
       # Install schema
-      echo "Installing schema extension file"
-      install -d -m 0755 "/usr/share/glib-2.0/schemas/"
-      install -D -p -m 0644 "${TMP_DIR}/schemas/"*.gschema.xml "/usr/share/glib-2.0/schemas/"
+      if [[ -d "${TMP_DIR}/schemas" ]]; then
+        echo "Installing schema extension file"
+        install -d -m 0755 "/usr/share/glib-2.0/schemas/"
+        install -D -p -m 0644 "${TMP_DIR}/schemas/"*.gschema.xml "/usr/share/glib-2.0/schemas/"
+      else
+        echo "ERROR: Extension '${EXTENSION_NAME}' doesn't supply crucial gschema.xml file."
+        echo "       Please contact extension developer about this issue."
+        exit 1
+      fi  
       # Install languages
-      echo "Installing language extension files"
-      install -d -m 0755 "/usr/share/locale/"
-      cp -r "${TMP_DIR}/locale"/* "/usr/share/locale/"
+      # Locale is not crucial for extensions to work, as they will fallback to gschema.xml
+      # Some of them might not have any locale at the moment
+      # So that's why I made a check for directory
+      if [[ -d "${TMP_DIR}/locale" ]]; then
+        echo "Installing language extension files"
+        install -d -m 0755 "/usr/share/locale/"
+        cp -r "${TMP_DIR}/locale"/* "/usr/share/locale/"
+      fi  
+      # Install icons if extension uses them
+      # This is only for extensions which respect XDG icon standard
+      # Some extensions simply supply icons in the extension folder & they work
+      if [[ -d "${TMP_DIR}/icons" ]]; then
+        echo "Installing extension icons"
+        install -d -m 0755 "/usr/share/icons/"
+        cp -r "${TMP_DIR}/icons"/* "/usr/share/icons/"
+      fi  
       # Delete the temporary directory
       echo "Cleaning up the temporary directory"
       rm -r "${TMP_DIR}"
-      echo "Extension ${EXTENSION_NAME} is successfully installed"
+      echo "Extension '${EXTENSION_NAME}' is successfully installed"
       echo "------------------------------DONE----------------------------------"     
   done
 else

--- a/modules/gnome-extensions/gnome-extensions.sh
+++ b/modules/gnome-extensions/gnome-extensions.sh
@@ -49,7 +49,7 @@ if [[ ${#GETTEXT_DOMAIN[@]} -gt 0 ]]; then
       # Install main extension files
       echo "Installing main extension files"
       install -d -m 0755 "/usr/share/gnome-shell/extensions/${UUID}/"
-      find "${TMP_DIR}" -mindepth 1 -maxdepth 1 ! -path "*locale*" ! -path "*schemas*" ! -path "*icons*" -exec cp -r {} "/usr/share/gnome-shell/extensions/${UUID}/" \;
+      find "${TMP_DIR}" -mindepth 1 -maxdepth 1 ! -path "*locale*" ! -path "*schemas*" -exec cp -r {} "/usr/share/gnome-shell/extensions/${UUID}/" \;
       find "/usr/share/gnome-shell/extensions/${UUID}" -type d -exec chmod 0755 {} +
       find "/usr/share/gnome-shell/extensions/${UUID}" -type f -exec chmod 0644 {} +
       # Install schema
@@ -70,14 +70,6 @@ if [[ ${#GETTEXT_DOMAIN[@]} -gt 0 ]]; then
         echo "Installing language extension files"
         install -d -m 0755 "/usr/share/locale/"
         cp -r "${TMP_DIR}/locale"/* "/usr/share/locale/"
-      fi  
-      # Install icons if extension uses them
-      # This is only for extensions which respect XDG icon standard
-      # Some extensions simply supply icons in the extension folder & they work
-      if [[ -d "${TMP_DIR}/icons" ]]; then
-        echo "Installing icons for the extension"
-        install -d -m 0755 "/usr/share/icons/"
-        cp -r "${TMP_DIR}/icons"/* "/usr/share/icons/"
       fi  
       # Delete the temporary directory
       echo "Cleaning up the temporary directory"

--- a/modules/gnome-extensions/gnome-extensions.sh
+++ b/modules/gnome-extensions/gnome-extensions.sh
@@ -75,10 +75,10 @@ if [[ ${#GETTEXT_DOMAIN[@]} -gt 0 ]]; then
       echo "Cleaning up the temporary directory"
       rm -r "${TMP_DIR}"
       echo "Extension '${EXTENSION_NAME}' is successfully installed"
-      echo "------------------------------DONE----------------------------------"     
+      echo "----------------------------------DONE----------------------------------"
   done
 else
-  echo "ERROR: You did not specify gettext-domain in module recipe file"
+  echo "ERROR: You did not specify extension to install in module recipe file"
   exit 1
 fi
 

--- a/modules/gnome-extensions/gnome-extensions.sh
+++ b/modules/gnome-extensions/gnome-extensions.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+
+# Tell build process to exit if there are any errors.
+set -euo pipefail
+
+get_yaml_array GETTEXT_DOMAIN '.install.gettext-domain[]' "$1"
+
+if [[ ${#GETTEXT_DOMAIN[@]} -gt 0 ]]; then
+  for EXTENSION in "${GETTEXT_DOMAIN[@]}"; do
+      URL="https://extensions.gnome.org/extension-data/${EXTENSION}.shell-extension.zip"
+      TMP_DIR="/tmp/${EXTENSION}"
+      ARCHIVE=$(basename "${URL}")
+      ARCHIVE_DIR="${TMP_DIR}/${ARCHIVE}"
+      VERSION=$(echo "${EXTENSION}" | grep -oP 'v\d+')
+      echo "Installing ${EXTENSION} Gnome extension with version ${VERSION}"
+      # Download archive
+      curl -L "${URL}" --create-dirs -o "${ARCHIVE_DIR}"
+      # Extract archive
+      echo "Extracting ZIP archive"
+      unzip "${ARCHIVE_DIR}" -d "${TMP_DIR}" > /dev/null
+      # Remove archive
+      echo "Removing archive"
+      rm "${ARCHIVE_DIR}"
+      # Read necessary info from metadata.json
+      echo "Reading necessary info from metadata.json"
+      UUID=$(yq '.uuid' < "${TMP_DIR}/metadata.json")
+      SCHEMA_ID=$(yq '.settings-schema' < "${TMP_DIR}/metadata.json")
+      # Install main extension files
+      echo "Installing main extension files"
+      install -d -m 0755 "/usr/share/gnome-shell/extensions/${UUID}/"
+      find "${TMP_DIR}" -mindepth 1 -maxdepth 1 ! -path "*locale*" ! -path "*schemas*" -exec cp -r {} "/usr/share/gnome-shell/extensions/${UUID}/" \;
+      find "/usr/share/gnome-shell/extensions/${UUID}" -type d -exec chmod 0755 {} +
+      find "/usr/share/gnome-shell/extensions/${UUID}" -type f -exec chmod 0644 {} +
+      # Install schema
+      echo "Installing schema extension file"
+      install -d -m 0755 "/usr/share/glib-2.0/schemas/"
+      install -D -p -m 0644 "${TMP_DIR}/schemas/${SCHEMA_ID}.gschema.xml" "/usr/share/glib-2.0/schemas/${SCHEMA_ID}.gschema.xml"
+      # Install languages
+      echo "Installing language extension files"
+      install -d -m 0755 "/usr/share/locale/"
+      cp -r "${TMP_DIR}/locale"/* "/usr/share/locale/"
+      # Delete the temporary directory
+      echo "Cleaning up the temporary directory"
+      rm -r "${TMP_DIR}"
+      echo "------------------------------DONE----------------------------------"     
+  done
+else
+  echo "ERROR: You did not specify gettext-domain"
+  exit 1
+fi
+
+echo "Finished the installation of Gnome extensions"

--- a/modules/gnome-extensions/gnome-extensions.sh
+++ b/modules/gnome-extensions/gnome-extensions.sh
@@ -28,6 +28,25 @@ if [[ ${#GETTEXT_DOMAIN[@]} -gt 0 ]]; then
       UUID=$(yq '.uuid' < "${TMP_DIR}/metadata.json")
       SCHEMA_ID=$(yq '.settings-schema' < "${TMP_DIR}/metadata.json")
       EXT_GNOME_VER=$(yq '.shell-version[]' < "${TMP_DIR}/metadata.json")
+      # Some extensions like GSConnect don't have schema_id information for some reason
+      # So if that's the case, fail the build & notify the user about it
+      # I will try to find the workaround for this,
+      # maybe as manual input inside the recipe
+      if [[ "${UUID}" == "null" ]]; then
+        echo "ERROR: Extension ${EXTENSION} doesn't have UUID inside metadata.json"
+        echo "You may inform the extension developer about this error, as he can fix it"
+        exit 1
+      fi
+      if [[ "${SCHEMA_ID}" == "null" ]]; then
+        echo "ERROR: Extension ${EXTENSION} doesn't have Schema ID inside metadata.json"
+        echo "You may inform the extension developer about this error, as he can fix it"
+        exit 1
+      fi
+      if [[ "${EXT_GNOME_VER}" == "null" ]]; then
+        echo "ERROR: Extension ${EXTENSION} doesn't have Gnome Version inside metadata.json"
+        echo "You may inform the extension developer about this error, as he can fix it"
+        exit 1
+      fi      
       # Compare if extension is compatible with current Gnome version
       if ! [[ "${EXT_GNOME_VER}" =~ "${GNOME_VER}" ]]; then
         echo "ERROR: Extension is not compatible with current Gnome v${GNOME_VER}!"

--- a/modules/gnome-extensions/gnome-extensions.sh
+++ b/modules/gnome-extensions/gnome-extensions.sh
@@ -75,7 +75,7 @@ if [[ ${#GETTEXT_DOMAIN[@]} -gt 0 ]]; then
       # This is only for extensions which respect XDG icon standard
       # Some extensions simply supply icons in the extension folder & they work
       if [[ -d "${TMP_DIR}/icons" ]]; then
-        echo "Installing extension icons"
+        echo "Installing icons for the extension"
         install -d -m 0755 "/usr/share/icons/"
         cp -r "${TMP_DIR}/icons"/* "/usr/share/icons/"
       fi  

--- a/modules/gnome-extensions/gnome-extensions.sh
+++ b/modules/gnome-extensions/gnome-extensions.sh
@@ -78,7 +78,7 @@ if [[ ${#GETTEXT_DOMAIN[@]} -gt 0 ]]; then
       echo "----------------------------------DONE----------------------------------"
   done
 else
-  echo "ERROR: You did not specify extension to install in module recipe file"
+  echo "ERROR: You did not specify the extension to install in module recipe file"
   exit 1
 fi
 

--- a/modules/gnome-extensions/gnome-extensions.sh
+++ b/modules/gnome-extensions/gnome-extensions.sh
@@ -25,31 +25,31 @@ if [[ ${#GETTEXT_DOMAIN[@]} -gt 0 ]]; then
       rm "${ARCHIVE_DIR}"
       # Read necessary info from metadata.json
       echo "Reading necessary info from metadata.json"
+      EXTENSION_NAME=$(yq '.name' < "${TMP_DIR}/metadata.json")
       UUID=$(yq '.uuid' < "${TMP_DIR}/metadata.json")
       SCHEMA_ID=$(yq '.settings-schema' < "${TMP_DIR}/metadata.json")
       EXT_GNOME_VER=$(yq '.shell-version[]' < "${TMP_DIR}/metadata.json")
-      # Some extensions like GSConnect don't have schema_id information for some reason
-      # So if that's the case, fail the build & notify the user about it
-      # I will try to find the workaround for this,
-      # maybe as manual input inside the recipe
+      # If extension does not have the important key in metadata.json,
+      # inform the user & fail the build
       if [[ "${UUID}" == "null" ]]; then
-        echo "ERROR: Extension ${EXTENSION} doesn't have UUID inside metadata.json"
+        echo "ERROR: Extension ${EXTENSION_NAME} doesn't have 'uuid' key inside metadata.json"
         echo "You may inform the extension developer about this error, as he can fix it"
         exit 1
       fi
       if [[ "${SCHEMA_ID}" == "null" ]]; then
-        echo "ERROR: Extension ${EXTENSION} doesn't have Schema ID inside metadata.json"
+        echo "ERROR: Extension ${EXTENSION_NAME} doesn't have 'settings-schema' key inside metadata.json"
         echo "You may inform the extension developer about this error, as he can fix it"
         exit 1
       fi
       if [[ "${EXT_GNOME_VER}" == "null" ]]; then
-        echo "ERROR: Extension ${EXTENSION} doesn't have Gnome Version inside metadata.json"
+        echo "ERROR: Extension ${EXTENSION_NAME} doesn't have 'shell-version' key inside metadata.json"
         echo "You may inform the extension developer about this error, as he can fix it"
         exit 1
       fi      
       # Compare if extension is compatible with current Gnome version
+      # If extension is not compatible, inform the user & fail the build
       if ! [[ "${EXT_GNOME_VER}" =~ "${GNOME_VER}" ]]; then
-        echo "ERROR: Extension is not compatible with current Gnome v${GNOME_VER}!"
+        echo "ERROR: Extension ${EXTENSION_NAME} is not compatible with current Gnome v${GNOME_VER}!"
         exit 1
       fi  
       # Install main extension files
@@ -72,7 +72,7 @@ if [[ ${#GETTEXT_DOMAIN[@]} -gt 0 ]]; then
       echo "------------------------------DONE----------------------------------"     
   done
 else
-  echo "ERROR: You did not specify gettext-domain"
+  echo "ERROR: You did not specify gettext-domain in module recipe file"
   exit 1
 fi
 

--- a/modules/gnome-extensions/gnome-extensions.sh
+++ b/modules/gnome-extensions/gnome-extensions.sh
@@ -27,17 +27,11 @@ if [[ ${#GETTEXT_DOMAIN[@]} -gt 0 ]]; then
       echo "Reading necessary info from metadata.json"
       EXTENSION_NAME=$(yq '.name' < "${TMP_DIR}/metadata.json")
       UUID=$(yq '.uuid' < "${TMP_DIR}/metadata.json")
-      SCHEMA_ID=$(yq '.settings-schema' < "${TMP_DIR}/metadata.json")
       EXT_GNOME_VER=$(yq '.shell-version[]' < "${TMP_DIR}/metadata.json")
       # If extension does not have the important key in metadata.json,
       # inform the user & fail the build
       if [[ "${UUID}" == "null" ]]; then
         echo "ERROR: Extension ${EXTENSION_NAME} doesn't have 'uuid' key inside metadata.json"
-        echo "You may inform the extension developer about this error, as he can fix it"
-        exit 1
-      fi
-      if [[ "${SCHEMA_ID}" == "null" ]]; then
-        echo "ERROR: Extension ${EXTENSION_NAME} doesn't have 'settings-schema' key inside metadata.json"
         echo "You may inform the extension developer about this error, as he can fix it"
         exit 1
       fi
@@ -61,7 +55,7 @@ if [[ ${#GETTEXT_DOMAIN[@]} -gt 0 ]]; then
       # Install schema
       echo "Installing schema extension file"
       install -d -m 0755 "/usr/share/glib-2.0/schemas/"
-      install -D -p -m 0644 "${TMP_DIR}/schemas/${SCHEMA_ID}.gschema.xml" "/usr/share/glib-2.0/schemas/${SCHEMA_ID}.gschema.xml"
+      install -D -p -m 0644 "${TMP_DIR}/schemas/"*.gschema.xml "/usr/share/glib-2.0/schemas/"
       # Install languages
       echo "Installing language extension files"
       install -d -m 0755 "/usr/share/locale/"

--- a/modules/gnome-extensions/gnome-extensions.sh
+++ b/modules/gnome-extensions/gnome-extensions.sh
@@ -63,6 +63,7 @@ if [[ ${#GETTEXT_DOMAIN[@]} -gt 0 ]]; then
       # Delete the temporary directory
       echo "Cleaning up the temporary directory"
       rm -r "${TMP_DIR}"
+      echo "Extension ${EXTENSION_NAME} is successfully installed"
       echo "------------------------------DONE----------------------------------"     
   done
 else

--- a/modules/gnome-extensions/gnome-extensions.sh
+++ b/modules/gnome-extensions/gnome-extensions.sh
@@ -3,7 +3,7 @@
 # Tell build process to exit if there are any errors.
 set -euo pipefail
 
-get_yaml_array GETTEXT_DOMAIN '.install.gettext-domain[]' "$1"
+get_yaml_array GETTEXT_DOMAIN '.install[]' "$1"
 GNOME_VER=$(gnome-shell --version | sed 's/[^0-9]*\([0-9]*\).*/\1/')
 echo "Gnome version: v${GNOME_VER}"
 

--- a/modules/gnome-extensions/gnome-extensions.sh
+++ b/modules/gnome-extensions/gnome-extensions.sh
@@ -5,6 +5,7 @@ set -euo pipefail
 
 get_yaml_array GETTEXT_DOMAIN '.install.gettext-domain[]' "$1"
 GNOME_VER=$(gnome-shell --version | sed 's/[^0-9]*\([0-9]*\).*/\1/')
+echo "Gnome version: v${GNOME_VER}"
 
 if [[ ${#GETTEXT_DOMAIN[@]} -gt 0 ]]; then
   for EXTENSION in "${GETTEXT_DOMAIN[@]}"; do
@@ -14,7 +15,6 @@ if [[ ${#GETTEXT_DOMAIN[@]} -gt 0 ]]; then
       ARCHIVE_DIR="${TMP_DIR}/${ARCHIVE}"
       VERSION=$(echo "${EXTENSION}" | grep -oP 'v\d+')
       echo "Installing ${EXTENSION} Gnome extension with version ${VERSION}"
-      echo "Gnome version: v${GNOME_VER}"
       # Download archive
       curl -L "${URL}" --create-dirs -o "${ARCHIVE_DIR}"
       # Extract archive

--- a/modules/gnome-extensions/module.yml
+++ b/modules/gnome-extensions/module.yml
@@ -3,6 +3,5 @@ shortdesc: The gnome-extensions module can be used to install Gnome extensions i
 readme: https://raw.githubusercontent.com/blue-build/modules/main/modules/gnome-extensions/README.md
 example: |
   type: gnome-extensions
-  install:
-    gettext-domain:                                 # Omit @ symbol from gettext-domain. You can see the gettext-domain by looking into extension metadata.json.
-      - nightthemeswitcherromainvigier.fr.v75       # Version must be specified by adding .v%VERSION% after gettext domain. Extension version must be compatible with current Gnome version.
+  install:                                        # Omit @ symbol from gettext-domain. You can see the gettext-domain by looking into extension metadata.json.
+    - nightthemeswitcherromainvigier.fr.v75       # Version must be specified by adding .v%VERSION% after gettext domain. Extension version must be compatible with current Gnome version.

--- a/modules/gnome-extensions/module.yml
+++ b/modules/gnome-extensions/module.yml
@@ -3,5 +3,5 @@ shortdesc: The gnome-extensions module can be used to install Gnome extensions i
 readme: https://raw.githubusercontent.com/blue-build/modules/main/modules/gnome-extensions/README.md
 example: |
   type: gnome-extensions
-  install:                                        # Omit @ symbol from gettext-domain. You can see the gettext-domain by looking into extension metadata.json.
-    - nightthemeswitcherromainvigier.fr.v75       # Version must be specified by adding .v%VERSION% after gettext domain. Extension version must be compatible with current Gnome version.
+  install:
+    - nightthemeswitcherromainvigier.fr.v75

--- a/modules/gnome-extensions/module.yml
+++ b/modules/gnome-extensions/module.yml
@@ -1,0 +1,8 @@
+name: gnome-extensions
+shortdesc: The gnome-extensions module can be used to install Gnome extensions inside system directory.
+readme: https://raw.githubusercontent.com/blue-build/modules/main/modules/gnome-extensions/README.md
+example: |
+  type: gnome-extensions
+  install:
+    gettext-domain:                                 # Omit @ symbol from gettext-domain. You can see the gettext-domain by looking into extension metadata.json.
+      - nightthemeswitcherromainvigier.fr.v75       # Version must be specified by adding .v%VERSION% after gettext domain. Extension version must be compatible with current Gnome version.


### PR DESCRIPTION
If you wished to install some Gnome extension, but couldn't find it in RPM, this extension will help you in that.

Basically all extensions are supported, with some rare extensions like Pano just additionally needing some system dependencies.

See README for more details.

PR is in draft as it just needs some cosmetic refinements in some areas & probably some documentation fixes.

It's not a big code, so I believe that it will suit the future bash module code guidelines nicely.

Some check like extension compatibility with Gnome version can also be implemented to fail if detected, based on metadata.json. I forgot that I could implement that.

EDIT: Implemented the compatibility check between extension & Gnome version.