### PR TITLE
fix(gnome-extensions): Use `wget` instead of `curl`

### DIFF
--- a/modules/gnome-extensions/gnome-extensions.sh
+++ b/modules/gnome-extensions/gnome-extensions.sh
@@ -16,7 +16,7 @@ if [[ ${#GETTEXT_DOMAIN[@]} -gt 0 ]]; then
       VERSION=$(echo "${EXTENSION}" | grep -oP 'v\d+')
       echo "Installing ${EXTENSION} Gnome extension with version ${VERSION}"
       # Download archive
-      curl -L "${URL}" --create-dirs -o "${ARCHIVE_DIR}"
+      wget "${URL}" -P "${ARCHIVE_DIR}"
       # Extract archive
       echo "Extracting ZIP archive"
       unzip "${ARCHIVE_DIR}" -d "${TMP_DIR}" > /dev/null


### PR DESCRIPTION
`wget` might be more reliable for downloading things, which is performed in this module.

Some user faced the error with extension that didn't download fully, causing the `unzip` command to fail. I tested the same extension & it installed successfully for me.

This was maybe a server error, maybe `curl`'s, but I will still do this change, as I have more trust in `wget` for strictly downloading things.

Also, every other BlueBuild bash module uses `wget` too, so this makes things more consistent.