### PR TITLE
fix(gnome-extensions): Extensions can't see gschema.xml, even when it…

### DIFF
--- a/modules/gnome-extensions/gnome-extensions.sh
+++ b/modules/gnome-extensions/gnome-extensions.sh
@@ -78,4 +78,8 @@ else
   exit 1
 fi
 
+# Compile gschema to include schemas from extensions
+echo "Compiling gschema to include extension schemas
+glib-compile-schemas "/usr/share/glib-2.0/schemas/" &>/dev/null
+
 echo "Finished the installation of Gnome extensions"


### PR DESCRIPTION
…'s present

Gschema needs to be compiled also.

It worked for me initially, because I use `gschema-overrides` module after `gnome-extensions`, which does the same thing.

So I missed this crucial step.