### PR TITLE
use curl instead of wget in rpm-ostree module so it can be used with …

### DIFF
--- a/modules/rpm-ostree/rpm-ostree.sh
+++ b/modules/rpm-ostree/rpm-ostree.sh
@@ -9,7 +9,7 @@ if [[ ${#REPOS[@]} -gt 0 ]]; then
     echo "Adding repositories"
     for REPO in "${REPOS[@]}"; do
         REPO="${REPO//%OS_VERSION%/${OS_VERSION}}"
-        wget "${REPO//[$'\t\r\n ']}" -P "/etc/yum.repos.d/"
+        curl --output-dir "/etc/yum.repos.d/" -O "${REPO//[$'\t\r\n ']}"
     done
 fi
 


### PR DESCRIPTION
…ucore/coreos base images