### PR TITLE
feat: detect URLs and always install them using rpm-ostree install (#226)

### DIFF
--- a/modules/rpm-ostree/README.md
+++ b/modules/rpm-ostree/README.md
@@ -6,6 +6,8 @@ The module first downloads the repository files from repositories declared under
 
 Then the module installs the packages declared under `install:` using `rpm-ostree install`, it removes the packages declared under `remove:` using `rpm-ostree override remove`. If there are packages declared under both `install:` and `remove:` a hybrid command `rpm-ostree remove <packages> --install <packages>` is used, which should allow you to switch required packages for other ones.
 
+Installing RPM packages directly from a `http(s)` url that points to the RPM file is also supported, you can just put the URLs under `install:` and they'll be installed along with the other packages.
+
 :::note
 [Removed packages are still present in the underlying ostree repository](https://coreos.github.io/rpm-ostree/administrator-handbook/#removing-a-base-package), what `remove` does is kind of like hiding them from the system, it doesn't free up storage space.
 :::

--- a/modules/rpm-ostree/rpm-ostree.sh
+++ b/modules/rpm-ostree/rpm-ostree.sh
@@ -34,6 +34,16 @@ fi
 get_yaml_array INSTALL '.install[]' "$1"
 get_yaml_array REMOVE '.remove[]' "$1"
 
+if [[ ${#INSTALL[@]} -gt 0 ]]; then
+    for PKG in "${INSTALL[@]}"; do
+        if [[ "$PKG" =~ ^https?:\/\/.* ]]; then
+            echo "Installing directly from URL: ${PKG}"
+            rpm-ostree install "$PKG"
+            INSTALL=( "${INSTALL[@]/$PKG}" ) # delete URL from install array
+        fi
+    done
+fi
+
 # The installation is done with some wordsplitting hacks
 # because of errors when doing array destructuring at the installation step.
 # This is different from other ublue projects and could be investigated further.


### PR DESCRIPTION
`rpm-ostree override remove --install` doesn't seem to support installing directly from URLs.

This feature has been tested locally and found to work perfectly.