### PR TITLE
docs(chezmoi): fix using underscores as delimiters in docs, when code uses dashes

### DIFF
--- a/modules/chezmoi/README.md
+++ b/modules/chezmoi/README.md
@@ -28,7 +28,7 @@ Set `disable_init` to `true` if you do not want to install the init service.
 If `repository` is not set, and `disable_init` is false the module will fail, due to not being able to initialize the repository.
 :::
 
-Set `enable_all_users` to `false` if you want to install the update and initialization services, but do not want them enabled for all users.
+Set `all-users` to `false` if you want to install the update and initialization services, but do not want them enabled for all users.
 You can enable them manually instead when the system has been installed:
 
 To enable the services for a single user, run the following command as that user:

--- a/modules/chezmoi/README.md
+++ b/modules/chezmoi/README.md
@@ -22,10 +22,10 @@ Set `repository` to the URL of your dotfiles repository. (eg. `repository: https
 The value of `repository` will be passed directly to `chezmoi init --apply ${repository}`.
 See the [`chezmoi init` documentation](https://www.chezmoi.io/reference/commands/init/) for detailed syntax.
 ::: 
-Set `disable_init` to `true` if you do not want to install the init service.
+Set `disable-init` to `true` if you do not want to install the init service.
 
 :::caution
-If `repository` is not set, and `disable_init` is false the module will fail, due to not being able to initialize the repository.
+If `repository` is not set, and `disable-init` is false the module will fail, due to not being able to initialize the repository.
 :::
 
 Set `all-users` to `false` if you want to install the update and initialization services, but do not want them enabled for all users.
@@ -57,18 +57,18 @@ If you understand the above implications, and decide you need this feature, you 
 sudo loginctl enable-linger <username>`
 ```
 
-You can configure the interval between updates of your dotfiles by setting the value of `run_every`.
+You can configure the interval between updates of your dotfiles by setting the value of `run-every`.
 The string is passed directly to OnUnitInactiveSec. (default: '1d')
 See [`systemd.time` documenation](https://www.freedesktop.org/software/systemd/man/latest/systemd.time.html) for detailed syntax.
 Examples: '1d' (1 day - default), '6h' (6 hours), '10m' (10 minutes)
 
-Likewise, `wait_after_boot` configures the delay between the system booting and the update service starting.
-This follows the same syntax as `run_every`. (default: '5m')
+Likewise, `wait-after-boot` configures the delay between the system booting and the update service starting.
+This follows the same syntax as `run-every`. (default: '5m')
 
-The installation of the initialization service and the update service can be disabled separately by setting `disable_init` and/or `disable_update` to `true`. (Both default: false)
+The installation of the initialization service and the update service can be disabled separately by setting `disable-init` and/or `disable-update` to `true`. (Both default: false)
 
 :::caution
-Note that this will skip the installation of the services completely. If you want them installed but disabled, see `enable_all_users` instead.
+Note that this will skip the installation of the services completely. If you want them installed but disabled, see `all-users` instead.
 :::
 
 ## Development

--- a/modules/chezmoi/README.md
+++ b/modules/chezmoi/README.md
@@ -6,7 +6,7 @@ Each feature can be enabled or disabled individually.
 Installation of the `chezmoi` binary happens at build time and is done by downloading the `amd64` binary from the latest release to `/usr/bin/chezmoi`. 
 This can be disabled by setting `install` to false. (defaults: true)
 
-Choose how `chezmoi` handles changed files with `changed-file-policy`. 
+Choose how `chezmoi` handles conflicting files with `file-conflict-policy`. 
 The following values are valid:
 `"skip"` Will not take any action if the file has changed from what is in your dotfiles repository. 
 This executes `chezmoi update --no-tty --keep-going` under the hood. 

--- a/modules/chezmoi/chezmoi.sh
+++ b/modules/chezmoi/chezmoi.sh
@@ -60,18 +60,18 @@ if [[ -z $DISABLE_UPDATE || $DISABLE_UPDATE == "null" ]]; then
 	DISABLE_UPDATE=false
 fi
 
-# Determines how chezmoi handles duplicate files. (default: "skip")
+# Determines how chezmoi handles conflicting files. (default: "skip")
 # "skip" will not replace files that have changed.
 # "replace" will overwrite all files that have changed.
-CHANGED_FILE_POLICY=$(echo "$1" | yq -I=0 ".changed-file-policy") # (string)
-if [[ -z $CHANGED_FILE_POLICY || $CHANGED_FILE_POLICY == "null" ]]; then
-	CHANGED_FILE_POLICY="skip"
+FILE_CONFLICT_POLICY=$(echo "$1" | yq -I=0 ".file-conflict-policy") # (string)
+if [[ -z $FILE_CONFLICT_POLICY || $FILE_CONFLICT_POLICY == "null" ]]; then
+	FILE_CONFLICT_POLICY="skip"
 fi
 
-if [[ $CHANGED_FILE_POLICY == "skip" ]]; then
-	CHANGED_FILE_POLICY_FLAGS="--no-tty --keep-going"
-elif [[ $CHANGED_FILE_POLICY == "replace" ]]; then
-	CHANGED_FILE_POLICY_FLAGS="--no-tty --force"
+if [[ $FILE_CONFLICT_POLICY == "skip" ]]; then
+	FILE_CONFLICT_POLICY_FLAGS="--no-tty --keep-going"
+elif [[ $FILE_CONFLICT_POLICY == "replace" ]]; then
+	FILE_CONFLICT_POLICY_FLAGS="--no-tty --force"
 else
 	echo "ERROR: 'duplicate-file-policy' has an invalid value."
 	echo "Only \"skip\" or \"replace\" are acceptable values"
@@ -132,7 +132,7 @@ if [[ $DISABLE_UPDATE == false ]]; then
   Description=Chezmoi Update
 
   [Service]
-  ExecStart=/usr/bin/chezmoi update ${CHANGED_FILE_POLICY_FLAGS}
+  ExecStart=/usr/bin/chezmoi update ${FILE_CONFLICT_POLICY_FLAGS}
   Type=oneshot
 EOF
 

--- a/modules/chezmoi/chezmoi.sh
+++ b/modules/chezmoi/chezmoi.sh
@@ -87,7 +87,7 @@ fi
 echo "Checking for conflicting arguments"
 if [[ (-z $DOTFILE_REPOSITORY || $DOTFILE_REPOSITORY == "null") && $DISABLE_INIT == false ]]; then
 	echo "ERROR: Invalid Config: 'repository' is not set, but initialization is not disabled."
-	echo "Set a value for 'repository' or set 'disable_update' to true, if you do not wish to initialize a chezmoi directory using this module"
+	echo "Set a value for 'repository' or set 'disable-update' to true, if you do not wish to initialize a chezmoi directory using this module"
 	exit 1
 fi
 

--- a/modules/chezmoi/chezmoi.sh
+++ b/modules/chezmoi/chezmoi.sh
@@ -35,9 +35,9 @@ DOTFILE_REPOSITORY=$(echo "$1" | yq -I=0 ".repository") # (string)
 #
 # To turn on lingering for a given user, run the following commmand with sudo:
 # 'sudo loginctl enable-linger <username>'
-ENABLE_ALL_USERS=$(echo "$1" | yq -I=0 ".enable-all-users") # (boolean)
-if [[ -z $ENABLE_ALL_USERS || $ENABLE_ALL_USERS == "null" ]]; then
-	ENABLE_ALL_USERS=true
+ALL_USERS=$(echo "$1" | yq -I=0 ".all-users") # (boolean)
+if [[ -z $ALL_USERS || $ALL_USERS == "null" ]]; then
+	ALL_USERS=true
 fi
 
 # chezmoi-update.service will run with this interval
@@ -159,13 +159,13 @@ fi
 
 # Enable services
 echo "Checking which services to enable"
-if [[ $ENABLE_ALL_USERS == true && $DISABLE_INIT == false && $DISABLE_UPDATE == false ]]; then
+if [[ $ALL_USERS == true && $DISABLE_INIT == false && $DISABLE_UPDATE == false ]]; then
 	echo "Enabling init timer and update service"
 	systemctl --global enable chezmoi-init.service chezmoi-update.timer
-elif [[ $ENABLE_ALL_USERS == true && $DISABLE_INIT == true && $DISABLE_UPDATE == false ]]; then
+elif [[ $ALL_USERS == true && $DISABLE_INIT == true && $DISABLE_UPDATE == false ]]; then
 	echo "Enabling update timer"
 	systemctl --global enable chezmoi-update.timer
-elif [[ $ENABLE_ALL_USERS == true && $DISABLE_INIT == false && $DISABLE_UPDATE == true ]]; then
+elif [[ $ALL_USERS == true && $DISABLE_INIT == false && $DISABLE_UPDATE == true ]]; then
 	echo "Enabling init service"
 	systemctl --global enable chezmoi-init.service
 else

--- a/modules/chezmoi/chezmoi.sh
+++ b/modules/chezmoi/chezmoi.sh
@@ -15,12 +15,6 @@ if [[ $DEBUG == true ]]; then
 	set -vux
 fi
 
-# If true, downloads the chezmoi binary from the latest Github release and moves it to /usr/bin/. (default: true)
-INSTALL_CHEZMOI=$(echo "$1" | yq -I=0 ".install-chezmoi") # (boolean)
-if [[ -z $INSTALL_CHEZMOI || $INSTALL_CHEZMOI == "null" ]]; then
-	INSTALL_CHEZMOI=true
-fi
-
 # The repository with your chezmoi dotfiles. (default: null)
 DOTFILE_REPOSITORY=$(echo "$1" | yq -I=0 ".repository") # (string)
 
@@ -91,7 +85,11 @@ if [[ (-z $DOTFILE_REPOSITORY || $DOTFILE_REPOSITORY == "null") && $DISABLE_INIT
 	exit 1
 fi
 
-if [[ $INSTALL_CHEZMOI == true ]]; then
+
+echo "Checking if /usr/bin/chezmoi exists"
+if [ -e /usr/bin/chezmoi ]; then
+	echo "chezmoi binary already exists, no need to redownload it"
+else
 	echo "Checking if curl is installed and executable at /usr/bin/curl"
 	if [ -x /usr/bin/curl ]; then
 		echo "Downloading chezmoi binary from the latest Github release"
@@ -103,9 +101,8 @@ if [[ $INSTALL_CHEZMOI == true ]]; then
 		echo "Please make sure curl is installed on the system you are building your image."
 		exit 1
 	fi
-else
-	echo "Skipping install of chezmoi binary"
 fi
+
 
 if [[ $DISABLE_INIT == false ]]; then
 	# Write the service to initialize Chezmoi, and insert the repo url in the file

--- a/modules/chezmoi/module.yml
+++ b/modules/chezmoi/module.yml
@@ -7,8 +7,8 @@ example: |
   install-chezmoi: true # Optional - Default: true  - Expects type: boolean
   # Git repository to initialize
   repository: "https://example.org/user/dotfiles" # Required - Default: n/a  - Expects type: string
-  # Enable the modules services globally for all users, if false users need to enable services manually
-  enable-all-users: true # Optional - Default: true - Expects type: boolean
+  # Whether to enable the modules services globally for all users, if false users need to enable services manually
+  all-users: true # Optional - Default: true - Expects type: boolean
   # Dotfiles will be updated with this interval
   run-every: '1d' # Optional - Default: '1d' - Expects type: string
   # Dotfile updates will wait this long after a boot before running

--- a/modules/chezmoi/module.yml
+++ b/modules/chezmoi/module.yml
@@ -4,18 +4,19 @@ readme: https://raw.githubusercontent.com/blue-build/modules/main/modules/chezmo
 example: |
   type: chezmoi
   # Installs chezmoi to /usr/bin/chezmoi from latest Github release
-  install_chezmoi: true # Optional - Default: true  - Expects type: boolean
-  # () Git repository to initialize
+  install-chezmoi: true # Optional - Default: true  - Expects type: boolean
+  # Git repository to initialize
   repository: "https://example.org/user/dotfiles" # Required - Default: n/a  - Expects type: string
-  # Enable the modules services globally for all users
-  enable_all_users: true # Optional - Default: true - Expects type: boolean
+  # Enable the modules services globally for all users, if false users need to enable services manually
+  enable-all-users: true # Optional - Default: true - Expects type: boolean
   # Dotfiles will be updated with this interval
-  run_every: '1d' # Optional - Default: '1d' - Expects type: string
+  run-every: '1d' # Optional - Default: '1d' - Expects type: string
   # Dotfile updates will wait this long after a boot before running
-  wait_after_boot: '5m' # Optional - Default: '5m' - Expects type: string
-  # Disable the service that initializes `repository` on users that are logged in or has linger enabled
-  disable_init: false # Optional - Default: false - Expects type: boolean
+  wait-after-boot: '5m' # Optional - Default: '5m' - Expects type: string
+  # Disable the service that initializes `repository` on users that are logged in or have linger enabled
+  disable-init: false # Optional - Default: false - Expects type: boolean
   # Disable the timer that updates chezmoi with the interval set above
-  disable_update: false # Optional - Default: false - Expects type: boolean
+  disable-update: false # Optional - Default: false - Expects type: boolean
   # Policy for handling file that has changed on disk compared to your repo. Accepts "skip" or "replace"
   changed-file-policy: "skip" # Optional - Default: "skip" - Expects type: string
+

--- a/modules/chezmoi/module.yml
+++ b/modules/chezmoi/module.yml
@@ -15,6 +15,6 @@ example: |
   disable-init: false # Optional - Default: false - Expects type: boolean
   # Disable the timer that updates chezmoi with the interval set above
   disable-update: false # Optional - Default: false - Expects type: boolean
-  # Policy for handling file that has changed on disk compared to your repo. Accepts "skip" or "replace"
-  changed-file-policy: "skip" # Optional - Default: "skip" - Expects type: string
+  # What to do when file different that exists on your repo is has been changed or exists locally. Accepts "skip" or "replace"
+  file-conflict-policy: "skip" # Optional - Default: "skip" - Expects type: string
 

--- a/modules/chezmoi/module.yml
+++ b/modules/chezmoi/module.yml
@@ -3,8 +3,6 @@ shortdesc: The chezmoi module installs the latest chezmoi release at build time,
 readme: https://raw.githubusercontent.com/blue-build/modules/main/modules/chezmoi/README.md
 example: |
   type: chezmoi
-  # Installs chezmoi to /usr/bin/chezmoi from latest Github release
-  install-chezmoi: true # Optional - Default: true  - Expects type: boolean
   # Git repository to initialize
   repository: "https://example.org/user/dotfiles" # Required - Default: n/a  - Expects type: string
   # Whether to enable the modules services globally for all users, if false users need to enable services manually


### PR DESCRIPTION
this apparently was just a documentation problem, not an actual issue