### PR TITLE
fix(gnome-extensions): Fly-Pie extension not working

### DIFF
--- a/modules/gnome-extensions/gnome-extensions.sh
+++ b/modules/gnome-extensions/gnome-extensions.sh
@@ -82,8 +82,19 @@ if [[ ${#INSTALL[@]} -gt 0 ]]; then
       # Install schema
       if [[ -d "${TMP_DIR}/schemas" ]]; then
         echo "Installing schema extension file"
-        install -d -m 0755 "/usr/share/glib-2.0/schemas/"
-        install -D -p -m 0644 "${TMP_DIR}/schemas/"*.gschema.xml "/usr/share/glib-2.0/schemas/"
+        # Workaround for extensions, which explicitly require compiled schema to be in extension UUID directory (rare scenario due to how extension is programmed in non-standard way)
+        # Error code example:
+        # GLib.FileError: Failed to open file “/usr/share/gnome-shell/extensions/flypie@schneegans.github.com/schemas/gschemas.compiled”: open() failed: No such file or directory
+        # If any extension produces this error, it can be added in if statement below to solve the problem
+        if [[ "${INSTALL_EXT}" == "Fly-Pie" ]]; then
+          install -d -m 0755 "/usr/share/gnome-shell/extensions/${EXT_UUID}/schemas/"        
+          install -D -p -m 0644 "${TMP_DIR}/schemas/"*.gschema.xml "/usr/share/gnome-shell/extensions/${EXT_UUID}/schemas/"
+          install -D -p -m 0644 "${TMP_DIR}/schemas/gschemas.compiled" "/usr/share/gnome-shell/extensions/${EXT_UUID}/schemas/"
+        else
+          # Regular schema installation
+          install -d -m 0755 "/usr/share/glib-2.0/schemas/"
+          install -D -p -m 0644 "${TMP_DIR}/schemas/"*.gschema.xml "/usr/share/glib-2.0/schemas/"
+        fi  
       fi  
       # Install languages
       # Locale is not crucial for extensions to work, as they will fallback to gschema.xml
@@ -146,8 +157,19 @@ if [[ ${#INSTALL[@]} -gt 0 ]] && ! "${LEGACY}"; then
       # Install schema
       if [[ -d "${TMP_DIR}/schemas" ]]; then
         echo "Installing schema extension file"
-        install -d -m 0755 "/usr/share/glib-2.0/schemas/"
-        install -D -p -m 0644 "${TMP_DIR}/schemas/"*.gschema.xml "/usr/share/glib-2.0/schemas/"
+        # Workaround for extensions, which explicitly require compiled schema to be in extension UUID directory (rare scenario due to how extension is programmed in non-standard way)
+        # Error code example:
+        # GLib.FileError: Failed to open file “/usr/share/gnome-shell/extensions/flypie@schneegans.github.com/schemas/gschemas.compiled”: open() failed: No such file or directory
+        # If any extension produces this error, it can be added in if statement below to solve the problem
+        if [[ "${INSTALL_EXT}" == "Fly-Pie" ]]; then
+          install -d -m 0755 "/usr/share/gnome-shell/extensions/${EXT_UUID}/schemas/"
+          install -D -p -m 0644 "${TMP_DIR}/schemas/"*.gschema.xml "/usr/share/gnome-shell/extensions/${EXT_UUID}/schemas/"
+          install -D -p -m 0644 "${TMP_DIR}/schemas/gschemas.compiled" "/usr/share/gnome-shell/extensions/${EXT_UUID}/schemas/"
+        else
+          # Regular schema installation
+          install -d -m 0755 "/usr/share/glib-2.0/schemas/"
+          install -D -p -m 0644 "${TMP_DIR}/schemas/"*.gschema.xml "/usr/share/glib-2.0/schemas/"
+        fi  
       fi  
       # Install languages
       # Locale is not crucial for extensions to work, as they will fallback to gschema.xml


### PR DESCRIPTION
It requires hard-coded compiled schema to be in extension UUID folder, else it fails.

This is a rare scenario, since extension shouldn't have hard-coded schema location by itself. It should respect Gnome extension standards of schema location.

If there is any other extension which produces error like this:
`GLib.FileError: Failed to open file “/usr/share/gnome-shell/extensions/flypie@schneegans.github.com/schemas/gschemas.compiled”: open() failed: No such file or directory`

Than it's very easy to add it to this workaround list.