### PR TITLE
fix(gnome-extensions): Fix workaround for Fly-Pie

### DIFF
--- a/modules/gnome-extensions/gnome-extensions.sh
+++ b/modules/gnome-extensions/gnome-extensions.sh
@@ -86,7 +86,7 @@ if [[ ${#INSTALL[@]} -gt 0 ]]; then
         # Error code example:
         # GLib.FileError: Failed to open file “/usr/share/gnome-shell/extensions/flypie@schneegans.github.com/schemas/gschemas.compiled”: open() failed: No such file or directory
         # If any extension produces this error, it can be added in if statement below to solve the problem
-        if [[ "${INSTALL_EXT}" == "Fly-Pie" ]]; then
+        if [[ "${EXTENSION_NAME}" == "Fly-Pie" ]]; then
           install -d -m 0755 "/usr/share/gnome-shell/extensions/${EXT_UUID}/schemas/"        
           install -D -p -m 0644 "${TMP_DIR}/schemas/"*.gschema.xml "/usr/share/gnome-shell/extensions/${EXT_UUID}/schemas/"
           glib-compile-schemas "/usr/share/gnome-shell/extensions/${EXT_UUID}/schemas/" &>/dev/null

--- a/modules/gnome-extensions/gnome-extensions.sh
+++ b/modules/gnome-extensions/gnome-extensions.sh
@@ -87,9 +87,9 @@ if [[ ${#INSTALL[@]} -gt 0 ]]; then
         # GLib.FileError: Failed to open file “/usr/share/gnome-shell/extensions/flypie@schneegans.github.com/schemas/gschemas.compiled”: open() failed: No such file or directory
         # If any extension produces this error, it can be added in if statement below to solve the problem
         if [[ "${EXTENSION_NAME}" == "Fly-Pie" ]]; then
-          install -d -m 0755 "/usr/share/gnome-shell/extensions/${EXT_UUID}/schemas/"        
-          install -D -p -m 0644 "${TMP_DIR}/schemas/"*.gschema.xml "/usr/share/gnome-shell/extensions/${EXT_UUID}/schemas/"
-          glib-compile-schemas "/usr/share/gnome-shell/extensions/${EXT_UUID}/schemas/" &>/dev/null
+          install -d -m 0755 "/usr/share/gnome-shell/extensions/${UUID}/schemas/"
+          install -D -p -m 0644 "${TMP_DIR}/schemas/"*.gschema.xml "/usr/share/gnome-shell/extensions/${UUID}/schemas/"
+          glib-compile-schemas "/usr/share/gnome-shell/extensions/${UUID}/schemas/" &>/dev/null
         else
           # Regular schema installation
           install -d -m 0755 "/usr/share/glib-2.0/schemas/"


### PR DESCRIPTION
INSTALL_EXT and EXT_UUID are undefined in legacy config logic, but EXTENSION_NAME and UUID are defined there. This PR fixes this error: https://github.com/blue-build/modules/issues/243#issuecomment-2143625704