### PR TITLE
feat(gnome-extensions): Add PK ID recipe input support

### DIFF
--- a/modules/gnome-extensions/README.md
+++ b/modules/gnome-extensions/README.md
@@ -1,7 +1,7 @@
 # `gnome-extensions`
 
 :::caution
-The legacy configuration formats are still supported. Those include module inputs in part-of-URL format (with `.v` as the final version suffix with numbers) & literal extension name format. However, it is advised to migrate to new configuration, since it offers some benefits. For part-of-URL legacy config, benefit is automatic installation of the latest extension version compatible with the GNOME version in the image. For literal name legacy config, additional benefit is the better reliability of installing extensions, since collision with same-named extensions are avoided. The new configuration format is showcased below in detail.
+The legacy configuration format, which uses a part of the extension download URL to declare extensions to install, is still supported. However, it is advised to migrate to new configuration, since it offers the benefits of a clearer configuration and automatic installation of the latest extension version compatible with the GNOME version in the image. The new configuration format is showcased below in detail.
 :::
 
 The `gnome-extensions` module can be used to install Gnome extensions inside system directory.  
@@ -15,8 +15,8 @@ Thanks to https://extensions.gnome.org which provides releases of extensions as 
 
 What does this module do?  
 - It checks the current Gnome version of your image
-- It parses the extension PK ID input from module recipe file
-- It processes the jsquery from https://extensions.gnome.org using the extension PK ID input,  
+- It parses the extension name input from module recipe file
+- It processes the jsquery from https://extensions.gnome.org using the extension name input,  
   which contains useful info about latest extension version compatible with Gnome version of your image 
 - Download archive URL is formed based on the info above  
 - Downloaded extension archive is then extracted to temporary directory
@@ -34,13 +34,11 @@ By default, latest extension version compatible with Gnome version of your image
 
 How to install extensions using the module:  
 1. Go to https://extensions.gnome.org or preferably [Extension Manager](https://github.com/mjakeman/extension-manager) application
-2. Search for the extension that you want to install & open its extension page
+2. Search for the extension that you want to install and open its extension page
 3. If browsing through https://extensions.gnome.org, select the correct GNOME shell version, which matches the GNOME shell version of your image
    - The command `gnome-shell --version` can be used to get the GNOME version of a running system.
    If there is no GNOME shell version of the extension that matches the GNOME version of your image, that means that extension is not compatible
-4. Copy the extension PK ID (which is always in numbers) as part of the URL of the extension (in Extension Manager, "View in Extensions" card shows the URL):  
-https://extensions.gnome.org/extension/PK-ID/extension-name/
-5. Input the PK ID in module recipe
+4. Copy the extension name & input it in module recipe (it is case-sensitive, so be sure that you copied it correctly)
 
 An extension might need additional system dependencies in order to function.  
 In that case, you should install the required dependencies before the `gnome-extensions` module is ran.  
@@ -56,29 +54,4 @@ However, if extensions in the base image are installed through OS package manage
 How to uninstall extensions using the module:  
 1. Go to Gnome Extensions app, https://extensions.gnome.org/local/ or [Extension Manager](https://github.com/mjakeman/extension-manager) application
 2. List of installed system extensions should be presented
-3. Extension Manager:  
-      - Click installed system extension drop-down  
-      - Click "See Details"  
-      - You will notice the "View on Extensions" card, which has extension URL  
-      - Copy the extension PK ID (which is always in numbers) as part of the URL of the extension:  
-         https://extensions.gnome.org/extension/PK-ID/extension-name/
-  
-    Gnome Extensions / extensions.gnome.org website:  
-      - Go to https://extensions.gnome.org  
-      - Search for the extension that you want to uninstall & open its extension page  
-      - Copy the extension PK ID (which is always in numbers) as part of the URL of the extension:  
-         https://extensions.gnome.org/extension/PK-ID/extension-name/
-4. Input the PK ID in module recipe
-
-## Known issues
-  
-### Some extensions complain about missing gschema.compiled file
-
-This is a rarity, but some extensions might complain about this one, due to the way they are programmed with hard-coded gschema locations.  
-Most extensions which follow Gnome extension standards don't have this issue.
-
-If you get the error similar to this one (Fly-Pie extension example):  
-`GLib.FileError: Failed to open file “/usr/share/gnome-shell/extensions/flypie@schneegans.github.com/schemas/gschemas.compiled”: open() failed: No such file or directory`
-
-Then please open the issue in BlueBuild Modules GitHub repo with the affecting extension, as it's trivial to fix.  
-https://github.com/blue-build/modules/issues/new
+3. Copy the extension name & input it in module recipe (it is case-sensitive, so be sure that you copied it correctly)

--- a/modules/gnome-extensions/README.md
+++ b/modules/gnome-extensions/README.md
@@ -1,7 +1,7 @@
 # `gnome-extensions`
 
 :::caution
-The legacy configuration format, which uses a part of the extension download URL to declare extensions to install, is still supported. However, it is advised to migrate to new configuration, since it offers the benefits of a clearer configuration and automatic installation of the latest extension version compatible with the GNOME version in the image. The new configuration format is showcased below in detail.
+The legacy configuration format, which uses a part of the extension download URL to declare extensions to install, is still supported. However, it is advised to migrate to new configuration, since it offers the benefits of a clearer configuration & automatic installation of the latest extension version compatible with the GNOME version in the image. The new configuration format is showcased below in detail.
 :::
 
 The `gnome-extensions` module can be used to install Gnome extensions inside system directory.  
@@ -55,3 +55,16 @@ How to uninstall extensions using the module:
 1. Go to Gnome Extensions app, https://extensions.gnome.org/local/ or [Extension Manager](https://github.com/mjakeman/extension-manager) application
 2. List of installed system extensions should be presented
 3. Copy the extension name & input it in module recipe (it is case-sensitive, so be sure that you copied it correctly)
+
+## Known issues
+  
+### Some extensions complain about missing gschema.compiled file
+
+This is a rarity, but some extensions might complain about this one, due to the way they are programmed with hard-coded gschema locations.  
+Most extensions which follow Gnome extension standards don't have this issue.
+
+If you get the error similar to this one (Fly-Pie extension example):  
+`GLib.FileError: Failed to open file “/usr/share/gnome-shell/extensions/flypie@schneegans.github.com/schemas/gschemas.compiled”: open() failed: No such file or directory`
+
+Then please open the issue in BlueBuild Modules GitHub repo with the affecting extension, as it's trivial to fix.  
+https://github.com/blue-build/modules/issues/new

--- a/modules/gnome-extensions/README.md
+++ b/modules/gnome-extensions/README.md
@@ -55,3 +55,27 @@ How to uninstall extensions using the module:
 1. Go to Gnome Extensions app, https://extensions.gnome.org/local/ or [Extension Manager](https://github.com/mjakeman/extension-manager) application
 2. List of installed system extensions should be presented
 3. Copy the extension name & input it in module recipe (it is case-sensitive, so be sure that you copied it correctly)
+
+## Known issues
+
+###Multiple compatible Gnome extensions with the same name are not supported
+
+For example,  
+Your custom image is on Gnome 46.  
+You want to install extension named "Titler"  
+You find out there are 2 "Titler" extensions, where both of them are compatible with Gnome 46.  
+In this case, extension will fail with the message:  
+`Multiple compatible Gnome extensions with the same name are found, which this module cannot select`
+  
+If there are multiple extensions with the same name, but only 1 is compatible with the Gnome 46, then it won't fail & it will install that one.
+  
+### Some extensions complain about missing gschema.compiled file
+
+This is a rarity, but some extensions might complain about this one, due to the way they are programmed with hard-coded gschema locations.  
+Most extensions which follow Gnome extension standards don't have this issue.
+
+If you get the error similar to this one (Fly-Pie extension example):  
+`GLib.FileError: Failed to open file “/usr/share/gnome-shell/extensions/flypie@schneegans.github.com/schemas/gschemas.compiled”: open() failed: No such file or directory`
+
+Then please open the issue with the affecting extension, as it's trivial to fix.  
+https://github.com/blue-build/modules/issues/new

--- a/modules/gnome-extensions/README.md
+++ b/modules/gnome-extensions/README.md
@@ -58,7 +58,7 @@ How to uninstall extensions using the module:
 
 ## Known issues
 
-###Multiple compatible Gnome extensions with the same name are not supported
+### Multiple compatible Gnome extensions with the same name are not supported
 
 For example,  
 Your custom image is on Gnome 46.  

--- a/modules/gnome-extensions/README.md
+++ b/modules/gnome-extensions/README.md
@@ -1,7 +1,7 @@
 # `gnome-extensions`
 
 :::caution
-The legacy configuration format, which uses a part of the extension download URL to declare extensions to install, is still supported. However, it is advised to migrate to new configuration, since it offers the benefits of a clearer configuration and automatic installation of the latest extension version compatible with the GNOME version in the image. The new configuration format is showcased below in detail.
+The legacy configuration formats are still supported. Those include module inputs in part-of-URL format (with `.v` as the final version suffix with numbers) & literal extension name format. However, it is advised to migrate to new configuration, since it offers some benefits. For part-of-URL legacy config, benefits are clearer configuration & automatic installation of the latest extension version compatible with the GNOME version in the image. For literal name legacy config, additional benefit is the better reliability of installing extensions, since collision with same-named extensions are avoided. The new configuration format is showcased below in detail.
 :::
 
 The `gnome-extensions` module can be used to install Gnome extensions inside system directory.  
@@ -15,8 +15,8 @@ Thanks to https://extensions.gnome.org which provides releases of extensions as 
 
 What does this module do?  
 - It checks the current Gnome version of your image
-- It parses the extension name input from module recipe file
-- It processes the jsquery from https://extensions.gnome.org using the extension name input,  
+- It parses the extension PK ID input from module recipe file
+- It processes the jsquery from https://extensions.gnome.org using the extension PK ID input,  
   which contains useful info about latest extension version compatible with Gnome version of your image 
 - Download archive URL is formed based on the info above  
 - Downloaded extension archive is then extracted to temporary directory
@@ -34,11 +34,13 @@ By default, latest extension version compatible with Gnome version of your image
 
 How to install extensions using the module:  
 1. Go to https://extensions.gnome.org or preferably [Extension Manager](https://github.com/mjakeman/extension-manager) application
-2. Search for the extension that you want to install and open its extension page
+2. Search for the extension that you want to install & open its extension page
 3. If browsing through https://extensions.gnome.org, select the correct GNOME shell version, which matches the GNOME shell version of your image
    - The command `gnome-shell --version` can be used to get the GNOME version of a running system.
    If there is no GNOME shell version of the extension that matches the GNOME version of your image, that means that extension is not compatible
-4. Copy the extension name & input it in module recipe (it is case-sensitive, so be sure that you copied it correctly)
+4. Copy the extension PK ID (which is always in numbers) as part of the URL of the extension (in Extension Manager, "View in Extensions" card shows the URL):  
+https://extensions.gnome.org/extension/PK-ID/extension-name/
+5. Input the PK ID in module recipe
 
 An extension might need additional system dependencies in order to function.  
 In that case, you should install the required dependencies before the `gnome-extensions` module is ran.  
@@ -54,20 +56,20 @@ However, if extensions in the base image are installed through OS package manage
 How to uninstall extensions using the module:  
 1. Go to Gnome Extensions app, https://extensions.gnome.org/local/ or [Extension Manager](https://github.com/mjakeman/extension-manager) application
 2. List of installed system extensions should be presented
-3. Copy the extension name & input it in module recipe (it is case-sensitive, so be sure that you copied it correctly)
+3. Extension Manager:  
+      - Click installed system extension drop-down  
+      - Click "See Details"  
+      - You will notice the "View on Extensions" card, which has extension URL  
+      - Copy the extension PK ID (which is always in numbers) as part of the URL of the extension:  
+         https://extensions.gnome.org/extension/PK-ID/extension-name/      
+    Gnome Extensions / extensions.gnome.org website:  
+      - Go to https://extensions.gnome.org  
+      - Search for the extension that you want to uninstall & open its extension page  
+      - Copy the extension PK ID (which is always in numbers) as part of the URL of the extension:  
+         https://extensions.gnome.org/extension/PK-ID/extension-name/
+4. Input the PK ID in module recipe
 
 ## Known issues
-
-### Multiple compatible Gnome extensions with the same name are not supported
-
-For example,  
-Your custom image is on Gnome 46.  
-You want to install extension named "Titler"  
-You find out there are 2 "Titler" extensions, where both of them are compatible with Gnome 46.  
-In this case, extension will fail with the message:  
-`Multiple compatible Gnome extensions with the same name are found, which this module cannot select`
-  
-If there are multiple extensions with the same name, but only 1 is compatible with the Gnome 46, then it won't fail & it will install that one.
   
 ### Some extensions complain about missing gschema.compiled file
 

--- a/modules/gnome-extensions/README.md
+++ b/modules/gnome-extensions/README.md
@@ -1,7 +1,7 @@
 # `gnome-extensions`
 
 :::caution
-The legacy configuration formats are still supported. Those include module inputs in part-of-URL format (with `.v` as the final version suffix with numbers) & literal extension name format. However, it is advised to migrate to new configuration, since it offers some benefits. For part-of-URL legacy config, benefits are clearer configuration & automatic installation of the latest extension version compatible with the GNOME version in the image. For literal name legacy config, additional benefit is the better reliability of installing extensions, since collision with same-named extensions are avoided. The new configuration format is showcased below in detail.
+The legacy configuration formats are still supported. Those include module inputs in part-of-URL format (with `.v` as the final version suffix with numbers) & literal extension name format. However, it is advised to migrate to new configuration, since it offers some benefits. For part-of-URL legacy config, benefit is automatic installation of the latest extension version compatible with the GNOME version in the image. For literal name legacy config, additional benefit is the better reliability of installing extensions, since collision with same-named extensions are avoided. The new configuration format is showcased below in detail.
 :::
 
 The `gnome-extensions` module can be used to install Gnome extensions inside system directory.  

--- a/modules/gnome-extensions/README.md
+++ b/modules/gnome-extensions/README.md
@@ -61,7 +61,8 @@ How to uninstall extensions using the module:
       - Click "See Details"  
       - You will notice the "View on Extensions" card, which has extension URL  
       - Copy the extension PK ID (which is always in numbers) as part of the URL of the extension:  
-         https://extensions.gnome.org/extension/PK-ID/extension-name/      
+         https://extensions.gnome.org/extension/PK-ID/extension-name/
+  
     Gnome Extensions / extensions.gnome.org website:  
       - Go to https://extensions.gnome.org  
       - Search for the extension that you want to uninstall & open its extension page  

--- a/modules/gnome-extensions/README.md
+++ b/modules/gnome-extensions/README.md
@@ -77,5 +77,5 @@ Most extensions which follow Gnome extension standards don't have this issue.
 If you get the error similar to this one (Fly-Pie extension example):  
 `GLib.FileError: Failed to open file “/usr/share/gnome-shell/extensions/flypie@schneegans.github.com/schemas/gschemas.compiled”: open() failed: No such file or directory`
 
-Then please open the issue with the affecting extension, as it's trivial to fix.  
+Then please open the issue in BlueBuild Modules GitHub repo with the affecting extension, as it's trivial to fix.  
 https://github.com/blue-build/modules/issues/new

--- a/modules/gnome-extensions/gnome-extensions.sh
+++ b/modules/gnome-extensions/gnome-extensions.sh
@@ -87,7 +87,8 @@ if [[ ${#INSTALL[@]} -gt 0 ]]; then
         # Error code example:
         # GLib.FileError: Failed to open file “/usr/share/gnome-shell/extensions/flypie@schneegans.github.com/schemas/gschemas.compiled”: open() failed: No such file or directory
         # If any extension produces this error, it can be added in if statement below to solve the problem
-        if [[ "${EXTENSION_NAME}" == "Fly-Pie" ]]; then
+        # Fly-Pie
+        if [[ "${UUID}" == "flypie@schneegans.github.com" ]]; then
           install -d -m 0755 "/usr/share/gnome-shell/extensions/${UUID}/schemas/"
           install -D -p -m 0644 "${TMP_DIR}/schemas/"*.gschema.xml "/usr/share/gnome-shell/extensions/${UUID}/schemas/"
           glib-compile-schemas "/usr/share/gnome-shell/extensions/${UUID}/schemas/" &>/dev/null
@@ -190,7 +191,8 @@ if [[ ${#INSTALL[@]} -gt 0 ]] && ! "${LEGACY}"; then
         # Error code example:
         # GLib.FileError: Failed to open file “/usr/share/gnome-shell/extensions/flypie@schneegans.github.com/schemas/gschemas.compiled”: open() failed: No such file or directory
         # If any extension produces this error, it can be added in if statement below to solve the problem
-        if [[ "${INSTALL_EXT}" == "Fly-Pie" ]]; then
+        # Fly-Pie
+        if [[ "${EXT_UUID}" == "flypie@schneegans.github.com" ]]; then
           install -d -m 0755 "/usr/share/gnome-shell/extensions/${EXT_UUID}/schemas/"
           install -D -p -m 0644 "${TMP_DIR}/schemas/"*.gschema.xml "/usr/share/gnome-shell/extensions/${EXT_UUID}/schemas/"
           glib-compile-schemas "/usr/share/gnome-shell/extensions/${EXT_UUID}/schemas/" &>/dev/null

--- a/modules/gnome-extensions/gnome-extensions.sh
+++ b/modules/gnome-extensions/gnome-extensions.sh
@@ -114,7 +114,7 @@ if [[ ${#INSTALL[@]} -gt 0 ]]; then
 fi
 
 # Legacy support for installing extensions through literal extension names, to retain compatibility with legacy configs
-if [[ ${#INSTALL[@]} -gt 0 ]]; then
+if [[ ${#INSTALL[@]} -gt 0 ]] && ! "${LEGACY}"; then
   for INSTALL_EXT in "${INSTALL[@]}"; do
   # If extension input contains numbers only (PK), then break the loop
       if [[ "${INSTALL_EXT}" =~ ^[0-9]+$ ]]; then

--- a/modules/gnome-extensions/gnome-extensions.sh
+++ b/modules/gnome-extensions/gnome-extensions.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# shellcheck disable=SC2128
+# shellcheck disable=SC2128,SC2178
 
 # Tell build process to exit if there are any errors.
 set -euo pipefail

--- a/modules/gnome-extensions/gnome-extensions.sh
+++ b/modules/gnome-extensions/gnome-extensions.sh
@@ -212,7 +212,7 @@ if [[ ${#INSTALL[@]} -gt 0 ]] && ! "${LEGACY}"; then
   for INSTALL_EXT in "${INSTALL[@]}"; do
       URL_QUERY=$(curl -s "https://extensions.gnome.org/extension-info/?pk=${INSTALL_EXT}")
       PK_EXT=$(echo "${URL_QUERY}" | jq -r '.["pk"]' 2>/dev/null)
-      if [[ -z "${PK_EXT}" ]]; then
+      if [[ -z "${PK_EXT}" ]] || [[ "${PK_EXT}" == "null" ]]; then
         echo "ERROR: Extension with PK ID '${INSTALL_EXT}' does not exist in https://extensions.gnome.org/ website"
         echo "       Please assure that you typed the PK ID correctly,"
         echo "       and that it exists in Gnome extensions website"
@@ -222,7 +222,7 @@ if [[ ${#INSTALL[@]} -gt 0 ]] && ! "${LEGACY}"; then
       EXT_NAME=$(echo "${URL_QUERY}" | jq -r '.["name"]')
       SUITABLE_VERSION=$(echo "${URL_QUERY}" | jq ".shell_version_map[\"${GNOME_VER}\"].version")
       # Fail the build if extension is not compatible with the current Gnome version
-      if [[ -z "${SUITABLE_VERSION}" ]]; then
+      if [[ -z "${SUITABLE_VERSION}" ]] || [[ "${SUITABLE_VERSION}" == "null" ]]; then
         echo "ERROR: Extension '${EXT_NAME}' is not compatible with Gnome v${GNOME_VER} in your image"
         exit 1
       fi

--- a/modules/gnome-extensions/gnome-extensions.sh
+++ b/modules/gnome-extensions/gnome-extensions.sh
@@ -211,7 +211,7 @@ fi
 if [[ ${#INSTALL[@]} -gt 0 ]] && ! "${LEGACY}"; then
   for INSTALL_EXT in "${INSTALL[@]}"; do
       URL_QUERY=$(curl -s "https://extensions.gnome.org/extension-info/?pk=${INSTALL_EXT}")
-      EXT_PK=$(echo "${URL_QUERY}" | jq -r '.["pk"]' 2>/dev/null)
+      PK_EXT=$(echo "${URL_QUERY}" | jq -r '.["pk"]' 2>/dev/null)
       if [[ -z "${PK_EXT}" ]]; then
         echo "ERROR: Extension with PK ID '${INSTALL_EXT}' does not exist in https://extensions.gnome.org/ website"
         echo "       Please assure that you typed the PK ID correctly,"

--- a/modules/gnome-extensions/gnome-extensions.sh
+++ b/modules/gnome-extensions/gnome-extensions.sh
@@ -131,10 +131,9 @@ if [[ ${#INSTALL[@]} -gt 0 ]] && ! "${LEGACY}"; then
       QUERIED_EXT=$(echo "${URL_QUERY}" | jq ".extensions[] | select(.name == \"${INSTALL_EXT}\")")
       readarray -t EXT_UUID < <(echo "${QUERIED_EXT}" | jq -r '.["uuid"]')
       readarray -t EXT_NAME < <(echo "${QUERIED_EXT}" | jq -r '.["name"]')
-      # Gets suitable extension version for Gnome version from the image
-      SUITABLE_VERSION=$(echo "${QUERIED_EXT}" | jq ".shell_version_map[\"${GNOME_VER}\"].version")
-      if [[ "${SUITABLE_VERSION}" == "null" ]] || [[ -z "${QUERIED_EXT}" ]]; then
-        echo "ERROR: Extension '${EXT_NAME}' is not compatible with Gnome v${GNOME_VER} in your image"
+      # Fail the build if extension is not compatible with the current Gnome version
+      if [[ -z "${QUERIED_EXT}" ]]; then
+        echo "ERROR: Extension '${INSTALL_EXT}' is not compatible with Gnome v${GNOME_VER} in your image"
         exit 1
       fi
       # If multiple extensions with same name exist, which are compatible with the current Gnome version, then error out the build
@@ -142,6 +141,8 @@ if [[ ${#INSTALL[@]} -gt 0 ]] && ! "${LEGACY}"; then
         echo "Multiple compatible Gnome extensions with the same name are found, which this module cannot select"
         exit 1
       fi
+      # Gets suitable extension version for Gnome version from the image
+      SUITABLE_VERSION=$(echo "${QUERIED_EXT}" | jq ".shell_version_map[\"${GNOME_VER}\"].version")
       # Removes every @ symbol from UUID, since extension URL doesn't contain @ symbol
       URL="https://extensions.gnome.org/extension-data/${EXT_UUID//@/}.v${SUITABLE_VERSION}.shell-extension.zip"
       TMP_DIR="/tmp/${EXT_UUID}"

--- a/modules/gnome-extensions/gnome-extensions.sh
+++ b/modules/gnome-extensions/gnome-extensions.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# shellcheck disable=SC2128
 
 # Tell build process to exit if there are any errors.
 set -euo pipefail

--- a/modules/gnome-extensions/gnome-extensions.sh
+++ b/modules/gnome-extensions/gnome-extensions.sh
@@ -20,7 +20,7 @@ GNOME_VER=$(gnome-shell --version | sed 's/[^0-9]*\([0-9]*\).*/\1/')
 echo "Gnome version: ${GNOME_VER}"
 LEGACY=false
 
-# Legacy support for installing extensions, to retain compatibility with legacy configs
+# Legacy support for installing extensions through part of extension URL, to retain compatibility with legacy configs
 if [[ ${#INSTALL[@]} -gt 0 ]]; then
   for EXTENSION in "${INSTALL[@]}"; do
       # If extension contains .v12 suffix at the end, than it's the legacy install entry
@@ -33,7 +33,7 @@ if [[ ${#INSTALL[@]} -gt 0 ]]; then
       fi
       shopt -u extglob
       echo "ATTENTION: This is the legacy method of installing extensions."
-      echo "           Change the install entry to literal name of the extension"
+      echo "           Change the install entry to PK ID of the extension"
       echo "           Please see the latest docs of gnome-extensions module for more details:"
       echo "           https://blue-build.org/reference/modules/gnome-extensions/"
       URL="https://extensions.gnome.org/extension-data/${EXTENSION}.shell-extension.zip"
@@ -113,9 +113,19 @@ if [[ ${#INSTALL[@]} -gt 0 ]]; then
   done
 fi
 
-# New method of installing extensions
-if [[ ${#INSTALL[@]} -gt 0 ]] && ! "${LEGACY}"; then
+# Legacy support for installing extensions through literal extension names, to retain compatibility with legacy configs
+if [[ ${#INSTALL[@]} -gt 0 ]]; then
   for INSTALL_EXT in "${INSTALL[@]}"; do
+  # If extension input contains numbers only (PK), then break the loop
+      if [[ "${INSTALL_EXT}" =~ ^[0-9]+$ ]]; then
+        break
+      else
+        LEGACY=true
+      fi
+      echo "ATTENTION: This is the legacy method of installing extensions."
+      echo "           Change the install entry to PK ID of the extension"
+      echo "           Please see the latest docs of gnome-extensions module for more details:"
+      echo "           https://blue-build.org/reference/modules/gnome-extensions/"
       # Replaces whitespaces with %20 for install entries which contain extension name, since URLs can't contain whitespace
       WHITESPACE_HTML="${INSTALL_EXT// /%20}"
       # Gathers if extension name exists
@@ -138,7 +148,7 @@ if [[ ${#INSTALL[@]} -gt 0 ]] && ! "${LEGACY}"; then
       fi
       # If multiple extensions with same name exist, which are compatible with the current Gnome version, then error out the build
       if [[ ${#EXT_UUID[@]} -gt 1 ]] || [[ ${#EXT_NAME[@]} -gt 1 ]]; then
-        echo "Multiple compatible Gnome extensions with the same name are found, which this module cannot select"
+        echo "ERROR: Multiple compatible Gnome extensions with the same name are found, which this module cannot select"
         exit 1
       fi
       # Gets suitable extension version for Gnome version from the image
@@ -171,6 +181,80 @@ if [[ ${#INSTALL[@]} -gt 0 ]] && ! "${LEGACY}"; then
         # GLib.FileError: Failed to open file “/usr/share/gnome-shell/extensions/flypie@schneegans.github.com/schemas/gschemas.compiled”: open() failed: No such file or directory
         # If any extension produces this error, it can be added in if statement below to solve the problem
         if [[ "${INSTALL_EXT}" == "Fly-Pie" ]]; then
+          install -d -m 0755 "/usr/share/gnome-shell/extensions/${EXT_UUID}/schemas/"
+          install -D -p -m 0644 "${TMP_DIR}/schemas/"*.gschema.xml "/usr/share/gnome-shell/extensions/${EXT_UUID}/schemas/"
+          glib-compile-schemas "/usr/share/gnome-shell/extensions/${EXT_UUID}/schemas/" &>/dev/null
+        else
+          # Regular schema installation
+          install -d -m 0755 "/usr/share/glib-2.0/schemas/"
+          install -D -p -m 0644 "${TMP_DIR}/schemas/"*.gschema.xml "/usr/share/glib-2.0/schemas/"
+        fi  
+      fi  
+      # Install languages
+      # Locale is not crucial for extensions to work, as they will fallback to gschema.xml
+      # Some of them might not have any locale at the moment
+      # So that's why I made a check for directory
+      if [[ -d "${TMP_DIR}/locale" ]]; then
+        echo "Installing language extension files"
+        install -d -m 0755 "/usr/share/locale/"
+        cp -r "${TMP_DIR}/locale"/* "/usr/share/locale/"
+      fi  
+      # Delete the temporary directory
+      echo "Cleaning up the temporary directory"
+      rm -r "${TMP_DIR}"
+      echo "Extension '${EXT_NAME}' is successfully installed"
+      echo "----------------------------------INSTALLATION DONE----------------------------------"
+  done
+fi
+
+# New method of installing extensions through PK ID
+if [[ ${#INSTALL[@]} -gt 0 ]] && ! "${LEGACY}"; then
+  for INSTALL_EXT in "${INSTALL[@]}"; do
+      URL_QUERY=$(curl -s "https://extensions.gnome.org/extension-info/?pk=${INSTALL_EXT}")
+      EXT_PK=$(echo "${URL_QUERY}" | jq -r '.["pk"]' 2>/dev/null)
+      if [[ -z "${PK_EXT}" ]]; then
+        echo "ERROR: Extension with PK ID '${INSTALL_EXT}' does not exist in https://extensions.gnome.org/ website"
+        echo "       Please assure that you typed the PK ID correctly,"
+        echo "       and that it exists in Gnome extensions website"
+        exit 1
+      fi
+      EXT_UUID=$(echo "${URL_QUERY}" | jq -r '.["uuid"]')
+      EXT_NAME=$(echo "${URL_QUERY}" | jq -r '.["name"]')
+      SUITABLE_VERSION=$(echo "${URL_QUERY}" | jq ".shell_version_map[\"${GNOME_VER}\"].version")
+      # Fail the build if extension is not compatible with the current Gnome version
+      if [[ -z "${SUITABLE_VERSION}" ]]; then
+        echo "ERROR: Extension '${EXT_NAME}' is not compatible with Gnome v${GNOME_VER} in your image"
+        exit 1
+      fi
+      # Removes every @ symbol from UUID, since extension URL doesn't contain @ symbol
+      URL="https://extensions.gnome.org/extension-data/${EXT_UUID//@/}.v${SUITABLE_VERSION}.shell-extension.zip"
+      TMP_DIR="/tmp/${EXT_UUID}"
+      ARCHIVE=$(basename "${URL}")
+      ARCHIVE_DIR="${TMP_DIR}/${ARCHIVE}"
+      echo "Installing '${EXT_NAME}' Gnome extension with version ${SUITABLE_VERSION}"
+      # Download archive
+      wget --directory-prefix="${TMP_DIR}" "${URL}"
+      # Extract archive
+      echo "Extracting ZIP archive"
+      unzip "${ARCHIVE_DIR}" -d "${TMP_DIR}" > /dev/null
+      # Remove archive
+      echo "Removing archive"
+      rm "${ARCHIVE_DIR}"
+      # Install main extension files
+      echo "Installing main extension files"
+      install -d -m 0755 "/usr/share/gnome-shell/extensions/${EXT_UUID}/"
+      find "${TMP_DIR}" -mindepth 1 -maxdepth 1 ! -path "*locale*" ! -path "*schemas*" -exec cp -r {} "/usr/share/gnome-shell/extensions/${EXT_UUID}/" \;
+      find "/usr/share/gnome-shell/extensions/${EXT_UUID}" -type d -exec chmod 0755 {} +
+      find "/usr/share/gnome-shell/extensions/${EXT_UUID}" -type f -exec chmod 0644 {} +
+      # Install schema
+      if [[ -d "${TMP_DIR}/schemas" ]]; then
+        echo "Installing schema extension file"
+        # Workaround for extensions, which explicitly require compiled schema to be in extension UUID directory (rare scenario due to how extension is programmed in non-standard way)
+        # Error code example:
+        # GLib.FileError: Failed to open file “/usr/share/gnome-shell/extensions/flypie@schneegans.github.com/schemas/gschemas.compiled”: open() failed: No such file or directory
+        # If any extension produces this error, PK ID of it can be added in if statement below to solve the problem
+        # 3433 = Fly-Pie
+        if [[ "${INSTALL_EXT}" == "3433" ]]; then
           install -d -m 0755 "/usr/share/gnome-shell/extensions/${EXT_UUID}/schemas/"
           install -D -p -m 0644 "${TMP_DIR}/schemas/"*.gschema.xml "/usr/share/gnome-shell/extensions/${EXT_UUID}/schemas/"
           glib-compile-schemas "/usr/share/gnome-shell/extensions/${EXT_UUID}/schemas/" &>/dev/null

--- a/modules/gnome-extensions/gnome-extensions.sh
+++ b/modules/gnome-extensions/gnome-extensions.sh
@@ -131,15 +131,15 @@ if [[ ${#INSTALL[@]} -gt 0 ]] && ! "${LEGACY}"; then
       QUERIED_EXT=$(echo "${URL_QUERY}" | jq ".extensions[] | select(.name == \"${INSTALL_EXT}\")")
       readarray -t EXT_UUID < <(echo "${QUERIED_EXT}" | jq -r '.["uuid"]')
       readarray -t EXT_NAME < <(echo "${QUERIED_EXT}" | jq -r '.["name"]')
+      # Gets suitable extension version for Gnome version from the image
+      SUITABLE_VERSION=$(echo "${QUERIED_EXT}" | jq ".shell_version_map[\"${GNOME_VER}\"].version")
+      if [[ "${SUITABLE_VERSION}" == "null" ]] || [[ -z "${QUERIED_EXT}" ]]; then
+        echo "ERROR: Extension '${EXT_NAME}' is not compatible with Gnome v${GNOME_VER} in your image"
+        exit 1
+      fi
       # If multiple extensions with same name exist, which are compatible with the current Gnome version, then error out the build
       if [[ ${#EXT_UUID[@]} -gt 1 ]] || [[ ${#EXT_NAME[@]} -gt 1 ]]; then
         echo "Multiple compatible Gnome extensions with the same name are found, which this module cannot select"
-        exit 1
-      fi
-      # Gets suitable extension version for Gnome version from the image
-      SUITABLE_VERSION=$(echo "${QUERIED_EXT}" | jq ".shell_version_map[\"${GNOME_VER}\"].version")
-      if [[ "${SUITABLE_VERSION}" == "null" ]]; then
-        echo "ERROR: Extension '${EXT_NAME}' is not compatible with Gnome v${GNOME_VER} in your image"
         exit 1
       fi
       # Removes every @ symbol from UUID, since extension URL doesn't contain @ symbol

--- a/modules/gnome-extensions/gnome-extensions.sh
+++ b/modules/gnome-extensions/gnome-extensions.sh
@@ -116,24 +116,52 @@ fi
 # New method of installing extensions
 if [[ ${#INSTALL[@]} -gt 0 ]] && ! "${LEGACY}"; then
   for INSTALL_EXT in "${INSTALL[@]}"; do
-      # Replaces whitespaces with %20 for install entries which contain extension name, since URLs can't contain whitespace
-      WHITESPACE_HTML="${INSTALL_EXT// /%20}"
-      URL_QUERY=$(curl -s "https://extensions.gnome.org/extension-query/?search=${WHITESPACE_HTML}")
-      QUERIED_EXT=$(echo "${URL_QUERY}" | jq ".extensions[] | select(.name == \"${INSTALL_EXT}\")")
-      if [[ -z "${QUERIED_EXT}" ]]; then
-        echo "ERROR: Extension '${INSTALL_EXT}' does not exist in https://extensions.gnome.org/ website"
-        echo "       Extension name is case-sensitive, so be sure that you typed it correctly,"
-        echo "       including the correct uppercase & lowercase characters"
-        exit 1
-      fi
-      EXT_UUID=$(echo "${QUERIED_EXT}" | jq -r '.["uuid"]')
-      EXT_NAME=$(echo "${QUERIED_EXT}" | jq -r '.["name"]')
-      # Gets suitable extension version for Gnome version from the image
-      SUITABLE_VERSION=$(echo "${QUERIED_EXT}" | jq ".shell_version_map[\"${GNOME_VER}\"].version")
-      if [[ "${SUITABLE_VERSION}" == "null" ]]; then
-        echo "ERROR: Extension '${EXT_NAME}' is not compatible with Gnome v${GNOME_VER} in your image"
-        exit 1
-      fi
+      if [[ ! "${INSTALL_EXT}" =~ ^[0-9]+$ ]]; then
+        # Literal-name extension config
+        # Replaces whitespaces with %20 for install entries which contain extension name, since URLs can't contain whitespace      
+        WHITESPACE_HTML="${INSTALL_EXT// /%20}"
+        URL_QUERY=$(curl -s "https://extensions.gnome.org/extension-query/?search=${WHITESPACE_HTML}")
+        QUERIED_EXT=$(echo "${URL_QUERY}" | jq ".extensions[] | select(.name == \"${INSTALL_EXT}\")")
+        if [[ -z "${QUERIED_EXT}" ]] || [[ "${QUERIED_EXT}" == "null" ]]; then
+          echo "ERROR: Extension '${INSTALL_EXT}' does not exist in https://extensions.gnome.org/ website"
+          echo "       Extension name is case-sensitive, so be sure that you typed it correctly,"
+          echo "       including the correct uppercase & lowercase characters"
+          exit 1
+        fi
+        readarray -t EXT_UUID < <(echo "${QUERIED_EXT}" | jq -r '.["uuid"]')
+        readarray -t EXT_NAME < <(echo "${QUERIED_EXT}" | jq -r '.["name"]')
+        if [[ ${#EXT_UUID[@]} -gt 1 ]] || [[ ${#EXT_NAME[@]} -gt 1 ]]; then
+          echo "ERROR: Multiple compatible Gnome extensions with the same name are found, which this module cannot select"
+          echo "       To solve this problem, please use PK ID as a module input entry instead of the extension name"
+          echo "       You can get PK ID from the extension URL, like from Blur my Shell's 3193 PK ID example below:"
+          echo "       https://extensions.gnome.org/extension/3193/blur-my-shell/"
+          exit 1
+        fi        
+        # Gets suitable extension version for Gnome version from the image
+        SUITABLE_VERSION=$(echo "${QUERIED_EXT}" | jq ".shell_version_map[\"${GNOME_VER}\"].version")
+        if [[ -z "${SUITABLE_VERSION}" ]] || [[ "${SUITABLE_VERSION}" == "null" ]]; then
+          echo "ERROR: Extension '${EXT_NAME}' is not compatible with Gnome v${GNOME_VER} in your image"
+          exit 1
+        fi
+      else
+        # PK ID extension config fallback if specified
+        URL_QUERY=$(curl -s "https://extensions.gnome.org/extension-info/?pk=${INSTALL_EXT}")
+        PK_EXT=$(echo "${URL_QUERY}" | jq -r '.["pk"]' 2>/dev/null)
+        if [[ -z "${PK_EXT}" ]] || [[ "${PK_EXT}" == "null" ]]; then
+          echo "ERROR: Extension with PK ID '${INSTALL_EXT}' does not exist in https://extensions.gnome.org/ website"
+          echo "       Please assure that you typed the PK ID correctly,"
+          echo "       and that it exists in Gnome extensions website"
+          exit 1
+        fi
+        EXT_UUID=$(echo "${URL_QUERY}" | jq -r '.["uuid"]')
+        EXT_NAME=$(echo "${URL_QUERY}" | jq -r '.["name"]')
+        SUITABLE_VERSION=$(echo "${URL_QUERY}" | jq ".shell_version_map[\"${GNOME_VER}\"].version")
+        # Fail the build if extension is not compatible with the current Gnome version
+        if [[ -z "${SUITABLE_VERSION}" ]] || [[ "${SUITABLE_VERSION}" == "null" ]]; then
+          echo "ERROR: Extension '${EXT_NAME}' is not compatible with Gnome v${GNOME_VER} in your image"
+          exit 1
+        fi
+      fi  
       # Removes every @ symbol from UUID, since extension URL doesn't contain @ symbol
       URL="https://extensions.gnome.org/extension-data/${EXT_UUID//@/}.v${SUITABLE_VERSION}.shell-extension.zip"
       TMP_DIR="/tmp/${EXT_UUID}"
@@ -190,19 +218,34 @@ fi
 
 if [[ ${#UNINSTALL[@]} -gt 0 ]]; then
   for UNINSTALL_EXT in "${UNINSTALL[@]}"; do
-      # Replaces whitespaces with %20 for install entries which contain extension name, since URLs can't contain whitespace
-      # Getting json query from the website is useful to intuitively uninstall the extension without need to manually input UUID
-      WHITESPACE_HTML="${UNINSTALL_EXT// /%20}"
-      URL_QUERY=$(curl -s "https://extensions.gnome.org/extension-query/?search=${WHITESPACE_HTML}")
-      QUERIED_EXT=$(echo "${URL_QUERY}" | jq ".extensions[] | select(.name == \"${UNINSTALL_EXT}\")")
-      if [[ -z "${QUERIED_EXT}" ]]; then
-        echo "ERROR: Extension '${UNINSTALL_EXT}' does not exist in https://extensions.gnome.org/ website"
-        echo "       Extension name is case-sensitive, so be sure that you typed it correctly,"
-        echo "       including the correct uppercase & lowercase characters"
-        exit 1
+      if [[ ! "${INSTALL_EXT}" =~ ^[0-9]+$ ]]; then
+        # Literal-name extension config
+        # Replaces whitespaces with %20 for install entries which contain extension name, since URLs can't contain whitespace
+        # Getting json query from the website is useful to intuitively uninstall the extension without need to manually input UUID
+        WHITESPACE_HTML="${UNINSTALL_EXT// /%20}"
+        URL_QUERY=$(curl -s "https://extensions.gnome.org/extension-query/?search=${WHITESPACE_HTML}")
+        QUERIED_EXT=$(echo "${URL_QUERY}" | jq ".extensions[] | select(.name == \"${UNINSTALL_EXT}\")")
+        if [[ -z "${QUERIED_EXT}" ]]; then
+          echo "ERROR: Extension '${UNINSTALL_EXT}' does not exist in https://extensions.gnome.org/ website"
+          echo "       Extension name is case-sensitive, so be sure that you typed it correctly,"
+          echo "       including the correct uppercase & lowercase characters"
+          exit 1
+        fi
+        EXT_UUID=$(echo "${QUERIED_EXT}" | jq -r '.["uuid"]')
+        EXT_NAME=$(echo "${QUERIED_EXT}" | jq -r '.["name"]')
+      else
+        # PK ID extension config fallback if specified
+        URL_QUERY=$(curl -s "https://extensions.gnome.org/extension-info/?pk=${INSTALL_EXT}")
+        PK_EXT=$(echo "${URL_QUERY}" | jq -r '.["pk"]' 2>/dev/null)
+        if [[ -z "${PK_EXT}" ]] || [[ "${PK_EXT}" == "null" ]]; then
+          echo "ERROR: Extension with PK ID '${INSTALL_EXT}' does not exist in https://extensions.gnome.org/ website"
+          echo "       Please assure that you typed the PK ID correctly,"
+          echo "       and that it exists in Gnome extensions website"
+          exit 1
+        fi
+        EXT_UUID=$(echo "${URL_QUERY}" | jq -r '.["uuid"]')
+        EXT_NAME=$(echo "${URL_QUERY}" | jq -r '.["name"]')
       fi
-      EXT_UUID=$(echo "${QUERIED_EXT}" | jq -r '.["uuid"]')
-      EXT_NAME=$(echo "${QUERIED_EXT}" | jq -r '.["name"]')
       # This is where uninstall step goes, above step is reused from install part
       EXT_FILES="/usr/share/gnome-shell/extensions/${EXT_UUID}"
       UNINSTALL_METADATA="${EXT_FILES}/metadata.json"

--- a/modules/gnome-extensions/module.yml
+++ b/modules/gnome-extensions/module.yml
@@ -4,11 +4,10 @@ readme: https://raw.githubusercontent.com/blue-build/modules/main/modules/gnome-
 example: |
   type: gnome-extensions
   install:
-    - 2236 # Night Theme Switcher
-    - 3193 # Blur my Shell
+    - Night Theme Switcher
+    - Blur my Shell # Notice how extension is named "Blur my Shell" & not "Blur My Shell"?
+                    # Name is case-sensitive, so check if extension name is typed correctly
   uninstall:
-    - 1319 # GSConnect
-  #
-  # Uninstall step here should be used only for the extensions
-  # which are not installed through OS package manager in the base image,
-  # like extensions installed from gnome-extensions module
+    - GSConnect # Uninstall step here should be used only for the extensions
+                # which are not installed through OS package manager in the base image,
+                # like extensions installed from gnome-extensions module

--- a/modules/gnome-extensions/module.yml
+++ b/modules/gnome-extensions/module.yml
@@ -4,10 +4,11 @@ readme: https://raw.githubusercontent.com/blue-build/modules/main/modules/gnome-
 example: |
   type: gnome-extensions
   install:
-    - Night Theme Switcher
-    - Blur my Shell # Notice how extension is named "Blur my Shell" & not "Blur My Shell"?
-                    # Name is case-sensitive, so check if extension name is typed correctly
+    - 2236 # Night Theme Switcher
+    - 3193 # Blur my Shell
   uninstall:
-    - GSConnect # Uninstall step here should be used only for the extensions
-                # which are not installed through OS package manager in the base image,
-                # like extensions installed from gnome-extensions module
+    - 1319 # GSConnect
+  #
+  # Uninstall step here should be used only for the extensions
+  # which are not installed through OS package manager in the base image,
+  # like extensions installed from gnome-extensions module

--- a/modules/gnome-extensions/module.yml
+++ b/modules/gnome-extensions/module.yml
@@ -7,6 +7,12 @@ example: |
     - Night Theme Switcher
     - Blur my Shell # Notice how extension is named "Blur my Shell" & not "Blur My Shell"?
                     # Name is case-sensitive, so check if extension name is typed correctly
+    - AppIndicator and KStatusNotifierItem Support                
+    - 307 # Dash-to-Dock
+          # https://extensions.gnome.org/extension/307/dash-to-dock/
+          # You can also specify PK ID number from the extension URL,
+          # if you encounter the scenario where there are multiple extensions with the same name.
+          # You don't need to look & search for this scenario, since module will automatically fail & inform you to put PK ID number instead
   uninstall:
     - GSConnect # Uninstall step here should be used only for the extensions
                 # which are not installed through OS package manager in the base image,


### PR DESCRIPTION
# Subject

PK number ID config can be used now for recipe input, in case if any duplicated extensions exist.
Module conveniently informs about this scenario & recommends the user to switch to PK ID in this case.

Mixed config in PK ID & "literal extension names" are supported for both install & uninstall entries.

Additionally not related to this PR's subject,
I improved reliability of applying missing gschema.compiled workaround.
I use UUID detetection now instead of "literal extension name".

# Status

Apart from maybe some doc updates, it's ready to merge.

Wondering If I should add additional documentation besides module.yml or not.