### PR TITLE
fix(brew): Revert #253

### DIFF
--- a/modules/brew/brew-fish-completions.fish
+++ b/modules/brew/brew-fish-completions.fish
@@ -4,7 +4,7 @@ if status --is-interactive
     if [ -d /home/linuxbrew/.linuxbrew ]
         eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
         if [ -w /home/linuxbrew/.linuxbrew ]
-            if  [ ! -L (brew --prefix)/share/fish/vendor_completions.d/brew-fish-completions.fish ]
+            if  [ ! -L (brew --prefix)/share/fish/vendor_completions.d/brew.fish ]
                 brew completions link > /dev/null
             end
         end


### PR DESCRIPTION
This reverts the change done in #253 to the following line:

https://github.com/blue-build/modules/blob/a7024ba47546080025cc80543ea9c0ee59f98bfb/modules/brew/brew-fish-completions.fish#L7

The check is meant for the `brew.fish` file that is included with Homebrew, not for the module-provided `brew-fish-completions.fish` file. Note that the path has `(brew --prefix)` at the start, indicating as such.

```
../modules on  revert-pr-253 
akzel@zenon-1700 at 17:16 ❯ brew --prefix
/home/linuxbrew/.linuxbrew

../modules on  revert-pr-253 [!] 
akzel@zenon-1700 at 17:18 ❯ ls (brew --prefix)/share/fish/vendor_completions.d/
atuin.fish  brew.fish     curl.fish   eza.fish        fd.fish  starship.fish  typst.fish
bat.fish    chezmoi.fish  delta.fish  fastfetch.fish  rg.fish  tldr.fish      zoxide.fish
```

The brew module's file is at `/usr/share/fish/vendor_conf.d`, not the aforementioned path being checked.
```
../modules on  revert-pr-253 
akzel@zenon-1700 at 17:20 ❯ ls /usr/share/fish/vendor_conf.d/
bling.fish  brew-fish-completions.fish  flatpak.fish  nano-default-editor.fish  zeliblue-just.fish
```