### PR TITLE
feat: Add justfiles module

### DIFF
--- a/modules/justfiles/README.md
+++ b/modules/justfiles/README.md
@@ -1,8 +1,8 @@
 # `justfiles`
 
-The `justfiles` module allows for easy `.just` files importing. It can be useful for example to separate DE specific justfiles when building multiple images.
+:::note The module is only compatible with Universal Blue images. :::
 
-:::note The module is compatible only with Universal Blue images. :::
+The `justfiles` module allows for easy `.just` files importing. It can be useful for example to separate DE specific justfiles when building multiple images.
 
 ## What it does
 

--- a/modules/justfiles/README.md
+++ b/modules/justfiles/README.md
@@ -4,35 +4,11 @@
 
 The `justfiles` module allows for easy `.just` files importing. It can be useful for example to separate DE specific justfiles when building multiple images.
 
-## What is just and what is a justfile ?
+## What is just ?
 
-`just` is a tool for running pre-defined commands or scripts.
+Just is a command runner (kind of like make) that can be used to supply arbitrary scripts under a single shell command. Images based on Universal Blue bundle a set of these scripts, called recipes, which can be accessed with the `ujust` command.
 
-The commands/scripts otherwise called recipes are defined in a file named `justfile`. That file can also contain import lines, allowing to include recipes from other files that usually end with the `.just` postfix.
-
-Without specifying any arguments, `just` will run the first recipe defined in a `justfile` of the current directory. If the current directory doesn't contain a `justfile`, `just` will attempt to find the nearest `justfile` going back the current directory path.
-
-In all Universal Blue images, `just` is preinstalled and a `.justfile` is created by default in the `$HOME` directory. It contains an import line that includes Universal Blue recipes and if this module was used, it will also include all recipes from the `.just` files this module worked with.
-
-* This means if you run `just` from anywhere in your `$HOME` directory, `$HOME/.justfile` will be considered the nearest (unless there's another `justfile` in the directory path as mentioned before) and all your recipes + recipes from Universal Blue should be available.
-
-* Universal Blue also includes the command `ujust`, that specifies what `justfile` to use, meaning all your recipes + recipes from Universal Blue will be available from anywhere, even if there is another `justfile` in your current directory path.
-
-### Usage examples
-
-Run a specific recipe from the nearest justfile by including its name as the first argument:
-    
-* `just build-a-program`
-
-List all recipes from the nearest justfile using:
-    
-* `just --list`
-
-Specify a justfile to be used:
-
-* `just --justfile <DESTINATION FILE>`
-
-### More information
+For more information, refer to these links:
 
 * [Official just documentation](https://just.systems/man/en)
 * [Universal Blue documentation](https://universal-blue.discourse.group/docs?topic=42)

--- a/modules/justfiles/README.md
+++ b/modules/justfiles/README.md
@@ -2,7 +2,7 @@
 
 :::note The module is only compatible with Universal Blue images. :::
 
-The `justfiles` module allows for easy `.just` files importing. It can be useful for example to separate DE specific justfiles when building multiple images.
+The `justfiles` module makes it easy to include [just](https://just.systems/) recipes from multiple files in Universal Blue -based images. It can be useful for example when utilizing DE-specific justfiles when building multiple images. On the other hand, you likely wont need the module if you're building just one image or need just one justfile for all your images.
 
 ## What is just ?
 
@@ -42,7 +42,7 @@ For more information, refer to these links:
 
 Place all your `.just` files or folders with `.just` files inside the `config/justfiles/` folder. If that folder doesn't exist, create it.
 
-Without specifying `include`, the module will assume you want to import everything. Otherwise, specify your files/folders under `include`.
+By default, the module will import all files with names ending in `.just` from `config/justfiles/`. You can also specify files or subfolders under `include`, and they will be the only ones imported.
 
 If you also want to validate your justfiles, set `validate: true`. The validation can be very unforgiving and is turned off by default.
 

--- a/modules/justfiles/README.md
+++ b/modules/justfiles/README.md
@@ -2,6 +2,8 @@
 
 The `justfiles` module allows for easy `.just` files importing. It can be useful for example to separate DE specific justfiles when building multiple images.
 
+:::note The module is compatible only with Universal Blue images. :::
+
 ## What it does
 
 1. The module checks if the `config/justfiles/` folder is present.
@@ -24,7 +26,7 @@ The `justfiles` module allows for easy `.just` files importing. It can be useful
     
     * The module does not overwrite the destination file. New lines are added to an existing file.
 
-    * If the generated import lines are already present, the module fails to avoid duplications.
+    * If the generated import lines are already present, the module skips them to avoid duplications.
 
 ## How to use it
 

--- a/modules/justfiles/README.md
+++ b/modules/justfiles/README.md
@@ -1,0 +1,37 @@
+# `justfiles`
+
+The `justfiles` module allows for easy `.just` files importing. It can be useful for example to separate DE specific justfiles when building multiple images.
+
+## What it does
+
+1. The module checks if the `config/justfiles/` folder is present.
+    
+    * If it's not there, it fails.
+
+2. The module finds all `.just` files inside of the `config/justfiles/` folder or starting from the relative path specified under `include`.
+    
+    * If no `.just` files are found, it fails.
+
+    * The structure of the `config/justfiles/` folder does not matter, folders/files can be placed in there however desired, the module will find all `.just` files.
+
+    * Optionally, the `.just` files can be validated.
+
+3. The module copies over the files/folders containing `.just` files to `/usr/share/bluebuild/justfiles/`.
+
+    * The folder structure of the copy destination remains the same as in the config folder.
+
+4. The module generates import lines and appends them to the `/usr/share/ublue-os/just/60-custom.just` file.
+    
+    * The module does not overwrite the destination file. New lines are added to an existing file.
+
+    * If the generated import lines are already present, the module fails to avoid duplications.
+
+## How to use it
+
+Place all your `.just` files or folders with `.just` files inside the `config/justfiles/` folder. If that folder doesn't exist, create it.
+
+Without specifying `include`, the module will assume you want to import everything. Otherwise, specify your files/folders under `include`.
+
+If you also want to validate your justfiles, set `validate: true`. The validation can be very unforgiving and is turned off by default.
+
+* The validation command usually prints huge number of lines. To avoid cluttering up the logs, the module will only tell you which files did not pass the validation. You can then use the command `just --fmt --check --unstable --justfile <DESTINATION FILE>` to troubleshoot them.

--- a/modules/justfiles/README.md
+++ b/modules/justfiles/README.md
@@ -4,7 +4,39 @@
 
 The `justfiles` module allows for easy `.just` files importing. It can be useful for example to separate DE specific justfiles when building multiple images.
 
-## What it does
+## What is just and what is a justfile ?
+
+`just` is a tool for running pre-defined commands or scripts.
+
+The commands/scripts otherwise called recipes are defined in a file named `justfile`. That file can also contain import lines, allowing to include recipes from other files that usually end with the `.just` postfix.
+
+Without specifying any arguments, `just` will run the first recipe defined in a `justfile` of the current directory. If the current directory doesn't contain a `justfile`, `just` will attempt to find the nearest `justfile` going back the current directory path.
+
+In all Universal Blue images, `just` is preinstalled and a `.justfile` is created by default in the `$HOME` directory. It contains an import line that includes Universal Blue recipes and if this module was used, it will also include all recipes from the `.just` files this module worked with.
+
+* This means if you run `just` from anywhere in your `$HOME` directory, `$HOME/.justfile` will be considered the nearest (unless there's another `justfile` in the directory path as mentioned before) and all your recipes + recipes from Universal Blue should be available.
+
+* Universal Blue also includes the command `ujust`, that specifies what `justfile` to use, meaning all your recipes + recipes from Universal Blue will be available from anywhere, even if there is another `justfile` in your current directory path.
+
+### Usage examples
+
+Run a specific recipe from the nearest justfile by including its name as the first argument:
+    
+* `just build-a-program`
+
+List all recipes from the nearest justfile using:
+    
+* `just --list`
+
+Specify a justfile to be used:
+
+* `just --justfile <DESTINATION FILE>`
+
+### More information
+
+* [Official just documentation](https://just.systems/man/en)
+
+## What the module does
 
 1. The module checks if the `config/justfiles/` folder is present.
     
@@ -28,7 +60,7 @@ The `justfiles` module allows for easy `.just` files importing. It can be useful
 
     * If the generated import lines are already present, the module skips them to avoid duplications.
 
-## How to use it
+## How to use the module
 
 Place all your `.just` files or folders with `.just` files inside the `config/justfiles/` folder. If that folder doesn't exist, create it.
 

--- a/modules/justfiles/README.md
+++ b/modules/justfiles/README.md
@@ -35,6 +35,8 @@ Specify a justfile to be used:
 ### More information
 
 * [Official just documentation](https://just.systems/man/en)
+* [Universal Blue documentation](https://universal-blue.discourse.group/docs?topic=42)
+* [BlueBuild documentation](https://blue-build.org/learn/universal-blue/#custom-just-recipes)
 
 ## What the module does
 

--- a/modules/justfiles/justfiles.sh
+++ b/modules/justfiles/justfiles.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+get_yaml_array CONFIG_SELECTION '.include[]' "$1"
+VALIDATE="$(echo "$1" | yq -I=0 ".validate")"
+
+IMPORT_FILE="/usr/share/ublue-os/just/60-custom.just"
+CONFIG_FOLDER="${CONFIG_DIRECTORY}/justfiles"
+DEST_FOLDER="/usr/share/bluebuild/justfiles"
+
+# Abort if justfiles folder is not present
+if [ ! -d "${CONFIG_FOLDER}" ]; then
+    echo "Error: The config folder '${CONFIG_FOLDER}' was not found."
+    exit 1
+fi
+
+# Include all files in the folder if none specified
+if [[ ${#CONFIG_SELECTION[@]} == 0 ]]; then
+    CONFIG_SELECTION=($(ls "${CONFIG_FOLDER}"))
+fi
+
+for SELECTED in "${CONFIG_SELECTION[@]}"; do
+
+    echo "----------------------------------------------------------"
+    echo "------------ Adding folder/file '${SELECTED}' ------------"
+    echo "----------------------------------------------------------"
+
+    # Find all justfiles, starting from 'SELECTED' and get their paths
+    JUSTFILES=($(find "${CONFIG_FOLDER}/${SELECTED}" -type f -name "*.just" | sed "s|${CONFIG_FOLDER}/||g"))
+
+    # Abort if no justfiles found at 'SELECTED'
+    if [[ ${#JUSTFILES[@]} == 0 ]]; then
+        echo "Error: No justfiles were found in '${CONFIG_FOLDER}/${SELECTED}'."
+        exit 1
+    fi
+
+    # Validate all found justfiles if set to do so
+    if [ "${VALIDATE}" == "true" ]; then
+
+        echo "-- Validating justfiles"
+        VALIDATION_FAILED=0
+        for JUSTFILE in "${JUSTFILES[@]}"; do
+            if ! /usr/bin/just --fmt --check --unstable --justfile "${CONFIG_FOLDER}/${JUSTFILE}" &> /dev/null; then
+                echo "The justfile '${JUSTFILE}' FAILED validation."
+                VALIDATION_FAILED=1
+            fi
+        done
+
+        # Exit if any justfiles are not valid
+        if [ ${VALIDATION_FAILED} -eq 1 ]; then
+            echo "Error: Some justfiles didn't pass validation."
+            exit 1
+        else
+            echo "All justfiles passed validation."
+        fi
+
+    fi
+
+    # Copy 'SELECTED' to destination folder
+    echo "-- Copying folders/files"
+    mkdir -p "${DEST_FOLDER}/$(dirname ${SELECTED})"
+    cp -rfT "${CONFIG_FOLDER}/${SELECTED}" "${DEST_FOLDER}/${SELECTED}"
+    echo "Copied '${CONFIG_FOLDER}/${SELECTED}' to '${DEST_FOLDER}/${SELECTED}'."
+
+    # Generate import lines for all found justfiles
+    echo "-- Adding import lines"
+    for JUSTFILE in "${JUSTFILES[@]}"; do
+
+        # Create an import line
+        IMPORT_LINE="import \"${DEST_FOLDER}/${JUSTFILE}\""
+        
+        # Abort if import line already exists, else append it to import file
+        if grep -wq "${IMPORT_LINE}" "${IMPORT_FILE}"; then
+            echo "Error: Duplicated import line: '${IMPORT_LINE}' found."
+            exit 1
+        else
+            echo "${IMPORT_LINE}" | tee -a "${IMPORT_FILE}"
+        fi
+
+    done
+
+done

--- a/modules/justfiles/justfiles.sh
+++ b/modules/justfiles/justfiles.sh
@@ -17,7 +17,7 @@ fi
 
 # Include all files in the folder if none specified
 if [[ ${#CONFIG_SELECTION[@]} == 0 ]]; then
-    CONFIG_SELECTION=($(ls "${CONFIG_FOLDER}"))
+    CONFIG_SELECTION=($(find "${CONFIG_FOLDER}" -mindepth 1 -maxdepth 1 -exec basename {} \;))
 fi
 
 for SELECTED in "${CONFIG_SELECTION[@]}"; do

--- a/modules/justfiles/justfiles.sh
+++ b/modules/justfiles/justfiles.sh
@@ -70,7 +70,7 @@ for SELECTED in "${CONFIG_SELECTION[@]}"; do
         # Create an import line
         IMPORT_LINE="import \"${DEST_FOLDER}/${JUSTFILE}\""
         
-        # Abort if import line already exists, else append it to import file
+        # Skip the import line if it already exists, else append it to import file
         if grep -wq "${IMPORT_LINE}" "${IMPORT_FILE}"; then
             echo "- Skipped: '${IMPORT_LINE}' (already present)"
         else

--- a/modules/justfiles/justfiles.sh
+++ b/modules/justfiles/justfiles.sh
@@ -22,9 +22,9 @@ fi
 
 for SELECTED in "${CONFIG_SELECTION[@]}"; do
 
-    echo "----------------------------------------------------------"
-    echo "------------ Adding folder/file '${SELECTED}' ------------"
-    echo "----------------------------------------------------------"
+    echo "------------------------------------------------------------------------"
+    echo "--- Adding folder/file '${SELECTED}'"
+    echo "------------------------------------------------------------------------"
 
     # Find all justfiles, starting from 'SELECTED' and get their paths
     JUSTFILES=($(find "${CONFIG_FOLDER}/${SELECTED}" -type f -name "*.just" | sed "s|${CONFIG_FOLDER}/||g"))
@@ -38,11 +38,11 @@ for SELECTED in "${CONFIG_SELECTION[@]}"; do
     # Validate all found justfiles if set to do so
     if [ "${VALIDATE}" == "true" ]; then
 
-        echo "-- Validating justfiles"
+        echo "Validating justfiles"
         VALIDATION_FAILED=0
         for JUSTFILE in "${JUSTFILES[@]}"; do
             if ! /usr/bin/just --fmt --check --unstable --justfile "${CONFIG_FOLDER}/${JUSTFILE}" &> /dev/null; then
-                echo "The justfile '${JUSTFILE}' FAILED validation."
+                echo "- The justfile '${JUSTFILE}' FAILED validation."
                 VALIDATION_FAILED=1
             fi
         done
@@ -52,19 +52,19 @@ for SELECTED in "${CONFIG_SELECTION[@]}"; do
             echo "Error: Some justfiles didn't pass validation."
             exit 1
         else
-            echo "All justfiles passed validation."
+            echo "- All justfiles passed validation."
         fi
 
     fi
 
     # Copy 'SELECTED' to destination folder
-    echo "-- Copying folders/files"
+    echo "Copying folders/files"
     mkdir -p "${DEST_FOLDER}/$(dirname ${SELECTED})"
     cp -rfT "${CONFIG_FOLDER}/${SELECTED}" "${DEST_FOLDER}/${SELECTED}"
-    echo "Copied '${CONFIG_FOLDER}/${SELECTED}' to '${DEST_FOLDER}/${SELECTED}'."
+    echo "- Copied '${CONFIG_FOLDER}/${SELECTED}' to '${DEST_FOLDER}/${SELECTED}'."
 
     # Generate import lines for all found justfiles
-    echo "-- Adding import lines"
+    echo "Adding import lines"
     for JUSTFILE in "${JUSTFILES[@]}"; do
 
         # Create an import line
@@ -72,10 +72,10 @@ for SELECTED in "${CONFIG_SELECTION[@]}"; do
         
         # Abort if import line already exists, else append it to import file
         if grep -wq "${IMPORT_LINE}" "${IMPORT_FILE}"; then
-            echo "Error: Duplicated import line: '${IMPORT_LINE}' found."
-            exit 1
+            echo "- Skipped: '${IMPORT_LINE}' (already present)"
         else
-            echo "${IMPORT_LINE}" | tee -a "${IMPORT_FILE}"
+            echo "${IMPORT_LINE}" >> "${IMPORT_FILE}"
+            echo "- Added: '${IMPORT_LINE}'"
         fi
 
     done

--- a/modules/justfiles/module.yml
+++ b/modules/justfiles/module.yml
@@ -1,5 +1,5 @@
 name: justfiles
-shortdesc: The justfiles module allows for easy justfiles importing.
+shortdesc: The justfiles module makes it easy to include just recipes from multiple files in Universal Blue -based images. 
 readme: https://raw.githubusercontent.com/blue-build/modules/main/modules/justfiles/README.md
 example: |
   type: justfiles

--- a/modules/justfiles/module.yml
+++ b/modules/justfiles/module.yml
@@ -1,0 +1,11 @@
+name: justfiles
+shortdesc: The justfiles module allows for easy justfiles importing.
+readme: https://raw.githubusercontent.com/blue-build/modules/main/modules/justfiles/README.md
+example: |
+  type: justfiles
+  validate: true
+  include:
+    - common
+    - gnome/monitors.just
+    - shared/flatpak/fix-theming.just
+    - justfile1.just


### PR DESCRIPTION
Users will be able to save their scripts in separate justfiles and won't have to worry about correctly importing them.

Can be especially useful for people building multiple images to have for example DE specific justfiles. GNOME specific justfiles don't end up in a KDE image, common justfiles are imported to all images,..