### PR TITLE
chore(akmods): Don't install `kernel-devel` packages

### DIFF
--- a/modules/akmods/akmods.sh
+++ b/modules/akmods/akmods.sh
@@ -15,7 +15,6 @@ function SET_HIGHER_PRIORITY_AKMODS_REPO {
 }
 
 get_yaml_array INSTALL '.install[]' "$1"
-SURFACE=$(rpm -qa --queryformat '%{NAME}\n' | awk '$0 == "kernel-surface"')
 
 INSTALL_PATH=("${INSTALL[@]/#/\/tmp/rpms/kmods/*}")
 INSTALL_PATH=("${INSTALL_PATH[@]/%/*.rpm}")
@@ -24,15 +23,9 @@ INSTALL_STR=$(echo "${INSTALL_PATH[*]}" | tr -d '\n')
 if [[ ${#INSTALL[@]} -gt 0 ]]; then
   echo "Installing akmods"
   echo "Installing: $(echo "${INSTALL[*]}" | tr -d '\n')"
-  if [[ -n "$SURFACE" ]]; then
-    SET_HIGHER_PRIORITY_AKMODS_REPO
-    ENABLE_MULTIMEDIA_REPO
-    rpm-ostree install kernel-surface-devel-matched $INSTALL_STR
-    DISABLE_MULTIMEDIA_REPO
-  else
-    SET_HIGHER_PRIORITY_AKMODS_REPO
-    ENABLE_MULTIMEDIA_REPO
-    rpm-ostree install kernel-devel-matched $INSTALL_STR
-    DISABLE_MULTIMEDIA_REPO
+  SET_HIGHER_PRIORITY_AKMODS_REPO
+  ENABLE_MULTIMEDIA_REPO
+  rpm-ostree install $INSTALL_STR
+  DISABLE_MULTIMEDIA_REPO
   fi  
 fi    


### PR DESCRIPTION
They are only needed when building the akmods, but not when shipping them.

This should considerably remove the bloat from the images like `perl`, `gcc` & some more without affecting the existing functionality.