### PR TITLE
chore(default-flatpaks): Add safe-check for FlatHub flatpak IDs

### DIFF
--- a/modules/default-flatpaks/default-flatpaks.sh
+++ b/modules/default-flatpaks/default-flatpaks.sh
@@ -110,7 +110,7 @@ check_flatpak_id_validity_from_flathub () {
       get_yaml_array INSTALL ".$INSTALL_LEVEL.install[]" "${CONFIG_FILE}"
       get_yaml_array REMOVE ".$INSTALL_LEVEL.remove[]" "${CONFIG_FILE}"
       if [[ "${SYSTEM_FLATHUB_REPO}" == "${FLATHUB_REPO_LINK}" ]] || [[ "${USER_FLATHUB_REPO}" == "${FLATHUB_REPO_LINK}" ]]; then
-      echo "Safe-checking if ${INSTALL_LEVEL} flatpak IDs are typed correctly. If test fails, build also fails"
+        echo "Safe-checking if ${INSTALL_LEVEL} flatpak IDs are typed correctly. If test fails, build also fails"
         if [[ ${#INSTALL[@]} -gt 0 ]]; then
           for id in "${INSTALL[@]}"; do
             if ! curl --output /dev/null --silent --head --fail "${URL}/${id}"; then

--- a/modules/default-flatpaks/default-flatpaks.sh
+++ b/modules/default-flatpaks/default-flatpaks.sh
@@ -136,7 +136,10 @@ check_flatpak_id_validity_from_flathub () {
           done
         fi  
       else
-        echo "NOTE: Flatpak ID safe-check is only available for FlatHub repo"
+        if ! ${MESSAGE_DISPLAYED}; then
+          echo "NOTE: Flatpak ID safe-check is only available for FlatHub repo"
+          MESSAGE_DISPLAYED=true
+        fi  
       fi  
 }
 
@@ -170,6 +173,7 @@ if [[ ! $(echo "$1" | yq -I=0 ".user") == "null" ]]; then
     configure_lists "$1" "user"
 fi
 
+MESSAGE_DISPLAYED=false
 check_flatpak_id_validity_from_flathub "${1}" "system"
 check_flatpak_id_validity_from_flathub "${1}" "user"
 

--- a/modules/default-flatpaks/default-flatpaks.sh
+++ b/modules/default-flatpaks/default-flatpaks.sh
@@ -101,8 +101,12 @@ configure_lists () {
 }
 
 check_flatpak_id_validity_from_flathub () {
-      SYSTEM_FLATHUB_REPO=$(yq .repo-url "/usr/share/bluebuild/default-flatpaks/system/repo-info.yml")
-      USER_FLATHUB_REPO=$(yq .repo-url "/usr/share/bluebuild/default-flatpaks/user/repo-info.yml")
+      if [[ -f "/usr/share/bluebuild/default-flatpaks/system/repo-info.yml" ]]; then
+        SYSTEM_FLATHUB_REPO=$(yq .repo-url "/usr/share/bluebuild/default-flatpaks/system/repo-info.yml")
+      fi  
+      if [[ -f "/usr/share/bluebuild/default-flatpaks/user/repo-info.yml" ]]; then
+        USER_FLATHUB_REPO=$(yq .repo-url "/usr/share/bluebuild/default-flatpaks/user/repo-info.yml")
+      fi  
       FLATHUB_REPO_LINK="https://dl.flathub.org/repo/flathub.flatpakrepo"
       URL="https://flathub.org/apps"
       CONFIG_FILE="${1}"

--- a/modules/default-flatpaks/default-flatpaks.sh
+++ b/modules/default-flatpaks/default-flatpaks.sh
@@ -103,9 +103,13 @@ configure_lists () {
 check_flatpak_id_validity_from_flathub () {
       if [[ -f "/usr/share/bluebuild/default-flatpaks/system/repo-info.yml" ]]; then
         SYSTEM_FLATHUB_REPO=$(yq .repo-url "/usr/share/bluebuild/default-flatpaks/system/repo-info.yml")
+      else
+        SYSTEM_FLATHUB_REPO=""
       fi  
       if [[ -f "/usr/share/bluebuild/default-flatpaks/user/repo-info.yml" ]]; then
         USER_FLATHUB_REPO=$(yq .repo-url "/usr/share/bluebuild/default-flatpaks/user/repo-info.yml")
+      else
+        USER_FLATHUB_REPO=""
       fi  
       FLATHUB_REPO_LINK="https://dl.flathub.org/repo/flathub.flatpakrepo"
       URL="https://flathub.org/apps"


### PR DESCRIPTION
Should avoid issues of users typing ID wrongly, which would fail the whole module on booted system, so nothing would get installed or removed.

Only FlatHub repo is supported as it's the most popular flatpak repo & it's easy to implement safe-check for it.