### PR TITLE
docs(chezmoi+gschema-overrides): Fix some typos

### DIFF
--- a/modules/chezmoi/README.md
+++ b/modules/chezmoi/README.md
@@ -43,7 +43,7 @@ To manually enable the services for all users, run the following command with su
 sudo systemctl enable --user chesmoi-init.service chezmoi-update.timer
 ```
 
-To turn on lingering for a given user, run the following commmand with sudo:
+To turn on lingering for a given user, run the following command with sudo:
 
 :::note
 By default, any systemd units in a user's namespace will run after the user logs in, and will close after the user closes their last session. 
@@ -59,7 +59,7 @@ sudo loginctl enable-linger <username>`
 
 You can configure the interval between updates of your dotfiles by setting the value of `run-every`.
 The string is passed directly to OnUnitInactiveSec. (default: '1d')
-See [`systemd.time` documenation](https://www.freedesktop.org/software/systemd/man/latest/systemd.time.html) for detailed syntax.
+See [`systemd.time` documentation](https://www.freedesktop.org/software/systemd/man/latest/systemd.time.html) for detailed syntax.
 Examples: '1d' (1 day - default), '6h' (6 hours), '10m' (10 minutes)
 
 Likewise, `wait-after-boot` configures the delay between the system booting and the update service starting.

--- a/modules/gschema-overrides/README.md
+++ b/modules/gschema-overrides/README.md
@@ -65,7 +65,7 @@ tap-to-click=true
   
   `gsettings list-recursively`
   
-  You should use this command everytime when you want to apply some setting override,
+  You should use this command every time when you want to apply some setting override,
   to ensure that it's listed as available.
 
 **Gschema.override files don't support relocatable schemas & locking settings.**


### PR DESCRIPTION
Since I found 1 typo accidentally (https://github.com/blue-build/modules/pull/297), I figured I'd look for some more.
Commits are split into files if necessary. Cheers!