### PR TITLE
feat(rpm-ostree): Add support for installing local repos & RPMs

### DIFF
--- a/modules/rpm-ostree/README.md
+++ b/modules/rpm-ostree/README.md
@@ -2,14 +2,13 @@
 
 The [`rpm-ostree`](https://coreos.github.io/rpm-ostree/) module offers pseudo-declarative package and repository management using `rpm-ostree`.
 
-The module first downloads the repository files from repositories declared under `repos:` into `/etc/yum.repos.d/`. The magic string `%OS_VERSION%` is substituted with the current VERSION_ID (major Fedora version), which can be used, for example, for pulling correct versions of repositories from [Fedora's Copr](https://copr.fedorainfracloud.org/).
+The module first downloads the repository files from URLs declared under `repos:` into `/etc/yum.repos.d/`. The magic string `%OS_VERSION%` is substituted with the current VERSION_ID (major Fedora version), which can be used, for example, for pulling correct versions of repositories from [Fedora's Copr](https://copr.fedorainfracloud.org/).
 
-You can also have local repos inserted in this file location (make the directory if it doesn't exist):  
+You can also add repository files directly into your git repository if URLs are not provided. For example:
+```yml
+repos:
+   - my-repository.repo # copies in .repo file from files/rpm-ostree/my-repository.repo to /etc/yum.repos.d/
 ```
-files/rpm-ostree/my-repository.repo
-files/rpm-ostree/my-image/my-2nd-repository.repo
-```
-
 If you use a repo that requires adding custom keys (eg. Brave Browser), you can import the keys by declaring the key URLs under `keys:`. The magic string acts the same as it does in `repos`.
 
 Then the module installs the packages declared under `install:` using `rpm-ostree install`, it removes the packages declared under `remove:` using `rpm-ostree override remove`. If there are packages declared under both `install:` and `remove:` a hybrid command `rpm-ostree remove <packages> --install <packages>` is used, which should allow you to switch required packages for other ones.

--- a/modules/rpm-ostree/README.md
+++ b/modules/rpm-ostree/README.md
@@ -15,12 +15,11 @@ Then the module installs the packages declared under `install:` using `rpm-ostre
 
 Installing RPM packages directly from a `http(s)` url that points to the RPM file is also supported, you can just put the URLs under `install:` and they'll be installed along with the other packages. The magic string `%OS_VERSION%` is substituted with the current VERSION_ID (major Fedora version) like with the `repos:` property.
 
-Installing local RPM packages from the file location is supported. You can insert those RPMs in this file location (make the directory if it doesn't exist):  
+If an RPM is not available in a repository or as an URL, you can also install it directly from a file in your git repository. For example:
+```yml
+install:
+   - weird-package.rpm # tries to install files/rpm-ostree/weird-package.rpm
 ```
-files/rpm-ostree/my-package.rpm
-files/rpm-ostree/my-image/somepackage.rpm
-```
-
 The module can also replace base RPM packages with packages from COPR repo. Under `replace:`, the module finds every pair of keys `- from-repo:` and `packages:`. (Multiple pairs are supported.) The module downloads the COPR repository file declared by `- from-repo:` into `/etc/yum.repos.d/`, and from that repository replaces packages declared under `packages:` using the command `rpm-ostree override replace`. The COPR repository file is then deleted. The magic string `%OS_VERSION%` is substituted with the current VERSION_ID (major Fedora version) as already said above. At the moment, only COPR repo is supported.
 
 :::note

--- a/modules/rpm-ostree/README.md
+++ b/modules/rpm-ostree/README.md
@@ -4,11 +4,23 @@ The [`rpm-ostree`](https://coreos.github.io/rpm-ostree/) module offers pseudo-de
 
 The module first downloads the repository files from repositories declared under `repos:` into `/etc/yum.repos.d/`. The magic string `%OS_VERSION%` is substituted with the current VERSION_ID (major Fedora version), which can be used, for example, for pulling correct versions of repositories from [Fedora's Copr](https://copr.fedorainfracloud.org/).
 
+You can also have local repos inserted in this file location (make the directory if it doesn't exist):  
+```
+files/rpm-ostree/my-repository.repo
+files/rpm-ostree/my-image/my-2nd-repository.repo
+```
+
 If you use a repo that requires adding custom keys (eg. Brave Browser), you can import the keys by declaring the key URLs under `keys:`. The magic string acts the same as it does in `repos`.
 
 Then the module installs the packages declared under `install:` using `rpm-ostree install`, it removes the packages declared under `remove:` using `rpm-ostree override remove`. If there are packages declared under both `install:` and `remove:` a hybrid command `rpm-ostree remove <packages> --install <packages>` is used, which should allow you to switch required packages for other ones.
 
 Installing RPM packages directly from a `http(s)` url that points to the RPM file is also supported, you can just put the URLs under `install:` and they'll be installed along with the other packages. The magic string `%OS_VERSION%` is substituted with the current VERSION_ID (major Fedora version) like with the `repos:` property.
+
+Installing local RPM packages from the file location is supported. You can insert those RPMs in this file location (make the directory if it doesn't exist):  
+```
+files/rpm-ostree/my-package.rpm
+files/rpm-ostree/my-image/somepackage.rpm
+```
 
 The module can also replace base RPM packages with packages from COPR repo. Under `replace:`, the module finds every pair of keys `- from-repo:` and `packages:`. (Multiple pairs are supported.) The module downloads the COPR repository file declared by `- from-repo:` into `/etc/yum.repos.d/`, and from that repository replaces packages declared under `packages:` using the command `rpm-ostree override replace`. The COPR repository file is then deleted. The magic string `%OS_VERSION%` is substituted with the current VERSION_ID (major Fedora version) as already said above. At the moment, only COPR repo is supported.
 

--- a/modules/rpm-ostree/module.yml
+++ b/modules/rpm-ostree/module.yml
@@ -17,8 +17,6 @@ example: |
   remove:
     - firefox
     - firefox-langpacks
-    - my-local-package.rpm # local package located in `files/rpm-ostree/my-local-package.rpm`
-    - some-folder/my-local-package-2.rpm # local package located in `files/rpm-ostree/some-folder/my-local-package-2.rpm`
   replace:
     - from-repo: https://copr.fedorainfracloud.org/coprs/trixieua/mutter-patched/repo/fedora-%OS_VERSION%/trixieua-mutter-patched-fedora-%OS_VERSION%.repo
       packages:

--- a/modules/rpm-ostree/module.yml
+++ b/modules/rpm-ostree/module.yml
@@ -5,6 +5,7 @@ example: |
   repos:
     - https://copr.fedorainfracloud.org/coprs/atim/starship/repo/fedora-%OS_VERSION%/atim-starship-fedora-%OS_VERSION%.repo # when including COPR repos, use the %OS_VERSION% magic string
     - https://brave-browser-rpm-release.s3.brave.com/brave-browser.repo
+    - my-local-repository.repo # local repo located in `files/rpm-ostree/my-local-repository.repo`
   keys:
     - https://brave-browser-rpm-release.s3.brave.com/brave-core.asc
   optfix:
@@ -16,6 +17,8 @@ example: |
   remove:
     - firefox
     - firefox-langpacks
+    - my-local-package.rpm # local package located in `files/rpm-ostree/my-local-package.rpm`
+    - some-folder/my-local-package-2.rpm # local package located in `files/rpm-ostree/some-folder/my-local-package-2.rpm`
   replace:
     - from-repo: https://copr.fedorainfracloud.org/coprs/trixieua/mutter-patched/repo/fedora-%OS_VERSION%/trixieua-mutter-patched-fedora-%OS_VERSION%.repo
       packages:

--- a/modules/rpm-ostree/module.yml
+++ b/modules/rpm-ostree/module.yml
@@ -5,7 +5,6 @@ example: |
   repos:
     - https://copr.fedorainfracloud.org/coprs/atim/starship/repo/fedora-%OS_VERSION%/atim-starship-fedora-%OS_VERSION%.repo # when including COPR repos, use the %OS_VERSION% magic string
     - https://brave-browser-rpm-release.s3.brave.com/brave-browser.repo
-    - my-local-repository.repo # local repo located in `files/rpm-ostree/my-local-repository.repo`
   keys:
     - https://brave-browser-rpm-release.s3.brave.com/brave-core.asc
   optfix:

--- a/modules/rpm-ostree/rpm-ostree.sh
+++ b/modules/rpm-ostree/rpm-ostree.sh
@@ -54,19 +54,20 @@ LOCAL_INSTALL=false
 # Install and remove RPM packages
 # Sort classic, URL & local packages
 if [[ ${#INSTALL[@]} -gt 0 ]]; then
-    for PKG in "${INSTALL[@]}"; do
-    if [[ "$PKG" =~ ^https?:\/\/.* ]]; then
-      VERSION_SUBSTITUTED_PKG="${PKG//%OS_VERSION%/${OS_VERSION}}"    
-      HTTPS_INSTALL=true
-      HTTPS_PKG+=("${VERSION_SUBSTITUTED_PKG}")
-    elif [[ ! "$PKG" =~ ^https?:\/\/.* ]] && [[ -f "${CONFIG_DIRECTORY}/rpm-ostree/${PKG}" ]]; then
-      LOCAL_INSTALL=true
-      LOCAL_PKG+=("${CONFIG_DIRECTORY}/rpm-ostree/${PKG}")
-    else
-      CLASSIC_INSTALL=true
-      CLASSIC_PKG+=("${PKG}")
-    fi
-done
+  for PKG in "${INSTALL[@]}"; do
+      if [[ "$PKG" =~ ^https?:\/\/.* ]]; then
+        VERSION_SUBSTITUTED_PKG="${PKG//%OS_VERSION%/${OS_VERSION}}"    
+        HTTPS_INSTALL=true
+        HTTPS_PKG+=("${VERSION_SUBSTITUTED_PKG}")
+      elif [[ ! "$PKG" =~ ^https?:\/\/.* ]] && [[ -f "${CONFIG_DIRECTORY}/rpm-ostree/${PKG}" ]]; then
+        LOCAL_INSTALL=true
+        LOCAL_PKG+=("${CONFIG_DIRECTORY}/rpm-ostree/${PKG}")
+      else
+        CLASSIC_INSTALL=true
+        CLASSIC_PKG+=("${PKG}")
+      fi
+  done
+fi
 
 # The installation is done with some wordsplitting hacks
 # because of errors when doing array destructuring at the installation step.

--- a/modules/rpm-ostree/rpm-ostree.sh
+++ b/modules/rpm-ostree/rpm-ostree.sh
@@ -118,7 +118,27 @@ if [[ ${#INSTALL[@]} -gt 0 && ${#REMOVE[@]} -gt 0 ]]; then
     echo_rpm_install
     echo "Removing: ${REMOVE_STR[*]}"
     # Doing both actions in one command allows for replacing required packages with alternatives
-    rpm-ostree override remove $REMOVE_STR $(printf -- "--install=%s " $INSTALL_STR)
+    # When --install= flag is used, URLs & local packages are not supported
+    if ${CLASSIC_INSTALL} && ! ${HTTPS_INSTALL} && ! ${LOCAL_INSTALL}; then
+      CLASSIC_PKGS=$(echo "${CLASSIC_PKG[*]}" | tr -d '\n')
+      rpm-ostree override remove $REMOVE_STR $(printf -- "--install=%s " $CLASSIC_PKGS)
+    elif ${CLASSIC_INSTALL} && ${HTTPS_INSTALL} && ! ${LOCAL_INSTALL}; then
+      CLASSIC_PKGS=$(echo "${CLASSIC_PKG[*]}" | tr -d '\n')
+      HTTPS_PKGS=$(echo "${HTTPS_PKG[*]}" | tr -d '\n')
+      rpm-ostree override remove $REMOVE_STR $(printf -- "--install=%s " $CLASSIC_PKGS)
+      rpm-ostree install $HTTPS_PKGS
+    elif ${CLASSIC_INSTALL} && ! ${HTTPS_INSTALL} && ! ${LOCAL_INSTALL}; then
+      CLASSIC_PKGS=$(echo "${CLASSIC_PKG[*]}" | tr -d '\n')
+      LOCAL_PKGS=$(echo "${LOCAL_PKG[*]}" | tr -d '\n')
+      rpm-ostree override remove $REMOVE_STR $(printf -- "--install=%s " $CLASSIC_PKGS)    
+      rpm-ostree install $LOCAL_PKGS
+    elif ${CLASSIC_INSTALL} && ${HTTPS_INSTALL} && ${LOCAL_INSTALL}; then
+      CLASSIC_PKGS=$(echo "${CLASSIC_PKG[*]}" | tr -d '\n')
+      HTTPS_PKGS=$(echo "${HTTPS_PKG[*]}" | tr -d '\n')
+      LOCAL_PKGS=$(echo "${LOCAL_PKG[*]}" | tr -d '\n')
+      rpm-ostree override remove $REMOVE_STR $(printf -- "--install=%s " $CLASSIC_PKGS)
+      rpm-ostree install $HTTPS_PKGS $LOCAL_PKGS
+    fi  
 elif [[ ${#INSTALL[@]} -gt 0 ]]; then
     echo "Installing RPMs"
     echo_rpm_install

--- a/modules/rpm-ostree/rpm-ostree.sh
+++ b/modules/rpm-ostree/rpm-ostree.sh
@@ -12,7 +12,7 @@ if [[ ${#REPOS[@]} -gt 0 ]]; then
         if [[ "${REPO}" =~ ^https?:\/\/.* ]]; then
           curl --output-dir "/etc/yum.repos.d/" -O "${REPO//[$'\t\r\n ']}"
         elif [[ ! "${REPO}" =~ ^https?:\/\/.* ]] && [[ "${REPO}" == *".repo" ]] && [[ -f "${CONFIG_DIRECTORY}/rpm-ostree/${REPO}" ]]; then
-          cp "${CONFIG_DIRECTORY}/rpm-ostree/${REPO}" "/etc/yum.repos.d/${REPO}"
+          cp "${CONFIG_DIRECTORY}/rpm-ostree/${REPO}" "/etc/yum.repos.d/${REPO##*/}"
         fi  
     done
 fi


### PR DESCRIPTION
I also made installing packages more efficient, as rpm-ostree can install from URL, local RPM & classic RPM package at the same time, so there is no need to keep packages installing separately from URLs as it is now.
Exception to this is the case when `--install=` flag is used when doing `override remove`, where local & URL packages are not supported, so another run of `rpm-ostree install` is invoked.

I also made logs more informative for install section, so classic RPMs, local RPMs & URL RPMs are printed separately.

Edit: Tested & it works well, so it's ready. Waiting for review of potential doc or code improvements.