### PR TITLE
fix(yafti): Revert to `pip` installation method

### DIFF
--- a/modules/yafti/yafti.sh
+++ b/modules/yafti/yafti.sh
@@ -17,23 +17,11 @@ FIRSTBOOT_SCRIPT="${FIRSTBOOT_DATA}/launcher/login-profile.sh"
 PROFILED_DIR="/usr/etc/profile.d"
 FIRSTBOOT_LINK="${PROFILED_DIR}/ublue-firstboot.sh"
 
-# Fetch ublue COPR
-REPO="https://copr.fedorainfracloud.org/coprs/ublue-os/staging/repo/fedora-${OS_VERSION}/ublue-os-staging-fedora-${OS_VERSION}.repo"
-wget -O "/etc/yum.repos.d/ublue-os-staging-fedora-${OS_VERSION}.repo" "${REPO//[$'\t\r\n ']}"
-# Increase repo priority, since downstream Ublue images like Bluefin/Aurora & Bazzite can explicitly disable this repo in another .repo file
-echo "priority=90" >> "/etc/yum.repos.d/ublue-os-staging-fedora-${OS_VERSION}.repo"
+echo "Installing python3-pip and libadwaita"
+rpm-ostree install python3-pip libadwaita
 
-# Remove system python3-pydantic package if it's already installed, so yafti's older version is installed instead
-if rpm -q python3-pydantic >/dev/null; then
-  rpm-ostree uninstall python3-pydantic
-fi  
-
-# Install yafti RPM to fixed version, since refactored yafti should come after this version
-# We don't want to surprise users with that
-rpm-ostree install yafti-0.8.0
-
-# Remove ublue-staging COPR
-rm "/etc/yum.repos.d/ublue-os-staging-fedora-${OS_VERSION}.repo"
+echo "Installing and enabling yafti"
+pip install --prefix=/usr yafti==0.8.0
 
 # If the profile.d directory doesn't exist, create it
 if [ ! -d "${PROFILED_DIR}" ]; then


### PR DESCRIPTION
`rpm-ostree` method is not capable of installing yafti's older version of `python3-pydantic` instead of being confused between both system's & yafti's version of that package.

I tried to increase `ublue-os staging` repo priority, where yafti resides, but that doesn't work.

Pip method while not flawless with its hardlinking errors when same system package tries to get installed, it at least finishes yafti install successfully.