### PR TITLE
fix(rpm-ostree): Same-named repos are overwrited instead of being dow…

### DIFF
--- a/modules/rpm-ostree/rpm-ostree.sh
+++ b/modules/rpm-ostree/rpm-ostree.sh
@@ -9,8 +9,13 @@ if [[ ${#REPOS[@]} -gt 0 ]]; then
     echo "Adding repositories"
     for REPO in "${REPOS[@]}"; do
     REPO="${REPO//%OS_VERSION%/${OS_VERSION}}"
-        if [[ "${REPO}" =~ ^https?:\/\/.* ]]; then
+        # If it's the COPR repo, then download the repo normally
+        # If it's not, then download the repo with URL in it's filename, to avoid duplicate repo name issue
+        if [[ "${REPO}" =~ ^https?:\/\/.* ]] && [[ "${REPO}" == "https://copr.fedorainfracloud.org/coprs/"* ]]; then
           curl --output-dir "/etc/yum.repos.d/" -O "${REPO//[$'\t\r\n ']}"
+        elif [[ "${REPO}" =~ ^https?:\/\/.* ]] && [[ "${REPO}" != "https://copr.fedorainfracloud.org/coprs/"* ]]; then
+          CLEAN_REPO_NAME=$(echo "${REPO}" | sed 's/^https\?:\/\///')
+          curl -o "/etc/yum.repos.d/${CLEAN_REPO_NAME//\//.}" "${REPO//[$'\t\r\n ']}"
         elif [[ ! "${REPO}" =~ ^https?:\/\/.* ]] && [[ "${REPO}" == *".repo" ]] && [[ -f "${CONFIG_DIRECTORY}/rpm-ostree/${REPO}" ]]; then
           cp "${CONFIG_DIRECTORY}/rpm-ostree/${REPO}" "/etc/yum.repos.d/${REPO##*/}"
         fi  


### PR DESCRIPTION
…nloaded separately

If it's the COPR repo, then download it normally with the repo filename, since it would look ugly when it's too long & filename already indicates that it's the COPR repo in question.

If it's the repo other than COPR, then repo filename will be the URL ommited of `http(s)://` & replaced `/` with dots `.`

So
`https://packages.microsoft.com/yumrepos/edge/config.repo`

Would look like this:
`packages.microsoft.com.yumrepos.edge.config.repo`