### PR TITLE
fix: Set curl to silent and fail

### DIFF
--- a/modules/brew/brew.sh
+++ b/modules/brew/brew.sh
@@ -75,7 +75,8 @@ touch /.dockerenv
 
 # Always install Brew
 echo "Downloading and installing Brew..."
-curl -Lo /tmp/brew-install https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh
+curl -sfLo /tmp/brew-install https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh
+echo "Downloaded Brew install script"
 chmod +x /tmp/brew-install
 /tmp/brew-install
 
@@ -193,8 +194,10 @@ if [[ ! -d "/etc/profile.d/" ]]; then
 fi
 if [[ ! -f "/etc/profile.d/brew.sh" ]]; then
   echo "Apply brew path export fix, to solve path conflicts between system & brew programs with same name"
-  echo "#!/usr/bin/env bash
-[[ -d /home/linuxbrew/.linuxbrew && $- == *i* ]] && eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"" > "/etc/profile.d/brew.sh"
+  cat > /etc/profile.d/brew.sh <<EOF
+#!/usr/bin/env bash
+[[ -d /home/linuxbrew/.linuxbrew && $- == *i* ]] && eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
+EOF
 fi
 
 # Copy shell configuration files
@@ -234,7 +237,7 @@ fi
 
 # Apply nofile limits if enabled
 if [[ "${NOFILE_LIMITS}" == true ]]; then
-  source "${MODULE_DIRECTORY}"/brew/brew-nofile-limits-logic.sh
+  source "${MODULE_DIRECTORY}/brew/brew-nofile-limits-logic.sh"
 fi
 
 # Disable homebrew analytics if the flag is set to false

--- a/modules/brew/brew.sh
+++ b/modules/brew/brew.sh
@@ -196,7 +196,7 @@ if [[ ! -f "/etc/profile.d/brew.sh" ]]; then
   echo "Apply brew path export fix, to solve path conflicts between system & brew programs with same name"
   cat > /etc/profile.d/brew.sh <<EOF
 #!/usr/bin/env bash
-[[ -d /home/linuxbrew/.linuxbrew && $- == *i* ]] && eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
+[[ -d /home/linuxbrew/.linuxbrew && $- == *i* ]] && eval "\$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
 EOF
 fi
 

--- a/modules/chezmoi/chezmoi.sh
+++ b/modules/chezmoi/chezmoi.sh
@@ -93,7 +93,8 @@ else
 	echo "Checking if curl is installed and executable at /usr/bin/curl"
 	if [ -x /usr/bin/curl ]; then
 		echo "Downloading chezmoi binary from the latest Github release"
-		/usr/bin/curl -Ls https://github.com/twpayne/chezmoi/releases/latest/download/chezmoi-linux-amd64 -o /usr/bin/chezmoi
+		/usr/bin/curl -fLs https://github.com/twpayne/chezmoi/releases/latest/download/chezmoi-linux-amd64 -o /usr/bin/chezmoi
+		echo "Downloaded chezmoi binary and installed into /usr/bin"
 		echo "Ensuring chezmoi is executable"
 		/usr/bin/chmod 755 /usr/bin/chezmoi
 	else

--- a/modules/fonts/sources/google-fonts.sh
+++ b/modules/fonts/sources/google-fonts.sh
@@ -15,7 +15,7 @@ for FONT in "${FONTS[@]}"; do
 
         readarray -t "FILE_REFS" < <(
             if JSON=$(
-                curl -s "https://fonts.google.com/download/list?family=${FONT// /%20}" | # spaces are replaced with %20 for the URL
+                curl -sf "https://fonts.google.com/download/list?family=${FONT// /%20}" | # spaces are replaced with %20 for the URL
                 tail -n +2 # remove first line, which as of March 2024 contains ")]}'" and breaks JSON parsing
             ); then
                 if FILE_REFS=$(echo "$JSON" | jq -c '.manifest.fileRefs[]' 2>/dev/null); then
@@ -31,7 +31,8 @@ for FONT in "${FONTS[@]}"; do
                 if FILENAME=$(echo "${FILE_REF}" | jq -er '.filename' 2>/dev/null); then
                     if URL=$(echo "${FILE_REF}" | jq -er '.url' 2>/dev/null); then
                         echo "Downloading ${FILENAME} from ${URL}"
-                        curl "${URL}" -o "${DEST}/${FONT}/${FILENAME##*/}" # everything before the last / is removed to get the filename
+                        curl "${URL}" -sfo "${DEST}/${FONT}/${FILENAME##*/}" # everything before the last / is removed to get the filename
+                        echo "Downloaded ${FILENAME}"
                     else
                         echo "Failed to extract URLs for: ${FONT}" >&2
                     fi

--- a/modules/fonts/sources/nerd-fonts.sh
+++ b/modules/fonts/sources/nerd-fonts.sh
@@ -15,8 +15,9 @@ for FONT in "${FONTS[@]}"; do
         mkdir -p "${DEST}/${FONT}"
 
         echo "Downloading ${FONT} from ${URL}/${FONT}.tar.xz"
-        
-        curl "${URL}/${FONT}.tar.xz" -L -o "/tmp/fonts/${FONT}.tar.xz"
+        curl "${URL}/${FONT}.tar.xz" -sfL -o "/tmp/fonts/${FONT}.tar.xz"
+        echo "Downloaded ${FONT}"
+
         tar -xf "/tmp/fonts/${FONT}.tar.xz" -C "${DEST}/${FONT}"
     fi
 done

--- a/modules/gnome-extensions/gnome-extensions.sh
+++ b/modules/gnome-extensions/gnome-extensions.sh
@@ -133,7 +133,7 @@ if [[ ${#INSTALL[@]} -gt 0 ]] && ! "${LEGACY}"; then
         # Literal-name extension config
         # Replaces whitespaces with %20 for install entries which contain extension name, since URLs can't contain whitespace      
         WHITESPACE_HTML="${INSTALL_EXT// /%20}"
-        URL_QUERY=$(curl -s "https://extensions.gnome.org/extension-query/?search=${WHITESPACE_HTML}")
+        URL_QUERY=$(curl -sf "https://extensions.gnome.org/extension-query/?search=${WHITESPACE_HTML}")
         QUERIED_EXT=$(echo "${URL_QUERY}" | jq ".extensions[] | select(.name == \"${INSTALL_EXT}\")")
         if [[ -z "${QUERIED_EXT}" ]] || [[ "${QUERIED_EXT}" == "null" ]]; then
           echo "ERROR: Extension '${INSTALL_EXT}' does not exist in https://extensions.gnome.org/ website"
@@ -158,7 +158,7 @@ if [[ ${#INSTALL[@]} -gt 0 ]] && ! "${LEGACY}"; then
         fi
       else
         # PK ID extension config fallback if specified
-        URL_QUERY=$(curl -s "https://extensions.gnome.org/extension-info/?pk=${INSTALL_EXT}")
+        URL_QUERY=$(curl -sf "https://extensions.gnome.org/extension-info/?pk=${INSTALL_EXT}")
         PK_EXT=$(echo "${URL_QUERY}" | jq -r '.["pk"]' 2>/dev/null)
         if [[ -z "${PK_EXT}" ]] || [[ "${PK_EXT}" == "null" ]]; then
           echo "ERROR: Extension with PK ID '${INSTALL_EXT}' does not exist in https://extensions.gnome.org/ website"
@@ -237,7 +237,7 @@ if [[ ${#UNINSTALL[@]} -gt 0 ]]; then
         # Replaces whitespaces with %20 for install entries which contain extension name, since URLs can't contain whitespace
         # Getting json query from the website is useful to intuitively uninstall the extension without need to manually input UUID
         WHITESPACE_HTML="${UNINSTALL_EXT// /%20}"
-        URL_QUERY=$(curl -s "https://extensions.gnome.org/extension-query/?search=${WHITESPACE_HTML}")
+        URL_QUERY=$(curl -sf "https://extensions.gnome.org/extension-query/?search=${WHITESPACE_HTML}")
         QUERIED_EXT=$(echo "${URL_QUERY}" | jq ".extensions[] | select(.name == \"${UNINSTALL_EXT}\")")
         if [[ -z "${QUERIED_EXT}" ]] || [[ "${QUERIED_EXT}" == "null" ]]; then
           echo "ERROR: Extension '${UNINSTALL_EXT}' does not exist in https://extensions.gnome.org/ website"
@@ -249,7 +249,7 @@ if [[ ${#UNINSTALL[@]} -gt 0 ]]; then
         EXT_NAME=$(echo "${QUERIED_EXT}" | jq -r '.["name"]')
       else
         # PK ID extension config fallback if specified
-        URL_QUERY=$(curl -s "https://extensions.gnome.org/extension-info/?pk=${UNINSTALL_EXT}")
+        URL_QUERY=$(curl -sf "https://extensions.gnome.org/extension-info/?pk=${UNINSTALL_EXT}")
         PK_EXT=$(echo "${URL_QUERY}" | jq -r '.["pk"]' 2>/dev/null)
         if [[ -z "${PK_EXT}" ]] || [[ "${PK_EXT}" == "null" ]]; then
           echo "ERROR: Extension with PK ID '${UNINSTALL_EXT}' does not exist in https://extensions.gnome.org/ website"

--- a/modules/rpm-ostree/rpm-ostree.sh
+++ b/modules/rpm-ostree/rpm-ostree.sh
@@ -20,7 +20,7 @@ if [[ ${#REPOS[@]} -gt 0 ]]; then
         elif [[ "${REPO}" =~ ^https?:\/\/.* ]] && [[ "${REPO}" != "https://copr.fedorainfracloud.org/coprs/"* ]]; then
           REPO_URL="${REPO//[$'\t\r\n ']}"
           CLEAN_REPO_NAME=$(echo "${REPO_URL}" | sed 's/^https\?:\/\///')
-          CLEAN_REPO_NAME=$(echo "${CLEAN_REPO_NAME//\//.}")
+          CLEAN_REPO_NAME="${CLEAN_REPO_NAME//\//.}"
           
           echo "Downloading repo file ${REPO_URL}"
           curl -fs -o "/etc/yum.repos.d/${CLEAN_REPO_NAME}" "${REPO_URL}"

--- a/modules/rpm-ostree/rpm-ostree.sh
+++ b/modules/rpm-ostree/rpm-ostree.sh
@@ -18,11 +18,13 @@ if [[ ${#REPOS[@]} -gt 0 ]]; then
           curl -fs --output-dir "/etc/yum.repos.d/" -O "${REPO_URL}"
           echo "Downloaded repo file ${REPO_URL}"
         elif [[ "${REPO}" =~ ^https?:\/\/.* ]] && [[ "${REPO}" != "https://copr.fedorainfracloud.org/coprs/"* ]]; then
-          CLEAN_REPO_NAME=$(echo "${REPO}" | sed 's/^https\?:\/\///')
-
-          echo "Downloading repo file ${REPO}"
-          curl -fs -o "/etc/yum.repos.d/${CLEAN_REPO_NAME//\//.}" "${REPO//[$'\t\r\n ']}"
-          echo "Downloaded repo file ${REPO}"
+          REPO_URL="${REPO//[$'\t\r\n ']}"
+          CLEAN_REPO_NAME=$(echo "${REPO_URL}" | sed 's/^https\?:\/\///')
+          CLEAN_REPO_NAME=$(echo "${CLEAN_REPO_NAME//\//.}")
+          
+          echo "Downloading repo file ${REPO_URL}"
+          curl -fs -o "/etc/yum.repos.d/${CLEAN_REPO_NAME}" "${REPO_URL}"
+          echo "Downloaded repo file ${REPO_URL}"
         elif [[ ! "${REPO}" =~ ^https?:\/\/.* ]] && [[ "${REPO}" == *".repo" ]] && [[ -f "${CONFIG_DIRECTORY}/rpm-ostree/${REPO}" ]]; then
           cp "${CONFIG_DIRECTORY}/rpm-ostree/${REPO}" "/etc/yum.repos.d/${REPO##*/}"
         fi  

--- a/modules/rpm-ostree/rpm-ostree.sh
+++ b/modules/rpm-ostree/rpm-ostree.sh
@@ -12,10 +12,17 @@ if [[ ${#REPOS[@]} -gt 0 ]]; then
         # If it's the COPR repo, then download the repo normally
         # If it's not, then download the repo with URL in it's filename, to avoid duplicate repo name issue
         if [[ "${REPO}" =~ ^https?:\/\/.* ]] && [[ "${REPO}" == "https://copr.fedorainfracloud.org/coprs/"* ]]; then
-          curl --output-dir "/etc/yum.repos.d/" -O "${REPO//[$'\t\r\n ']}"
+          REPO_URL="${REPO//[$'\t\r\n ']}"
+
+          echo "Downloading repo file ${REPO_URL}"
+          curl -fs --output-dir "/etc/yum.repos.d/" -O "${REPO_URL}"
+          echo "Downloaded repo file ${REPO_URL}"
         elif [[ "${REPO}" =~ ^https?:\/\/.* ]] && [[ "${REPO}" != "https://copr.fedorainfracloud.org/coprs/"* ]]; then
           CLEAN_REPO_NAME=$(echo "${REPO}" | sed 's/^https\?:\/\///')
-          curl -o "/etc/yum.repos.d/${CLEAN_REPO_NAME//\//.}" "${REPO//[$'\t\r\n ']}"
+
+          echo "Downloading repo file ${CLEAN_REPO_NAME}"
+          curl -fs -o "/etc/yum.repos.d/${CLEAN_REPO_NAME//\//.}" "${REPO//[$'\t\r\n ']}"
+          echo "Downloaded repo file ${CLEAN_REPO_NAME}"
         elif [[ ! "${REPO}" =~ ^https?:\/\/.* ]] && [[ "${REPO}" == *".repo" ]] && [[ -f "${CONFIG_DIRECTORY}/rpm-ostree/${REPO}" ]]; then
           cp "${CONFIG_DIRECTORY}/rpm-ostree/${REPO}" "/etc/yum.repos.d/${REPO##*/}"
         fi  
@@ -158,8 +165,13 @@ if [[ ${#REPLACE[@]} -gt 0 ]]; then
         echo "Replacing packages from COPR repository: '${REPO_NAME}' owned by '${MAINTAINER}'"
         echo "Replacing: ${REPLACE_STR}"
 
-        curl --output-dir "/etc/yum.repos.d/" -O "${REPO//[$'\t\r\n ']}"
-        rpm-ostree override replace --experimental --from repo=copr:copr.fedorainfracloud.org:${MAINTAINER}:${REPO_NAME} ${REPLACE_STR}
+        REPO_URL="${REPO//[$'\t\r\n ']}"
+
+        echo "Downloading repo file ${REPO_URL}"
+        curl -fs --output-dir "/etc/yum.repos.d/" -O "${REPO_URL}"
+        echo "Downloaded repo file ${REPO_URL}"
+
+        rpm-ostree override replace --experimental --from "repo=copr:copr.fedorainfracloud.org:${MAINTAINER}:${REPO_NAME}" "${REPLACE_STR}"
         rm "/etc/yum.repos.d/${FILE_NAME}"
 
     done

--- a/modules/rpm-ostree/rpm-ostree.sh
+++ b/modules/rpm-ostree/rpm-ostree.sh
@@ -20,9 +20,9 @@ if [[ ${#REPOS[@]} -gt 0 ]]; then
         elif [[ "${REPO}" =~ ^https?:\/\/.* ]] && [[ "${REPO}" != "https://copr.fedorainfracloud.org/coprs/"* ]]; then
           CLEAN_REPO_NAME=$(echo "${REPO}" | sed 's/^https\?:\/\///')
 
-          echo "Downloading repo file ${CLEAN_REPO_NAME}"
+          echo "Downloading repo file ${REPO}"
           curl -fs -o "/etc/yum.repos.d/${CLEAN_REPO_NAME//\//.}" "${REPO//[$'\t\r\n ']}"
-          echo "Downloaded repo file ${CLEAN_REPO_NAME}"
+          echo "Downloaded repo file ${REPO}"
         elif [[ ! "${REPO}" =~ ^https?:\/\/.* ]] && [[ "${REPO}" == *".repo" ]] && [[ -f "${CONFIG_DIRECTORY}/rpm-ostree/${REPO}" ]]; then
           cp "${CONFIG_DIRECTORY}/rpm-ostree/${REPO}" "/etc/yum.repos.d/${REPO##*/}"
         fi  


### PR DESCRIPTION
While working on enhanced logging, I noticed that the control characters for curl's download log was causing weird issues. This is generally not something you want in docker logging anyways, so I silenced all instances of curl I could find. I also noticed that many of those same curl calls were not set to fail, so I updated that too while I was in there. More atomicity!