### PR TITLE
chore(scripts): Migrate module name from `script` to `scripts`

### DIFF
--- a/modules.json
+++ b/modules.json
@@ -10,7 +10,7 @@
   "https://raw.githubusercontent.com/blue-build/modules/main/modules/gschema-overrides/module.yml",
   "https://raw.githubusercontent.com/blue-build/modules/main/modules/justfiles/module.yml",  
   "https://raw.githubusercontent.com/blue-build/modules/main/modules/rpm-ostree/module.yml",
-  "https://raw.githubusercontent.com/blue-build/modules/main/modules/script/module.yml",
+  "https://raw.githubusercontent.com/blue-build/modules/main/modules/scripts/module.yml",
   "https://raw.githubusercontent.com/blue-build/modules/main/modules/signing/module.yml",
   "https://raw.githubusercontent.com/blue-build/modules/main/modules/systemd/module.yml",
   "https://raw.githubusercontent.com/blue-build/modules/main/modules/yafti/module.yml"

--- a/modules/script/legacy-compatibility-placeholder.md
+++ b/modules/script/legacy-compatibility-placeholder.md
@@ -1,0 +1,3 @@
+`script.sh` should mimic `scripts.sh` code, in order to retain compatibility with existing custom image users which use `script` as a module name instead of new `scripts` module name.
+
+This is done in order to standardize module naming convention better.

--- a/modules/scripts/README.md
+++ b/modules/scripts/README.md
@@ -1,6 +1,6 @@
-# `script`
+# `scripts`
 
-The `script` module can be used to run arbitrary bash snippets and scripts at image build time. This is intended for running commands that need no YAML configuration.
+The `scripts` module can be used to run arbitrary bash snippets and scripts at image build-time. This is intended for running commands that need no YAML configuration.
 
 The snippets, which are run in a bash subshell, are declared under `snippets:`.   
 The scripts, which are run from the `files/scripts/` directory, are declared under `scripts:`.

--- a/modules/scripts/README.md
+++ b/modules/scripts/README.md
@@ -1,5 +1,7 @@
 # `scripts`
 
+:::caution For the sake of module naming consistency, we renamed `script` module to `scripts`. Custom images which utilize `script` as a module name will still work, but it is advised to rename it to `scripts` in recipe. :::
+
 The `scripts` module can be used to run arbitrary bash snippets and scripts at image build-time. This is intended for running commands that need no YAML configuration.
 
 The snippets, which are run in a bash subshell, are declared under `snippets:`.   

--- a/modules/scripts/module.yml
+++ b/modules/scripts/module.yml
@@ -1,7 +1,7 @@
-name: script
-shortdesc: The script module can be used to run arbitrary bash snippets and scripts at image build time.
+name: scripts
+shortdesc: The scripts module can be used to run arbitrary bash snippets and scripts at image build time.
 example: |
-  type: script
+  type: scripts
   snippets:
     - "curl https://example.com/examplebinary > /usr/bin/examplebinary" # example: download binary
     - "ln -sf /usr/bin/ld.bfd /etc/alternatives/ld && ln -sf /etc/alternatives/ld /usr/bin/ld" # example: ld alternatives symlink workaround

--- a/modules/scripts/scripts.sh
+++ b/modules/scripts/scripts.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+# Tell build process to exit if there are any errors.
+set -euo pipefail
+
+get_yaml_array SCRIPTS '.scripts[]' "$1"
+get_yaml_array SNIPPETS '.snippets[]' "$1"
+
+cd "$CONFIG_DIRECTORY/scripts"
+# Make every script executable
+find "$PWD" -type f -exec chmod +x {} \;
+for SCRIPT in "${SCRIPTS[@]}"; do
+    echo "Running script $SCRIPT"
+    "$PWD/$SCRIPT"
+done
+
+for SNIPPET in "${SNIPPETS[@]}"; do
+    echo "Running snippet $SNIPPET"
+    bash -c "$SNIPPET"
+done

--- a/modules/scripts/scripts.tsp
+++ b/modules/scripts/scripts.tsp
@@ -1,12 +1,12 @@
 import "@typespec/json-schema";
 using TypeSpec.JsonSchema;
 
-@jsonSchema("/modules/script.json")
+@jsonSchema("/modules/scripts.json")
 model ScriptModule {
-    /** The script module can be used to run arbitrary bash snippets and scripts at image build time.
-     * https://blue-build.org/reference/modules/script/
+    /** The scripts module can be used to run arbitrary bash snippets and scripts at image build time.
+     * https://blue-build.org/reference/modules/scripts/
      */
-    type: "script";
+    type: "scripts";
 
     /** List of bash one-liners to run. */
     snippets?: Array<string>;


### PR DESCRIPTION
Placeholder `script.sh` is used, so custom images with old `script` module name will still work.
Added the caution card which informs users about this.

Some `website` parts should also be updated to reflect the new module name.
Maybe some CLI changes are needed as well.

https://github.com/blue-build/website/pull/66
https://github.com/blue-build/cli/pull/229