### PR TITLE
fix(default-flatpaks): `Couldn't resolve host name` in some network setups

### DIFF
--- a/modules/default-flatpaks/v1/system-flatpak-setup
+++ b/modules/default-flatpaks/v1/system-flatpak-setup
@@ -1,5 +1,28 @@
 #!/usr/bin/env bash
 
+# Check for available internet connection before proceeding (network-online.target doesn't work for some network connections)
+# Check it 3 times in 3 second interval, to avoid until loop
+# Used when adding remotes & when installing flatpaks
+check_internet_connection() {
+    local max_attempts=3
+    local sleep_time=3
+    local attempt=1
+
+    while [[ ${attempt} -le ${max_attempts} ]]; do
+        if curl --silent --head --fail "https://fedoraproject.org/static/hotspot.txt" > /dev/null; then
+            internet_connection=true
+            return 0
+        else
+            internet_connection=false  
+            echo "Internet connection is not available. Waiting..."
+            sleep ${sleep_time}
+            attempt=$((attempt + 1))
+        fi
+    done
+
+    echo "ERROR: Internet connection is not available. Skipping the operation above."
+}
+
 # Opt out of and remove Fedora's system flatpak repos
 FLATPAK_SYSTEM_REMOTES=($(flatpak --system remotes))
 
@@ -103,8 +126,11 @@ done
 # Set up system-wide Flatpak repository
 if [[ $REPO_URL != "null" && $REPO_NAME != "null" ]]; then
   echo "Adding system-wide remote $REPO_NAME from $REPO_URL"  
-  echo "Note that --if-not-exists flag doesn't prevent the repo from modifying repo URL"  
-  flatpak remote-add --if-not-exists --system "$REPO_NAME" "$REPO_URL"
+  echo "Note that --if-not-exists flag doesn't prevent the repo from modifying repo URL"
+  check_internet_connection
+  if "${internet_connection}"; then
+    flatpak remote-add --if-not-exists --system "$REPO_NAME" "$REPO_URL"
+  fi  
 fi
 
 # If configured remote is flathub, enable it here.
@@ -189,11 +215,19 @@ if [[ -f $INSTALL_LIST_FILE ]] || [[ -f $USER_INSTALL_LIST_FILE ]]; then
     INSTALL_LIST="$COMBINED_INSTALL_LIST"
   fi
   if [[ -n $INSTALL_LIST ]] && [[ ! $NOTIFICATIONS == "true" ]]; then
-    flatpak install --system --noninteractive "$REPO_NAME" ${INSTALL_LIST[@]}
+    echo "Installing system flatpaks from config list"
+    check_internet_connection
+    if "${internet_connection}"; then
+      flatpak install --system --noninteractive "$REPO_NAME" ${INSTALL_LIST[@]}
+    fi  
   elif  [[ -n $INSTALL_LIST ]] && [[ $NOTIFICATIONS == "true" ]]; then
-    notify-send-pre-install
-    flatpak install --system --noninteractive "$REPO_NAME" ${INSTALL_LIST[@]}
-    notify-send-install
+    echo "Installing system flatpaks from config list"
+    check_internet_connection
+    if "${internet_connection}"; then
+      notify-send-pre-install
+      flatpak install --system --noninteractive "$REPO_NAME" ${INSTALL_LIST[@]}
+      notify-send-install
+    fi  
   fi
 fi
 
@@ -201,8 +235,10 @@ fi
 if [[ -f $REMOVE_LIST_FILE ]] || [[ -f $USER_REMOVE_LIST_FILE ]]; then
   REMOVE_LIST=$(comm -12 <(echo "$COMBINED_REMOVE_LIST" | sort) <(echo "$FLATPAK_LIST" | sort))
   if [[ -n $REMOVE_LIST ]] && [[ ! $NOTIFICATIONS == "true" ]]; then
+    echo "Removing system flatpaks from config list"
     flatpak uninstall --system --noninteractive ${REMOVE_LIST[@]}
   elif [[ -n $REMOVE_LIST ]] && [[ $NOTIFICATIONS == "true" ]]; then
+    echo "Removing system flatpaks from config list"
     notify-send-pre-uninstall
     flatpak uninstall --system --noninteractive ${REMOVE_LIST[@]}
     notify-send-uninstall

--- a/modules/default-flatpaks/v1/system-flatpak-setup.service
+++ b/modules/default-flatpaks/v1/system-flatpak-setup.service
@@ -8,7 +8,7 @@ Type=oneshot
 ExecStart=/usr/bin/system-flatpak-setup
 Restart=on-failure
 RestartSec=30
-StartLimitInterval=0
+StartLimitInterval=3
 
 [Install]
 WantedBy=multi-user.target

--- a/modules/default-flatpaks/v1/user-flatpak-setup
+++ b/modules/default-flatpaks/v1/user-flatpak-setup
@@ -1,5 +1,28 @@
 #!/usr/bin/env bash
 
+# Check for available internet connection before proceeding (network-online.target doesn't work for some network connections)
+# Check it 3 times in 3 second interval, to avoid until loop
+# Used when adding remotes & when installing flatpaks
+check_internet_connection() {
+    local max_attempts=3
+    local sleep_time=3
+    local attempt=1
+
+    while [[ ${attempt} -le ${max_attempts} ]]; do
+        if curl --silent --head --fail "https://fedoraproject.org/static/hotspot.txt" > /dev/null; then
+            internet_connection=true
+            return 0
+        else
+            internet_connection=false
+            echo "Internet connection is not available. Waiting..."
+            sleep ${sleep_time}
+            attempt=$((attempt + 1))
+        fi
+    done
+
+    echo "ERROR: Internet connection is not available. Skipping the operation above."
+}
+
 # Remove Fedora's flatpak user repos, if they exist
 FLATPAK_USER_REMOTES=($(flatpak --user remotes))
 
@@ -91,7 +114,10 @@ done
 if [[ $REPO_URL != "null" && $REPO_NAME != "null" ]]; then
   echo "Adding remote $REPO_NAME from $REPO_URL"
   echo "Note that --if-not-exists flag doesn't prevent the repo from modifying repo URL"  
-  flatpak remote-add --if-not-exists --user "$REPO_NAME" "$REPO_URL"
+  check_internet_connection
+  if "${internet_connection}"; then
+    flatpak remote-add --if-not-exists --user "$REPO_NAME" "$REPO_URL"
+  fi  
 fi
 
 # Change repository title to configured title, if not null & if not already changed
@@ -140,11 +166,19 @@ if [[ -f $INSTALL_LIST_FILE ]] || [[ -f $USER_INSTALL_LIST_FILE ]]; then
     INSTALL_LIST="$COMBINED_INSTALL_LIST"
   fi
   if [[ -n $INSTALL_LIST ]] && [[ ! $NOTIFICATIONS == "true" ]]; then
-    flatpak install --user --noninteractive "$REPO_NAME" ${INSTALL_LIST[@]}
+    echo "Installing user flatpaks from config list"
+    check_internet_connection
+    if "${internet_connection}"; then
+      flatpak install --user --noninteractive "$REPO_NAME" ${INSTALL_LIST[@]}
+    fi  
   elif  [[ -n $INSTALL_LIST ]] && [[ $NOTIFICATIONS == "true" ]]; then
-    notify-send "Flatpak Installer" "Started install of user flatpaks" --app-name="Flatpak Installer" -u NORMAL
-    flatpak install --user --noninteractive "$REPO_NAME" ${INSTALL_LIST[@]}  
-    notify-send "Flatpak Installer" "Finished install of user flatpaks:\n$INSTALL_LIST" --app-name="Flatpak Installer" -u NORMAL
+    echo "Installing user flatpaks from config list"
+    check_internet_connection
+    if "${internet_connection}"; then
+      notify-send "Flatpak Installer" "Started install of user flatpaks" --app-name="Flatpak Installer" -u NORMAL
+      flatpak install --user --noninteractive "$REPO_NAME" ${INSTALL_LIST[@]}  
+      notify-send "Flatpak Installer" "Finished install of user flatpaks:\n$INSTALL_LIST" --app-name="Flatpak Installer" -u NORMAL
+    fi  
   fi
 fi
 
@@ -152,8 +186,10 @@ fi
 if [[ -f $REMOVE_LIST_FILE ]] || [[ -f $USER_REMOVE_LIST_FILE ]]; then
   REMOVE_LIST=$(comm -12 <(echo "$COMBINED_REMOVE_LIST" | sort) <(echo "$FLATPAK_LIST" | sort))
   if [[ -n $REMOVE_LIST ]] && [[ ! $NOTIFICATIONS == "true" ]]; then
+    echo "Removing user flatpaks from config list"
     flatpak uninstall --user --noninteractive ${REMOVE_LIST[@]}
   elif [[ -n $REMOVE_LIST ]] && [[ $NOTIFICATIONS == "true" ]]; then
+    echo "Removing user flatpaks from config list"
     notify-send "Flatpak Installer" "Started uninstall of some user flatpaks" --app-name="Flatpak Installer" -u NORMAL  
     flatpak uninstall --user --noninteractive ${REMOVE_LIST[@]}  
     notify-send "Flatpak Installer" "Finished uninstall of user flatpaks:\n$REMOVE_LIST" --app-name="Flatpak Installer" -u NORMAL

--- a/modules/default-flatpaks/v1/user-flatpak-setup.service
+++ b/modules/default-flatpaks/v1/user-flatpak-setup.service
@@ -8,7 +8,7 @@ Type=simple
 ExecStart=/usr/bin/user-flatpak-setup
 Restart=on-failure
 RestartSec=30
-StartLimitInterval=0
+StartLimitInterval=3
 
 [Install]
 WantedBy=default.target


### PR DESCRIPTION
Fixes: https://github.com/blue-build/modules/issues/346

This is the attempt to fix this `default-flatpaks` error in some network setups (when internet connection is not yet fully established when service is started).

If `network-online.target` in service is not sufficient, network is checked 3 times with 3 seconds pause.
I use the same server which Fedora uses to check the connection.

I also modified the setup, so internet-dependent tasks like adding remotes & installing flatpaks will be just skipped if there is no internet connection, while rest of the offline tasks will be performed.

`StartLimitInterval=0` is currently set to infinitely restart the setup until it performs without any errors. This can be problematic if users don't have the internet connection for some good period of time, so I set this to `3`, which is sufficient enough imo.

The only thing that is not implemented right now, is that setup doesn't retry on those skipped operations due to no internet connection, because it would then skip other offline operations. So using `exit 1` is not sufficient.
It's also tricky that adding remote task can't be skipped if it's already present, as flatpakref & repo URL are not the same for comparison. So we would needlessly restart the setup in this scenario if user doesn't have internet, but has the same remote already present.
It also should be noted that `Restart-on-failure` doesn't always trigger for some errors (like it doesn't trigger in `Couldn't resolve host name` when adding remote).
Because of that complexity, I won't implement that.

I tested this locally & it works well.