### PR TITLE
docs(justfiles): Add Bluefin's Just documentation

### DIFF
--- a/modules/justfiles/README.md
+++ b/modules/justfiles/README.md
@@ -13,7 +13,7 @@ Just is a command runner (kind of like make) that can be used to supply arbitrar
 For more information, refer to these links:
 
 * [Official just documentation](https://just.systems/man/en)
-* [Universal Blue documentation](https://universal-blue.discourse.group/docs?topic=42)
+* [Universal Blue documentation](https://docs.projectbluefin.io/administration#community-aliases-and-workarounds)
 * [BlueBuild documentation](https://blue-build.org/learn/universal-blue/#custom-just-recipes)
 
 ## What the module does


### PR DESCRIPTION
The old link is gone and I feel this might be the most "catch-all" documentation we have.