### PR TITLE
chore(default-flatpaks): Temporarily remove auto-restart of services

### DIFF
--- a/modules/default-flatpaks/v1/system-flatpak-setup.service
+++ b/modules/default-flatpaks/v1/system-flatpak-setup.service
@@ -6,6 +6,3 @@ After=network-online.target
 [Service]
 Type=oneshot
 ExecStart=/usr/bin/system-flatpak-setup
-Restart=on-failure
-RestartSec=30
-StartLimitInterval=3

--- a/modules/default-flatpaks/v1/user-flatpak-setup.service
+++ b/modules/default-flatpaks/v1/user-flatpak-setup.service
@@ -6,6 +6,3 @@ After=system-flatpak-setup.service
 [Service]
 Type=oneshot
 ExecStart=/usr/bin/user-flatpak-setup
-Restart=on-failure
-RestartSec=30
-StartLimitInterval=3


### PR DESCRIPTION
The issue with the current setup is that infinite loop restarts can potentially happen (when user has no internet connection or similar), which is a no go (even with the restart limits set). 

This is something I encountered for some unrelated systemd service I tested.

Information online about how systemd restart behaves in units is very confusing & conflicting, some say that some options are outdated, some undocumented, some non-working etc.

https://serverfault.com/questions/736624/systemd-service-automatic-restart-after-startlimitinterval

So to avoid potential bad scenario, let's disable this.