### PR TITLE
fix(default-flatpaks): Allow usage of Fedora flatpak remote

### DIFF
--- a/modules/default-flatpaks/README.md
+++ b/modules/default-flatpaks/README.md
@@ -1,6 +1,6 @@
 # `default-flatpaks`
 
-The `default-flatpaks` module can be used to install or uninstall Flatpaks from a configurable remote on every boot. It skips that operation if no changes are detected. This module first removes the Fedora Flatpaks remote and Flatpaks that come pre-installed in Fedora. A Flatpak remote is configured the first time the module is used, but it can be re-configured in subsequent usages of the module. If no Flatpak remote is specified, the module will default to using Flathub.
+The `default-flatpaks` module can be used to install or uninstall Flatpaks from a configurable remote on every boot. It skips that operation if no changes are detected. This module, first removes the Fedora Flatpaks remote and Flatpaks that come pre-installed in Fedora (unless Fedora remote is strictly specified in recipe). A Flatpak remote is configured the first time the module is used, but it can be re-configured in subsequent usages of the module. If no Flatpak remote is specified, the module will default to using Flathub.
 
 Flatpaks can either be installed system-wide or per-user. Per-user Flatpaks will be installed separately for every user on a system. Previously-installed flatpaks can also be removed.
 
@@ -19,6 +19,8 @@ The scripts are run on every boot by these services:
 This module stores the Flatpak remote configuration and Flatpak install/remove lists in `/usr/share/bluebuild/default-flatpaks/`. There are two subdirectories, `user` and `system` corresponding with the install level of the Flatpaks and repositories. Each directory has text files containing the IDs of flatpaks to `install` and `remove`, plus a `repo-info.yml` containing the details of the Flatpak repository.
 
 This module also supports disabling & enabling notifications. If not specified in the recipe, notifications are disabled by default.
+
+If you wish to use the Fedora flatpak remote, you just need to specify it in the recipe & it won't be removed (note that only `fedora` remote is supported, while `fedora-testing` isn't).
 
 ## Local modification
 

--- a/modules/default-flatpaks/README.md
+++ b/modules/default-flatpaks/README.md
@@ -20,7 +20,7 @@ This module stores the Flatpak remote configuration and Flatpak install/remove l
 
 This module also supports disabling & enabling notifications. If not specified in the recipe, notifications are disabled by default.
 
-If you wish to use the Fedora flatpak remote, you just need to specify it in the recipe & it won't be removed (note that only `fedora` remote is supported, while `fedora-testing` isn't).
+If you wish to continue the use of Fedora flatpak remote & it's installed apps on booted system, you just need to specify the remote in the recipe (`repo-name` + `repo-url`) & remote + all apps won't be removed (note that only `fedora` remote is supported, while `fedora-testing` isn't). When you do that, you can further customize flatpaks you want to install or remove from Fedora flatpak remote.
 
 ## Local modification
 

--- a/modules/default-flatpaks/v1/system-flatpak-setup
+++ b/modules/default-flatpaks/v1/system-flatpak-setup
@@ -21,6 +21,11 @@ check_internet_connection() {
     return 1
 }
 
+REPO_INFO="/usr/share/bluebuild/default-flatpaks/system/repo-info.yml"
+REPO_URL=$(yq '.repo-url' $REPO_INFO)
+REPO_NAME=$(yq '.repo-name' $REPO_INFO)
+REPO_TITLE=$(yq '.repo-title' $REPO_INFO)
+
 # Opt out of and remove Fedora's system flatpak repos
 FLATPAK_SYSTEM_REMOTES=($(flatpak --system remotes))
 
@@ -48,12 +53,18 @@ else
   echo "ERROR: Cannot opt-out from Fedora third-party repos, because fedora-third-party package is not installed"
 fi
 
-if "${fedora_system}"; then
-  echo "Removing system flatpak remote 'fedora'"
-  flatpak remote-delete --system fedora --force
+# Remove fedora system remote, unless fedora remote is strictly specified
+if [[ ! "${REPO_URL}" == "oci+https://registry.fedoraproject.org" ]]; then
+  if "${fedora_system}"; then
+    echo "Removing system flatpak remote 'fedora'"
+    flatpak remote-delete --system fedora --force
+  else
+    echo "System flatpak remote 'fedora' is already removed"  
+  fi
 else
-  echo "System flatpak remote 'fedora' is already removed"  
+  echo "Not removing the system flatpak remote 'fedora', as it's specified for use in config"  
 fi
+
 if "${fedora_testing_system}"; then
   echo "Removing system flatpak remote 'fedora-testing'"
   flatpak remote-delete --system fedora-testing --force
@@ -61,23 +72,31 @@ else
   echo "System flatpak remote 'fedora-testing' is already removed"  
 fi
 
-# Remove flatpak apps from system origin fedora
-FEDORA_FLATPAKS_APP=($(flatpak list --system --app --columns=application,origin | awk '$2 == "fedora" {print $1}'))
-if [[ ${#FEDORA_FLATPAKS_APP[@]} -gt 0 ]]; then
-  echo "Removing system flatpak apps from 'fedora' remote"
-  flatpak remove --system --noninteractive "${FEDORA_FLATPAKS_APP[@]}"
+# Remove flatpak apps from system origin fedora, unless fedora remote is strictly specified
+if [[ ! "${REPO_URL}" == "oci+https://registry.fedoraproject.org" ]]; then
+  FEDORA_FLATPAKS_APP=($(flatpak list --system --app --columns=application,origin | awk '$2 == "fedora" {print $1}'))
+  if [[ ${#FEDORA_FLATPAKS_APP[@]} -gt 0 ]]; then
+    echo "Removing system flatpak apps from 'fedora' remote"
+    flatpak remove --system --noninteractive "${FEDORA_FLATPAKS_APP[@]}"
+  else
+    echo "System flatpak apps from 'fedora' remote are already removed"
+  fi
 else
-  echo "System flatpak apps from 'fedora' remote are already removed"
-fi  
+  echo "Not automatically removing all flatpak apps from system remote 'fedora', as it's specified for use in config"
+fi
 
-# Remove flatpak runtimes from system origin fedora
-FEDORA_FLATPAKS_RUNTIME=($(flatpak list --system --runtime --columns=application,arch,branch,origin | awk '$4 == "fedora" {print $1"/"$2"/"$3}'))
-if [[ ${#FEDORA_FLATPAKS_RUNTIME[@]} -gt 0 ]]; then
-  echo "Removing system flatpak runtimes from 'fedora' remote"
-  flatpak remove --system --noninteractive "${FEDORA_FLATPAKS_RUNTIME[@]}"
+# Remove flatpak runtimes from system origin fedora, unless fedora remote is strictly specified
+if [[ ! "${REPO_URL}" == "oci+https://registry.fedoraproject.org" ]]; then
+  FEDORA_FLATPAKS_RUNTIME=($(flatpak list --system --runtime --columns=application,arch,branch,origin | awk '$4 == "fedora" {print $1"/"$2"/"$3}'))
+  if [[ ${#FEDORA_FLATPAKS_RUNTIME[@]} -gt 0 ]]; then
+    echo "Removing system flatpak runtimes from 'fedora' remote"
+    flatpak remove --system --noninteractive "${FEDORA_FLATPAKS_RUNTIME[@]}"
+  else
+    echo "System flatpak runtimes from 'fedora' remote are already removed"
+  fi  
 else
-  echo "System flatpak runtimes from 'fedora' remote are already removed"
-fi  
+  echo "Not automatically removing all flatpak runtimes from system remote 'fedora', as it's specified for use in config"
+fi
 
 # Remove flatpak apps from system origin fedora-testing
 FEDORA_TESTING_FLATPAKS_APP=($(flatpak list --system --app --columns=application,origin | awk '$2 == "fedora-testing" {print $1}'))
@@ -96,11 +115,6 @@ if [[ ${#FEDORA_TESTING_FLATPAKS_RUNTIME[@]} -gt 0 ]]; then
 else
   echo "System flatpak runtimes from 'fedora-testing' remote are already removed"
 fi  
-
-REPO_INFO="/usr/share/bluebuild/default-flatpaks/system/repo-info.yml"
-REPO_URL=$(yq '.repo-url' $REPO_INFO)
-REPO_NAME=$(yq '.repo-name' $REPO_INFO)
-REPO_TITLE=$(yq '.repo-title' $REPO_INFO)
 
 # General conditions for not running the unnecessary flatpak setup
 # Currently, we don't modify remote title if it's already modified

--- a/modules/default-flatpaks/v1/user-flatpak-setup
+++ b/modules/default-flatpaks/v1/user-flatpak-setup
@@ -21,6 +21,11 @@ check_internet_connection() {
     return 1
 }
 
+REPO_INFO="/usr/share/bluebuild/default-flatpaks/user/repo-info.yml"
+REPO_URL=$(yq '.repo-url' $REPO_INFO)
+REPO_NAME=$(yq '.repo-name' $REPO_INFO)
+REPO_TITLE=$(yq '.repo-title' $REPO_INFO)
+
 # Remove Fedora's flatpak user repos, if they exist
 FLATPAK_USER_REMOTES=($(flatpak --user remotes))
 
@@ -35,12 +40,18 @@ for user_remote in "${FLATPAK_USER_REMOTES[@]}"; do
   fi  
 done
 
-if "${fedora_user}"; then
-  echo "Removing user flatpak remote 'fedora'"
-  flatpak remote-delete --user fedora --force
+# Remove fedora user remote, unless fedora remote is strictly specified
+if [[ ! "${REPO_URL}" == "oci+https://registry.fedoraproject.org" ]]; then
+  if "${fedora_user}"; then
+    echo "Removing user flatpak remote 'fedora'"
+    flatpak remote-delete --user fedora --force
+  else
+    echo "User flatpak remote 'fedora' is already removed"  
+  fi
 else
-  echo "User flatpak remote 'fedora' is already removed"  
+  echo "Not removing the user flatpak remote 'fedora', as it's specified for use in config"  
 fi
+
 if "${fedora_testing_user}"; then
   echo "Removing user flatpak remote 'fedora-testing'"
   flatpak remote-delete --user fedora-testing --force
@@ -49,22 +60,30 @@ else
 fi
 
 # Remove flatpak apps from user origin fedora
-FEDORA_FLATPAKS_APP=($(flatpak list --user --app --columns=application,origin | awk '$2 == "fedora" {print $1}'))
-if [[ ${#FEDORA_FLATPAKS_APP[@]} -gt 0 ]]; then
-  echo "Removing user flatpak apps from 'fedora' remote"
-  flatpak remove --user --noninteractive "${FEDORA_FLATPAKS_APP[@]}"
+if [[ ! "${REPO_URL}" == "oci+https://registry.fedoraproject.org" ]]; then
+  FEDORA_FLATPAKS_APP=($(flatpak list --user --app --columns=application,origin | awk '$2 == "fedora" {print $1}'))
+  if [[ ${#FEDORA_FLATPAKS_APP[@]} -gt 0 ]]; then
+    echo "Removing user flatpak apps from 'fedora' remote"
+    flatpak remove --user --noninteractive "${FEDORA_FLATPAKS_APP[@]}"
+  else
+    echo "User flatpak apps from 'fedora' remote are already removed"
+  fi  
 else
-  echo "User flatpak apps from 'fedora' remote are already removed"
-fi  
+  echo "Not automatically removing all flatpak apps from user remote 'fedora', as it's specified for use in config"
+fi
 
-# Remove flatpak runtimes from user origin fedora
-FEDORA_FLATPAKS_RUNTIME=($(flatpak list --user --runtime --columns=application,arch,branch,origin | awk '$4 == "fedora" {print $1"/"$2"/"$3}'))
-if [[ ${#FEDORA_FLATPAKS_RUNTIME[@]} -gt 0 ]]; then
-  echo "Removing user flatpak runtimes from 'fedora' remote"
-  flatpak remove --user --noninteractive "${FEDORA_FLATPAKS_RUNTIME[@]}"
+# Remove flatpak runtimes from user origin fedora, unless fedora remote is strictly specified
+if [[ ! "${REPO_URL}" == "oci+https://registry.fedoraproject.org" ]]; then
+  FEDORA_FLATPAKS_RUNTIME=($(flatpak list --user --runtime --columns=application,arch,branch,origin | awk '$4 == "fedora" {print $1"/"$2"/"$3}'))
+  if [[ ${#FEDORA_FLATPAKS_RUNTIME[@]} -gt 0 ]]; then
+    echo "Removing user flatpak runtimes from 'fedora' remote"
+    flatpak remove --user --noninteractive "${FEDORA_FLATPAKS_RUNTIME[@]}"
+  else
+    echo "User flatpak runtimes from 'fedora' remote are already removed"
+  fi  
 else
-  echo "User flatpak runtimes from 'fedora' remote are already removed"
-fi  
+  echo "Not automatically removing all flatpak runtimes from user remote 'fedora', as it's specified for use in config"
+fi
 
 # Remove flatpak apps from origin user origin fedora-testing
 FEDORA_TESTING_FLATPAKS_APP=($(flatpak list --user --app --columns=application,origin | awk '$2 == "fedora-testing" {print $1}'))
@@ -83,11 +102,6 @@ if [[ ${#FEDORA_TESTING_FLATPAKS_RUNTIME[@]} -gt 0 ]]; then
 else
   echo "User flatpak runtimes from 'fedora-testing' remote are already removed"
 fi  
-
-REPO_INFO="/usr/share/bluebuild/default-flatpaks/user/repo-info.yml"
-REPO_URL=$(yq '.repo-url' $REPO_INFO)
-REPO_NAME=$(yq '.repo-name' $REPO_INFO)
-REPO_TITLE=$(yq '.repo-title' $REPO_INFO)
 
 # General conditions for not running the unnecessary flatpak setup
 # Currently, we don't modify remote title if it's already modified


### PR DESCRIPTION
Should resolve:
https://github.com/orgs/blue-build/discussions/41

Only `fedora` remote is supported, while `fedora-testing` isn't.