### PR TITLE
chore(signing): Switch fully from `/usr/etc/` to `/etc/`

### DIFF
--- a/modules/signing/signing.sh
+++ b/modules/signing/signing.sh
@@ -29,7 +29,13 @@ if ! [ -f "/etc/pki/containers/${IMAGE_NAME_FILE}.pub" ]; then
 fi
 
 TEMPLATE_POLICY="${MODULE_DIRECTORY}/signing/policy.json"
-POLICY_FILE="${CONTAINER_DIR}/policy.json"
+# Copy policy.json to '/usr/etc/containers/' on Universal Blue based images
+# until they solve the issue by copying 'policy.json' to '/etc/containers/' instead
+if rpm -q ublue-os-signing &>/dev/null; then
+  POLICY_FILE="/usr/etc/containers/policy.json"
+else
+  POLICY_FILE="${CONTAINER_DIR}/policy.json"
+fi
 
 jq --arg image_registry "${IMAGE_REGISTRY}" \
    --arg image_name "${IMAGE_NAME}" \

--- a/modules/signing/signing.sh
+++ b/modules/signing/signing.sh
@@ -3,40 +3,35 @@
 # Tell build process to exit if there are any errors.
 set -euo pipefail
 
-# Don't migrate this module from utilizing `/usr/etc/` to `/etc/` yet, as Ublue needs to solve this issue
-# https://github.com/ublue-os/config/pull/311
-CONTAINER_DIR="/usr/etc/containers"
+CONTAINER_DIR="/etc/containers"
 MODULE_DIRECTORY="${MODULE_DIRECTORY:-"/tmp/modules"}"
 IMAGE_NAME_FILE="${IMAGE_NAME//\//_}"
 
-echo "Setting up container signing in policy.json and cosign.yaml for $IMAGE_NAME"
-echo "Registry to write: $IMAGE_REGISTRY"
+echo "Setting up container signing in policy.json and cosign.yaml for ${IMAGE_NAME}"
+echo "Registry to write: ${IMAGE_REGISTRY}"
 
-if ! [ -d "$CONTAINER_DIR" ]; then
-    mkdir -p "$CONTAINER_DIR"
+if ! [ -d "${CONTAINER_DIR}" ]; then
+  mkdir -p "${CONTAINER_DIR}"
 fi
 
-if ! [ -d $CONTAINER_DIR/registries.d ]; then
-   mkdir -p "$CONTAINER_DIR/registries.d"
+if ! [ -d "${CONTAINER_DIR}/registries.d" ]; then
+  mkdir -p "${CONTAINER_DIR}/registries.d"
 fi
 
-if ! [ -d "/usr/etc/pki/containers" ]; then
-    mkdir -p "/usr/etc/pki/containers"
+if ! [ -d "/etc/pki/containers" ]; then
+  mkdir -p "/etc/pki/containers"
 fi
 
-if ! [ -f "$CONTAINER_DIR/policy.json" ]; then
-    cp "$MODULE_DIRECTORY/signing/policy.json" "$CONTAINER_DIR/policy.json"
+if ! [ -f "/etc/pki/containers/${IMAGE_NAME_FILE}.pub" ]; then
+    cp "/usr/share/ublue-os/cosign.pub" "/etc/pki/containers/${IMAGE_NAME_FILE}.pub"
 fi
 
-if ! [ -f "/usr/etc/pki/containers/$IMAGE_NAME_FILE.pub" ]; then
-    cp "/usr/share/ublue-os/cosign.pub" "/usr/etc/pki/containers/$IMAGE_NAME_FILE.pub"
-fi
+TEMPLATE_POLICY="${MODULE_DIRECTORY}/signing/policy.json"
+POLICY_FILE="${CONTAINER_DIR}/policy.json"
 
-POLICY_FILE="$CONTAINER_DIR/policy.json"
-
-jq --arg image_registry "$IMAGE_REGISTRY" \
-   --arg image_name "$IMAGE_NAME" \
-   --arg image_name_file "$IMAGE_NAME_FILE" \
+jq --arg image_registry "${IMAGE_REGISTRY}" \
+   --arg image_name "${IMAGE_NAME}" \
+   --arg image_name_file "${IMAGE_NAME_FILE}" \
    '.transports.docker |= 
     { ($image_registry + "/" + $image_name): [
         {
@@ -46,7 +41,7 @@ jq --arg image_registry "$IMAGE_REGISTRY" \
                 "type": "matchRepository"
             }
         }
-    ] } + .' "$POLICY_FILE" > /tmp/tmp-policy.json && mv /tmp/tmp-policy.json "$POLICY_FILE"
+    ] } + .' "${TEMPLATE_POLICY}" > "${POLICY_FILE}"
 
-mv "$MODULE_DIRECTORY/signing/registry-config.yaml" "$CONTAINER_DIR/registries.d/$IMAGE_NAME_FILE.yaml"
-sed -i "s ghcr.io/IMAGENAME $IMAGE_REGISTRY g" "$CONTAINER_DIR/registries.d/$IMAGE_NAME_FILE.yaml"
+mv "${MODULE_DIRECTORY}/signing/registry-config.yaml" "${CONTAINER_DIR}/registries.d/${IMAGE_NAME_FILE}.yaml"
+sed -i "s ghcr.io/IMAGENAME ${IMAGE_REGISTRY} g" "${CONTAINER_DIR}/registries.d/${IMAGE_NAME_FILE}.yaml"

--- a/modules/signing/signing.sh
+++ b/modules/signing/signing.sh
@@ -23,7 +23,7 @@ if ! [ -d "/etc/pki/containers" ]; then
 fi
 
 if ! [ -f "/etc/pki/containers/${IMAGE_NAME_FILE}.pub" ]; then
-  echo "ERROR: Cannot find '.pub' image key in '/etc/pki/containers/'"
+  echo "ERROR: Cannot find '${IMAGE_NAME_FILE}.pub' image key in '/etc/pki/containers/'"
   echo "       BlueBuild CLI should have copied it, but it didn't"
   exit 1
 fi

--- a/modules/signing/signing.sh
+++ b/modules/signing/signing.sh
@@ -23,7 +23,9 @@ if ! [ -d "/etc/pki/containers" ]; then
 fi
 
 if ! [ -f "/etc/pki/containers/${IMAGE_NAME_FILE}.pub" ]; then
-    cp "/usr/share/ublue-os/cosign.pub" "/etc/pki/containers/${IMAGE_NAME_FILE}.pub"
+  echo "ERROR: Cannot find '.pub' image key in '/etc/pki/containers/'"
+  echo "       BlueBuild CLI should have copied it, but it didn't"
+  exit 1
 fi
 
 TEMPLATE_POLICY="${MODULE_DIRECTORY}/signing/policy.json"


### PR DESCRIPTION
Fixes: #319

Related PR in CLI:
https://github.com/blue-build/cli/pull/288

I tested this in vanilla Fedora & Universal Blue based image. With & without rechunk.

# Logs
Before:
```
[11:39:42 g.i/h/rechunk:v1.0.1] => WARNING: FOUND /usr/etc. MERGING TO ETC FOR COMPATIBILITY
[11:39:42 g.i/h/rechunk:v1.0.1] => EXPECT PERMISSIONS ISSUES ON THE MERGED PATHS
[11:39:42 g.i/h/rechunk:v1.0.1] => The following files from /usr/etc will be merged to /etc:
[11:39:42 g.i/h/rechunk:v1.0.1] => ./usr/etc
[11:39:42 g.i/h/rechunk:v1.0.1] => |-- containers
[11:39:42 g.i/h/rechunk:v1.0.1] => |   |-- policy.json
[11:39:42 g.i/h/rechunk:v1.0.1] => |   `-- registries.d
[11:39:42 g.i/h/rechunk:v1.0.1] => |       `-- gidro-os.yaml
[11:39:42 g.i/h/rechunk:v1.0.1] => `-- pki
[11:39:42 g.i/h/rechunk:v1.0.1] =>     `-- containers
[11:39:42 g.i/h/rechunk:v1.0.1] =>         `-- gidro-os.pub
[11:39:42 g.i/h/rechunk:v1.0.1] => 
[11:39:42 g.i/h/rechunk:v1.0.1] => 5 directories, 3 files
```

After:
- No message about remaining files in `/usr/etc/`

After (Universal Blue):

```
[20:34:11 g.i/h/rechunk:v1.0.1] => WARNING: FOUND /usr/etc. MERGING TO ETC FOR COMPATIBILITY
[20:34:11 g.i/h/rechunk:v1.0.1] => EXPECT PERMISSIONS ISSUES ON THE MERGED PATHS
[20:34:11 g.i/h/rechunk:v1.0.1] => The following files from /usr/etc will be merged to /etc:
[20:34:11 g.i/h/rechunk:v1.0.1] => ./usr/etc
[20:34:11 g.i/h/rechunk:v1.0.1] => |-- containers
[20:34:11 g.i/h/rechunk:v1.0.1] => |   `-- policy.json
[20:34:11 g.i/h/rechunk:v1.0.1] => 
[20:34:11 g.i/h/rechunk:v1.0.1] => 2 directories, 1 file
```

# What needs to be fixed

## `/etc/containers/policy.json` (Universal Blue only)

For Universal Blue, `policy.json` still remains in `/usr/etc/` sadly.

Need to wait on Universal Blue to fix this properly.

Meanwhile, we'll copy `policy.json` to `/usr/etc/containers/policy.json` in Universal Blue based images only.
While otherwise, we'll normally copy to `/etc/containers/policy.json`