### PR TITLE
fix(ci): Fix publishing latest tag for default-flatpaks

### DIFF
--- a/build-individual.nu
+++ b/build-individual.nu
@@ -66,7 +66,7 @@ let images = ls modules | each { |moduleDir|
         let latest = ($versioned | last)
         ($versioned
             | update (($versioned | length) - 1) # update the last / latest item in list
-            ($latest | update "tags" ($latest.tags | append latest_tag)) # append tag which should only be given to the latest version
+            ($latest | update "tags" ($latest.tags | append $latest_tag)) # append tag which should only be given to the latest version
         )
 
     }


### PR DESCRIPTION
It would appear that `default-flatpaks` wasn't publishing the `latest` tag properly.

https://github.com/blue-build/modules/actions/runs/12452851938/job/34762313119#step:7:119