### PR TITLE
feat: Create a systemd unit to create opt links on boot

### DIFF
--- a/modules/rpm-ostree/bluebuild-optfix.service
+++ b/modules/rpm-ostree/bluebuild-optfix.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Create symbolic links for directories in /usr/lib/opt/ to /var/opt/
+After=multi-user.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/libexec/bluebuild/optfix.sh
+RemainAfterExit=no
+
+[Install]
+WantedBy=default.target

--- a/modules/rpm-ostree/optfix.sh
+++ b/modules/rpm-ostree/optfix.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SOURCE_DIR="/usr/lib/opt/"
+TARGET_DIR="/var/opt/"
+
+# Ensure the target directory exists
+mkdir -p "$TARGET_DIR"
+
+# Loop through directories in the source directory
+for dir in "$SOURCE_DIR"*/; do
+  if [ -d "$dir" ]; then
+    # Get the base name of the directory
+    dir_name=$(basename "$dir")
+    
+    # Check if the symlink already exists in the target directory
+    if [ -L "$TARGET_DIR/$dir_name" ]; then
+      echo "Symlink already exists for $dir_name, skipping."
+      continue
+    fi
+    
+    # Create the symlink
+    ln -s "$dir" "$TARGET_DIR/$dir_name"
+    echo "Created symlink for $dir_name"
+  fi
+done


### PR DESCRIPTION
This creates a systemd unit file that will execute on boot and create symlinks in `/var/opt/` for every directory that exists in `/usr/lib/opt/`. This removes the need for users to manually create these links to get programs working like the Brave browser.