### PR TITLE
chore: Update schemas to version all types

### DIFF
--- a/modules/akmods/akmods.tsp
+++ b/modules/akmods/akmods.tsp
@@ -1,27 +1,36 @@
 import "@typespec/json-schema";
 using TypeSpec.JsonSchema;
 
-@jsonSchema("/modules/akmods.json")
+@jsonSchema("/modules/akmods-v1.json")
+@jsonSchema("/modules/akmods-latest.json")
 model AkmodsModule {
-    /** The akmods module is a tool used for managing and installing kernel modules built by Universal Blue.
-     * https://blue-build.org/reference/modules/akmods/
-     */
-    type: "akmods";
+  /** The akmods module is a tool used for managing and installing kernel modules built by Universal Blue.
+   * https://blue-build.org/reference/modules/akmods/
+   */
+  type: "akmods" | "akmods@v1" | "akmods@latest";
 
-    /** The kernel your images uses.
-     * - main: stock Fedora kernel / main and nvidia images
-     * - asus: asus kernel / asus images
-     * - fsync: fsync kernel / not used in any Universal Blue images
-     * - fsync-ba: fsync kernel, stable version / not used in any Universal Blue images
-     * - surface: surface kernel / surface images
-     * - coreos-stable: stock CoreOS kernel / uCore stable images
-     * - coreos-testing: stock CoreOS Testing kernel / uCore testing images
-     * - bazzite: Bazzite's kernel / bazzite images
-     */
-    base?: "main" | "asus" | "fsync" | "fsync-ba" | "surface" | "coreos-stable" | "coreos-testing" | "bazzite" = "main";
+  /** The kernel your images uses.
+   * - main: stock Fedora kernel / main and nvidia images
+   * - asus: asus kernel / asus images
+   * - fsync: fsync kernel / not used in any Universal Blue images
+   * - fsync-ba: fsync kernel, stable version / not used in any Universal Blue images
+   * - surface: surface kernel / surface images
+   * - coreos-stable: stock CoreOS kernel / uCore stable images
+   * - coreos-testing: stock CoreOS Testing kernel / uCore testing images
+   * - bazzite: Bazzite's kernel / bazzite images
+   */
+  base?:
+    | "main"
+    | "asus"
+    | "fsync"
+    | "fsync-ba"
+    | "surface"
+    | "coreos-stable"
+    | "coreos-testing"
+    | "bazzite" = "main";
 
-    /** List of akmods to install.
-     * See all available akmods here: https://github.com/ublue-os/akmods#kmod-packages
-     */
-    install: Array<string>;
+  /** List of akmods to install.
+   * See all available akmods here: https://github.com/ublue-os/akmods#kmod-packages
+   */
+  install: Array<string>;
 }

--- a/modules/bling/bling.tsp
+++ b/modules/bling/bling.tsp
@@ -1,13 +1,20 @@
 import "@typespec/json-schema";
 using TypeSpec.JsonSchema;
 
-@jsonSchema("/modules/bling.json")
+@jsonSchema("/modules/bling-v1.json")
+@jsonSchema("/modules/bling-latest.json")
 model BlingModule {
-    /** The bling module can be used to pull in small "bling" into your image. 
-     * https://blue-build.org/reference/modules/bling/
-    */
-    type: "bling";
+  /** The bling module can be used to pull in small "bling" into your image.
+   * https://blue-build.org/reference/modules/bling/
+   */
+  type: "bling" | "bling@v1" | "bling@latest";
 
-    /** List of bling submodules to run / things to install onto your system. */
-    install: Array<"rpmfusion" | "negativo17" | "ublue-update" | "1password" | "dconf-update-service" | "gnome-vrr">;
+  /** List of bling submodules to run / things to install onto your system. */
+  install: Array<
+    | "rpmfusion"
+    | "negativo17"
+    | "ublue-update"
+    | "1password"
+    | "dconf-update-service"
+    | "gnome-vrr">;
 }

--- a/modules/brew/brew.tsp
+++ b/modules/brew/brew.tsp
@@ -1,42 +1,43 @@
 import "@typespec/json-schema";
 using TypeSpec.JsonSchema;
 
-@jsonSchema("/modules/brew.json")
+@jsonSchema("/modules/brew-v1.json")
+@jsonSchema("/modules/brew-latest.json")
 model BrewModule {
-    /** The brew module installs Homebrew / Linuxbrew at build time and ensures the package manager remains up-to-date.
-     * https://blue-build.org/reference/modules/brew/
-    */
-    type: "brew";
+  /** The brew module installs Homebrew / Linuxbrew at build time and ensures the package manager remains up-to-date.
+   * https://blue-build.org/reference/modules/brew/
+   */
+  type: "brew" | "brew@v1" | "brew@latest";
 
-    /** Whether to auto-update the Brew binary using a systemd service. */
-    "auto-update"?: boolean = true;
+  /** Whether to auto-update the Brew binary using a systemd service. */
+  `auto-update`?: boolean = true;
 
-    /** Defines how often the Brew update service should run. The string is passed directly to `OnUnitInactiveSec` in systemd timer. (Syntax: ['1d', '6h', '10m']). */
-    "update-interval"?: string = "6h";
+  /** Defines how often the Brew update service should run. The string is passed directly to `OnUnitInactiveSec` in systemd timer. (Syntax: ['1d', '6h', '10m']). */
+  `update-interval`?: string = "6h";
 
-    /** Time delay after system boot before the first Brew update runs. The string is passed directly to `OnBootSec` in systemd timer. (Syntax: ['1d', '6h', '10m']). */
-    "update-wait-after-boot"?: string = "10min";
+  /** Time delay after system boot before the first Brew update runs. The string is passed directly to `OnBootSec` in systemd timer. (Syntax: ['1d', '6h', '10m']). */
+  `update-wait-after-boot`?: string = "10min";
 
-    /** Whether to auto-upgrade all installed Brew packages using a systemd service. */
-    "auto-upgrade"?: boolean = true;
+  /** Whether to auto-upgrade all installed Brew packages using a systemd service. */
+  `auto-upgrade`?: boolean = true;
 
-    /** Defines how often the Brew upgrade service should run. The string is passed directly to `OnUnitInactiveSec` in systemd timer. (Syntax: ['1d', '6h', '10m']). */
-    "upgrade-interval"?: string = "8h";
+  /** Defines how often the Brew upgrade service should run. The string is passed directly to `OnUnitInactiveSec` in systemd timer. (Syntax: ['1d', '6h', '10m']). */
+  `upgrade-interval`?: string = "8h";
 
-    /** Time delay after system boot before the first Brew package upgrade runs. The string is passed directly to `OnBootSec` in systemd timer. (Syntax: ['1d', '6h', '10m']). */
-    "upgrade-wait-after-boot"?: string = "30min";
+  /** Time delay after system boot before the first Brew package upgrade runs. The string is passed directly to `OnBootSec` in systemd timer. (Syntax: ['1d', '6h', '10m']). */
+  `upgrade-wait-after-boot`?: string = "30min";
 
-    /** Whether to increase nofile limits (limits for number of open files) for Brew installations.
-     * When set to true, it increases the nofile limits to prevent certain "I/O heavy" Brew packages from failing due to "too many open files" error.
-     * However, it's important to note that increasing nofile limits can have potential security implications for malicious applications which would try to abuse storage I/O.
-     * Defaults to false for security purposes.
-     * 
-     * https://serverfault.com/questions/577437/what-is-the-impact-of-increasing-nofile-limits-in-etc-security-limits-conf
-     */
-    "nofile-limits"?: boolean = false;
+  /** Whether to increase nofile limits (limits for number of open files) for Brew installations.
+   * When set to true, it increases the nofile limits to prevent certain "I/O heavy" Brew packages from failing due to "too many open files" error.
+   * However, it's important to note that increasing nofile limits can have potential security implications for malicious applications which would try to abuse storage I/O.
+   * Defaults to false for security purposes.
+   *
+   * https://serverfault.com/questions/577437/what-is-the-impact-of-increasing-nofile-limits-in-etc-security-limits-conf
+   */
+  `nofile-limits`?: boolean = false;
 
-    /** Whether to enable Brew analytics. 
-     * The Homebrew project uses analytics to anonymously collect the information about Brew usage & your system in order to improve the experience of Brew users.  
-     */
-    "brew-analytics"?: boolean = true;
+  /** Whether to enable Brew analytics.
+   * The Homebrew project uses analytics to anonymously collect the information about Brew usage & your system in order to improve the experience of Brew users.
+   */
+  `brew-analytics`?: boolean = true;
 }

--- a/modules/chezmoi/chezmoi.tsp
+++ b/modules/chezmoi/chezmoi.tsp
@@ -1,34 +1,35 @@
 import "@typespec/json-schema";
 using TypeSpec.JsonSchema;
 
-@jsonSchema("/modules/chezmoi.json")
+@jsonSchema("/modules/chezmoi-v1.json")
+@jsonSchema("/modules/chezmoi-latest.json")
 model ChezmoiModule {
-    /** The chezmoi module installs the latest chezmoi release at build time, along with services to clone a dotfile repository and keep it up-to-date.
-     * https://blue-build.org/reference/modules/chezmoi/
-    */
-    type: "chezmoi";
+  /** The chezmoi module installs the latest chezmoi release at build time, along with services to clone a dotfile repository and keep it up-to-date.
+   * https://blue-build.org/reference/modules/chezmoi/
+   */
+  type: "chezmoi" | "chezmoi@v1" | "chezmoi@latest";
 
-    /** Git repository to initialize. */
-    repository: string;
+  /** Git repository to initialize. */
+  repository: string;
 
-    /** Git branch of the chezmoi repository. */
-    branch?: string = "";
+  /** Git branch of the chezmoi repository. */
+  branch?: string = "";
 
-    /** Whether to enable the modules services globally for all users, if false users need to enable services manually. */
-    "all-users"?: boolean = true;
+  /** Whether to enable the modules services globally for all users, if false users need to enable services manually. */
+  `all-users`?: boolean = true;
 
-    /** Dotfiles will be updated with this interval. */
-    "run-every"?: string = "1d";
+  /** Dotfiles will be updated with this interval. */
+  `run-every`?: string = "1d";
 
-    /** Dotfile updates will wait this long after a boot before running. */
-    "wait-after-boot"?: string = "5m";
+  /** Dotfile updates will wait this long after a boot before running. */
+  `wait-after-boot`?: string = "5m";
 
-    /** Disable the service that initializes `repository` on users that are logged in or have linger enabled UI. */
-    "disable-init"?: boolean = false;
+  /** Disable the service that initializes `repository` on users that are logged in or have linger enabled UI. */
+  `disable-init`?: boolean = false;
 
-    /** Disable the timer that updates chezmoi with the set interval. */
-    "disable-update"?: boolean = false;
+  /** Disable the timer that updates chezmoi with the set interval. */
+  `disable-update`?: boolean = false;
 
-    /** What to do when file different that exists on your repo is has been changed or exists locally. Accepts "skip" or "replace". */
-    "file-conflict-policy"?: "skip" | "replace" = "skip";
+  /** What to do when file different that exists on your repo is has been changed or exists locally. Accepts "skip" or "replace". */
+  `file-conflict-policy`?: "skip" | "replace" = "skip";
 }

--- a/modules/default-flatpaks/default-flatpaks.tsp
+++ b/modules/default-flatpaks/default-flatpaks.tsp
@@ -1,49 +1,50 @@
 import "@typespec/json-schema";
 using TypeSpec.JsonSchema;
 
-@jsonSchema("/modules/default-flatpaks.json")
+@jsonSchema("/modules/default-flatpaks-v1.json")
+@jsonSchema("/modules/default-flatpaks-latest.json")
 model DefaultFlatpaksModule {
-    /** The default-flatpaks module can be used to install or uninstall flatpaks from a configurable remote on every boot.
-     * https://blue-build.org/reference/modules/default-flatpaks/
-    */
-    type: "default-flatpaks";
+  /** The default-flatpaks module can be used to install or uninstall flatpaks from a configurable remote on every boot.
+   * https://blue-build.org/reference/modules/default-flatpaks/
+   */
+  type: "default-flatpaks" | "default-flatpaks@v1" | "default-flatpaks@latest";
 
-    /** Whether to send a notification after the install/uninstall is finished. */
-    notify?: boolean = false;
+  /** Whether to send a notification after the install/uninstall is finished. */
+  notify?: boolean = false;
 
-    /** Configuration for system flatpaks. */
-    system?: {
-        /** URL of the repo to add. Defaults to Flathub's URL. */
-        "repo-url"?: string = "https://dl.flathub.org/repo/flathub.flatpakrepo";
+  /** Configuration for system flatpaks. */
+  system?: {
+    /** URL of the repo to add. Defaults to Flathub's URL. */
+    `repo-url`?: string = "https://dl.flathub.org/repo/flathub.flatpakrepo";
 
-        /** Name for the repo to add. */
-        "repo-name"?: string = "flathub";
+    /** Name for the repo to add. */
+    `repo-name`?: string = "flathub";
 
-        /** Pretty title for the repo to add. Not set by default. */
-        "repo-title"?: string;
+    /** Pretty title for the repo to add. Not set by default. */
+    `repo-title`?: string;
 
-        /** List of Flatpak IDs to install from the repo. */
-        install?: Array<string>;
+    /** List of Flatpak IDs to install from the repo. */
+    install?: Array<string>;
 
-        /** List of Flatpak IDs to remove. */
-        remove?: Array<string>;
-    };
+    /** List of Flatpak IDs to remove. */
+    remove?: Array<string>;
+  };
 
-    /** Configuration for user flatpaks. */
-    user?: {
-        /** URL of the repo to add. Defaults to Flathub's URL. */
-        "repo-url"?: string = "https://dl.flathub.org/repo/flathub.flatpakrepo";
+  /** Configuration for user flatpaks. */
+  user?: {
+    /** URL of the repo to add. Defaults to Flathub's URL. */
+    `repo-url`?: string = "https://dl.flathub.org/repo/flathub.flatpakrepo";
 
-        /** Name for the repo to add. */
-        "repo-name"?: string = "flathub";
+    /** Name for the repo to add. */
+    `repo-name`?: string = "flathub";
 
-        /** Pretty title for the repo to add. Not set by default. */
-        "repo-title"?: string;
+    /** Pretty title for the repo to add. Not set by default. */
+    `repo-title`?: string;
 
-        /** List of Flatpak IDs to install from the repo. */
-        install?: Array<string>;
+    /** List of Flatpak IDs to install from the repo. */
+    install?: Array<string>;
 
-        /** List of Flatpak IDs to remove. */
-        remove?: Array<string>;
-    };
+    /** List of Flatpak IDs to remove. */
+    remove?: Array<string>;
+  };
 }

--- a/modules/files/files.tsp
+++ b/modules/files/files.tsp
@@ -1,16 +1,17 @@
 import "@typespec/json-schema";
 using TypeSpec.JsonSchema;
 
-@jsonSchema("/modules/files.json")
+@jsonSchema("/modules/files-v1.json")
+@jsonSchema("/modules/files-latest.json")
 model FilesModule {
-    /** Copy files to your image at build time
-     * https://blue-build.org/reference/modules/files/
-     */
-    type: "files";
+  /** Copy files to your image at build time
+   * https://blue-build.org/reference/modules/files/
+   */
+  type: "files" | "files@v1" | "files@latest";
 
-    /** List of files / folders to copy. */
-    files: Array<Record<string>> | Array<{
-        source: string;
-        destination: string;
-    }>;
+  /** List of files / folders to copy. */
+  files: Array<Record<string>> | Array<{
+    source: string;
+    destination: string;
+  }>;
 }

--- a/modules/fonts/fonts.tsp
+++ b/modules/fonts/fonts.tsp
@@ -1,18 +1,19 @@
 import "@typespec/json-schema";
 using TypeSpec.JsonSchema;
 
-@jsonSchema("/modules/fonts.json")
+@jsonSchema("/modules/fonts-v1.json")
+@jsonSchema("/modules/fonts-latest.json")
 model FontsModule {
-    /** The fonts module can be used to install fonts from Nerd Fonts or Google Fonts. 
-     * https://blue-build.org/reference/modules/fonts/
-    */
-    type: "fonts";
-    
-    fonts: {
-        /** List of Nerd Fonts to install (without the "Nerd Font" suffix). */
-        "nerd-fonts"?: Array<string>;
+  /** The fonts module can be used to install fonts from Nerd Fonts or Google Fonts.
+   * https://blue-build.org/reference/modules/fonts/
+   */
+  type: "fonts" | "fonts@v1" | "fonts@latest";
 
-        /** List of Google Fonts to install. */
-        "google-fonts"?: Array<string>;
-    };
+  fonts: {
+    /** List of Nerd Fonts to install (without the "Nerd Font" suffix). */
+    `nerd-fonts`?: Array<string>;
+
+    /** List of Google Fonts to install. */
+    `google-fonts`?: Array<string>;
+  };
 }

--- a/modules/gnome-extensions/gnome-extensions.tsp
+++ b/modules/gnome-extensions/gnome-extensions.tsp
@@ -1,20 +1,21 @@
 import "@typespec/json-schema";
 using TypeSpec.JsonSchema;
 
-@jsonSchema("/modules/gnome-extensions.json")
+@jsonSchema("/modules/gnome-extensions-v1.json")
+@jsonSchema("/modules/gnome-extensions-latest.json")
 model GnomeExtensionsModule {
-    /** The gnome-extensions module can be used to install GNOME extensions inside system directory.
-     * https://blue-build.org/reference/modules/gnome-extensions/
-     */
-    type: "gnome-extensions";
+  /** The gnome-extensions module can be used to install GNOME extensions inside system directory.
+   * https://blue-build.org/reference/modules/gnome-extensions/
+   */
+  type: "gnome-extensions" | "gnome-extensions@v1" | "gnome-extensions@latest";
 
-    /** List of GNOME extensions to install. 
-     * (case sensitive extension names or extension IDs from https://extensions.gnome.org/)
-    */
-    install?: Array<string | integer>;
+  /** List of GNOME extensions to install.
+   * (case sensitive extension names or extension IDs from https://extensions.gnome.org/)
+   */
+  install?: Array<string | integer>;
 
-    /** List of system GNOME extensions to uninstall. 
-     * Only use this to remove extensions not installed by your package manager. Those extensions should be uninstalled using the package manager instead.
-    */
-    uninstall?: Array<string>;
+  /** List of system GNOME extensions to uninstall.
+   * Only use this to remove extensions not installed by your package manager. Those extensions should be uninstalled using the package manager instead.
+   */
+  uninstall?: Array<string>;
 }

--- a/modules/gschema-overrides/gschema-overrides.tsp
+++ b/modules/gschema-overrides/gschema-overrides.tsp
@@ -1,13 +1,14 @@
 import "@typespec/json-schema";
 using TypeSpec.JsonSchema;
 
-@jsonSchema("/modules/gschema-overrides.json")
+@jsonSchema("/modules/gschema-overrides-v1.json")
+@jsonSchema("/modules/gschema-overrides-latest.json")
 model GschemaOverridesModule {
-    /** The gschema-overrides module can be used for including system-setting overrides for GTK-based desktop environments.
-     * https://blue-build.org/reference/modules/gschema-overrides/
-    */
-    type: "gschema-overrides";
+  /** The gschema-overrides module can be used for including system-setting overrides for GTK-based desktop environments.
+   * https://blue-build.org/reference/modules/gschema-overrides/
+   */
+  type: "gschema-overrides" | "gschema-overrides@v1" | "gschema-overrides@latest";
 
-    /** Gschema override files to test and copy to the correct place. */
-    include?: Array<string>;
+  /** Gschema override files to test and copy to the correct place. */
+  include?: Array<string>;
 }

--- a/modules/initramfs/initramfs.tsp
+++ b/modules/initramfs/initramfs.tsp
@@ -1,10 +1,11 @@
 import "@typespec/json-schema";
 using TypeSpec.JsonSchema;
 
-@jsonSchema("/modules/initramfs.json")
+@jsonSchema("/modules/initramfs-v1.json")
+@jsonSchema("/modules/initramfs-latest.json")
 model InitramfsModule {
-    /** The initramfs module is used to regenerate initramfs, needed to apply some modifications early in the Linux startup process.
-     * https://blue-build.org/reference/modules/initramfs/
-     */    
-    type: "initramfs";
+  /** The initramfs module is used to regenerate initramfs, needed to apply some modifications early in the Linux startup process.
+   * https://blue-build.org/reference/modules/initramfs/
+   */
+  type: "initramfs" | "initramfs@v1" | "initramfs@latest";
 }

--- a/modules/justfiles/justfiles.tsp
+++ b/modules/justfiles/justfiles.tsp
@@ -1,16 +1,17 @@
 import "@typespec/json-schema";
 using TypeSpec.JsonSchema;
 
-@jsonSchema("/modules/justfiles.json")
+@jsonSchema("/modules/justfiles-v1.json")
+@jsonSchema("/modules/justfiles-latest.json")
 model JustfilesModule {
-    /** The justfiles module makes it easy to include just recipes from multiple files in Universal Blue -based images.
-     * https://blue-build.org/reference/modules/justfiles/
-     */
-    type: "justfiles";
+  /** The justfiles module makes it easy to include just recipes from multiple files in Universal Blue -based images.
+   * https://blue-build.org/reference/modules/justfiles/
+   */
+  type: "justfiles" | "justfiles@v1" | "justfiles@latest";
 
-    /** Whether to validate the syntax of the justfiles against `just --fmt`. (warning: can be very unforgiving) */
-    validate?: boolean = false;
+  /** Whether to validate the syntax of the justfiles against `just --fmt`. (warning: can be very unforgiving) */
+  validate?: boolean = false;
 
-    /** List of files or subfolders to include into this image. If omitted, all justfiles will be included. */
-    include?: Array<string>;
+  /** List of files or subfolders to include into this image. If omitted, all justfiles will be included. */
+  include?: Array<string>;
 }

--- a/modules/rpm-ostree/rpm-ostree.tsp
+++ b/modules/rpm-ostree/rpm-ostree.tsp
@@ -1,33 +1,35 @@
 import "@typespec/json-schema";
 using TypeSpec.JsonSchema;
 
-@jsonSchema("/modules/rpm-ostree.json")
+@jsonSchema("/modules/rpm-ostree-v1.json")
+@jsonSchema("/modules/rpm-ostree-latest.json")
 model RpmOstreeModule {
-    /** The rpm-ostree module offers pseudo-declarative package and repository management using rpm-ostree.
-     * https://blue-build.org/reference/modules/rpm-ostree/
-     */
-    type: "rpm-ostree";
+  /** The rpm-ostree module offers pseudo-declarative package and repository management using rpm-ostree.
+   * https://blue-build.org/reference/modules/rpm-ostree/
+   */
+  type: "rpm-ostree" | "rpm-ostree@v1" | "rpm-ostree@latest";
 
-    /** List of links to .repo files to download into /etc/yum.repos.d/. */
-    repos?: Array<string>;
+  /** List of links to .repo files to download into /etc/yum.repos.d/. */
+  repos?: Array<string>;
 
-    /** List of links to key files to import for installing from custom repositories. */
-    keys?: Array<string>;
+  /** List of links to key files to import for installing from custom repositories. */
+  keys?: Array<string>;
 
-    /** List of folder names under /opt/ to enable for installing into. */
-    optfix?: Array<string>;
+  /** List of folder names under /opt/ to enable for installing into. */
+  optfix?: Array<string>;
 
-    /** List of RPM packages to install. */
-    install?: Array<string>;
+  /** List of RPM packages to install. */
+  install?: Array<string>;
 
-    /** List of RPM packages to remove. */
-    remove?: Array<string>;
+  /** List of RPM packages to remove. */
+  remove?: Array<string>;
 
-    /** List of configurations for `rpm-ostree override replace`ing packages. */
-    replace?: Array<{
-        /** URL to the source COPR repo for the new packages. */
-        "from-repo": string,
-        /** List of packages to replace using packages from the defined repo. */
-        packages: Array<string>,
-    }>;
+  /** List of configurations for `rpm-ostree override replace`ing packages. */
+  replace?: Array<{
+    /** URL to the source COPR repo for the new packages. */
+    `from-repo`: string;
+
+    /** List of packages to replace using packages from the defined repo. */
+    packages: Array<string>;
+  }>;
 }

--- a/modules/script/script.tsp
+++ b/modules/script/script.tsp
@@ -1,16 +1,17 @@
 import "@typespec/json-schema";
 using TypeSpec.JsonSchema;
 
-@jsonSchema("/modules/script.json")
+@jsonSchema("/modules/script-v1.json")
+@jsonSchema("/modules/script-latest.json")
 model ScriptModule {
-    /** The script module can be used to run arbitrary bash snippets and scripts at image build time.
-     * https://blue-build.org/reference/modules/script/
-     */
-    type: "script";
+  /** The script module can be used to run arbitrary bash snippets and scripts at image build time.
+   * https://blue-build.org/reference/modules/script/
+   */
+  type: "script" | "script@v1" | "script@latest";
 
-    /** List of bash one-liners to run. */
-    snippets?: Array<string>;
+  /** List of bash one-liners to run. */
+  snippets?: Array<string>;
 
-    /** List of script files to run. */
-    scripts?: Array<string>;
+  /** List of script files to run. */
+  scripts?: Array<string>;
 }

--- a/modules/signing/signing.tsp
+++ b/modules/signing/signing.tsp
@@ -1,10 +1,11 @@
 import "@typespec/json-schema";
 using TypeSpec.JsonSchema;
 
-@jsonSchema("/modules/signing.json")
+@jsonSchema("/modules/signing-v1.json")
+@jsonSchema("/modules/signing-latest.json")
 model SigningModule {
-    /** The signing module is used to install the required signing policies for cosign image verification with rpm-ostree and bootc.
-     * https://blue-build.org/reference/modules/signing/
-     */    
-    type: "signing";
+  /** The signing module is used to install the required signing policies for cosign image verification with rpm-ostree and bootc.
+   * https://blue-build.org/reference/modules/signing/
+   */
+  type: "signing" | "signing@v1" | "signing@latest";
 }

--- a/modules/systemd/systemd.tsp
+++ b/modules/systemd/systemd.tsp
@@ -1,40 +1,41 @@
 import "@typespec/json-schema";
 using TypeSpec.JsonSchema;
 
-@jsonSchema("/modules/systemd.json")
+@jsonSchema("/modules/systemd-v1.json")
+@jsonSchema("/modules/systemd-latest.json")
 model SystemdModule {
-    /** The systemd module streamlines the management of systemd units during image building.
-     * https://blue-build.org/reference/modules/systemd/
-     */
-    type: "systemd";
+  /** The systemd module streamlines the management of systemd units during image building.
+   * https://blue-build.org/reference/modules/systemd/
+   */
+  type: "systemd" | "systemd@v1" | "systemd@latest";
 
-    /** System unit configuration. */
-    system?: {
-        /** List of systemd units to enable. (runs on system boot) */
-        enabled?: Array<string>;
+  /** System unit configuration. */
+  system?: {
+    /** List of systemd units to enable. (runs on system boot) */
+    enabled?: Array<string>;
 
-        /** List of systemd units to disable. (does not run on system boot, unless another unit strictly requires it) */
-        disabled?: Array<string>;
+    /** List of systemd units to disable. (does not run on system boot, unless another unit strictly requires it) */
+    disabled?: Array<string>;
 
-        /** List of systemd units to mask. (does not run on system boot, under any circumstances) */
-        masked?: Array<string>;
+    /** List of systemd units to mask. (does not run on system boot, under any circumstances) */
+    masked?: Array<string>;
 
-        /** List of systemd units to unmask. (runs on system boot, even if previously masked) */
-        unmasked?: Array<string>;
-    };
+    /** List of systemd units to unmask. (runs on system boot, even if previously masked) */
+    unmasked?: Array<string>;
+  };
 
-    /** User unit configuration (with --global to make changes for all users). */
-    user?: {
-         /** List of systemd units to enable. (runs for the users) */
-         enabled?: Array<string>;
+  /** User unit configuration (with --global to make changes for all users). */
+  user?: {
+    /** List of systemd units to enable. (runs for the users) */
+    enabled?: Array<string>;
 
-         /** List of systemd units to disable. (does not run for the users, unless another unit strictly requires it) */
-         disabled?: Array<string>;
- 
-         /** List of systemd units to mask. (does not run for the users, under any circumstances) */
-         masked?: Array<string>;
- 
-         /** List of systemd units to unmask. (runs for the users, even if previously masked) */
-         unmasked?: Array<string>;
-    };
+    /** List of systemd units to disable. (does not run for the users, unless another unit strictly requires it) */
+    disabled?: Array<string>;
+
+    /** List of systemd units to mask. (does not run for the users, under any circumstances) */
+    masked?: Array<string>;
+
+    /** List of systemd units to unmask. (runs for the users, even if previously masked) */
+    unmasked?: Array<string>;
+  };
 }

--- a/modules/yafti/yafti.tsp
+++ b/modules/yafti/yafti.tsp
@@ -1,13 +1,14 @@
 import "@typespec/json-schema";
 using TypeSpec.JsonSchema;
 
-@jsonSchema("/modules/yafti.json")
+@jsonSchema("/modules/yafti-v1.json")
+@jsonSchema("/modules/yafti-latest.json")
 model YaftiModule {
-    /** The yafti module can be used to install yafti and set it up to run on first boot.
-     * https://blue-build.org/reference/modules/yafti/
-     */
-    type: "yafti";
+  /** The yafti module can be used to install yafti and set it up to run on first boot.
+   * https://blue-build.org/reference/modules/yafti/
+   */
+  type: "yafti" | "yafti@v1" | "yafti@latest";
 
-    /** List of custom Flatpaks to inject to the default yafti.yml. Format is: `PrettyName: org.example.flatpak_id` */
-    "custom-flatpaks"?: Array<Record<string>>;
+  /** List of custom Flatpaks to inject to the default yafti.yml. Format is: `PrettyName: org.example.flatpak_id` */
+  `custom-flatpaks`?: Array<Record<string>>;
 }


### PR DESCRIPTION
I'm working on another method to improve the schema validation errors the user receives. This is going to require grabbing the proper schema based on the type and version specified. Existing validation should continue to work when this is merged in. Formatting was done by my editor using the typespec LSP.

CLI work is being done in https://github.com/blue-build/cli/pull/295