### PR TITLE
fix(default-flatpaks): Checking flatpak IDs from FlatHub

### DIFF
--- a/modules/default-flatpaks/v1/default-flatpaks.sh
+++ b/modules/default-flatpaks/v1/default-flatpaks.sh
@@ -126,7 +126,7 @@ check_flatpak_id_validity_from_flathub () {
         echo "Safe-checking if ${INSTALL_LEVEL} flatpak IDs are typed correctly. If test fails, build also fails"
         if [[ ${#INSTALL[@]} -gt 0 ]]; then
           for id in "${INSTALL[@]}"; do
-            if ! curl --output /dev/null --silent --head --fail "${URL}/${id}"; then
+            if ! wget --spider "${URL}/${id}" >/dev/null 2>&1; then
               echo "ERROR: This ${INSTALL_LEVEL} install flatpak ID '${id}' doesn't exist in FlatHub repo, please check if you typed it correctly in the recipe."
               exit 1
             fi
@@ -134,7 +134,7 @@ check_flatpak_id_validity_from_flathub () {
         fi
         if [[ ${#REMOVE[@]} -gt 0 ]]; then  
           for id in "${REMOVE[@]}"; do
-            if ! curl --output /dev/null --silent --head --fail "${URL}/${id}"; then
+            if ! wget --spider "${URL}/${id}" >/dev/null 2>&1; then
               echo "ERROR: This ${INSTALL_LEVEL} removal flatpak ID '${id}' doesn't exist in FlatHub repo, please check if you typed it correctly in the recipe."
               exit 1
             fi


### PR DESCRIPTION
For some reason, `curl` started to specifically fail for `com.obsproject.Studio` flatpak ID, which obviously exists.

I thought it's because of Flathub downtime at the moment, but it's not & is consistently reproducible.

Maybe it's a bug introduced with `curl` or something similar, so to solve this issue, `wget --spider` will be used instead.