### PR TITLE
Use api for flathub app id check to reduce build fails and speedup builds

### DIFF
--- a/modules/default-flatpaks/v1/default-flatpaks.sh
+++ b/modules/default-flatpaks/v1/default-flatpaks.sh
@@ -117,7 +117,7 @@ check_flatpak_id_validity_from_flathub () {
         USER_FLATHUB_REPO=""
       fi  
       FLATHUB_REPO_LINK="https://dl.flathub.org/repo/flathub.flatpakrepo"
-      URL="https://flathub.org/apps"
+      URL="https://flathub.org/api/v2/stats"
       CONFIG_FILE="${1}"
       INSTALL_LEVEL="${2}"
       get_json_array INSTALL "try .$INSTALL_LEVEL.install[]" "${CONFIG_FILE}"


### PR DESCRIPTION
Resolves #386:
> The default flatpaks module currently fetches https://flathub.org/apps/app and checks if it does not return an error response to check if the app exists. This can also be done by using the api (docs: https://flathub.org/api/v2/docs#/app/).....

Changes:
 - Replaced the flathub app url with the flathub stats api url