### PR TITLE
feat: `kargs` module

### DIFF
--- a/modules.json
+++ b/modules.json
@@ -10,6 +10,7 @@
   "https://raw.githubusercontent.com/blue-build/modules/main/modules/gschema-overrides/module.yml",
   "https://raw.githubusercontent.com/blue-build/modules/main/modules/justfiles/module.yml",  
   "https://raw.githubusercontent.com/blue-build/modules/main/modules/rpm-ostree/module.yml",
+  "https://raw.githubusercontent.com/blue-build/modules/main/modules/kargs/module.yml",
   "https://raw.githubusercontent.com/blue-build/modules/main/modules/initramfs/module.yml",
   "https://raw.githubusercontent.com/blue-build/modules/main/modules/script/module.yml",
   "https://raw.githubusercontent.com/blue-build/modules/main/modules/signing/module.yml",

--- a/modules/kargs/README.md
+++ b/modules/kargs/README.md
@@ -5,7 +5,7 @@ The `kargs `module injects kernel arguments into the image. Kernel arguments can
 Instead of modifying & rebuilding the kernel, the module uses `/usr/lib/bootc/kargs.d/` to define the kernel arguments. See the link below for how `bootc` injects kernel arguments:  
 https://containers.github.io/bootc/building/kernel-arguments.html
 
-Because the kargs are managed by `bootc`, to use this module, it is required to be have it installed & to be using it for example for updating the image. This means that instead of `rpm-ostree update`, you need to use `bootc update` for kargs to get applied on the next boot.  
+Because the kargs are managed by `bootc`, to use this module, it is required to be have it installed & to be using it for example for updating the image. This means that instead of `rpm-ostree update`, you need to use `bootc update` for kargs to get applied on the next boot. Or in case of changing the image, you need to use `bootc switch` instead of `rpm-ostree rebase`.
 
 To see which kargs are currently applied, you can issue `rpm-ostree kargs` command in a local terminal.
 

--- a/modules/kargs/README.md
+++ b/modules/kargs/README.md
@@ -8,3 +8,7 @@ https://containers.github.io/bootc/building/kernel-arguments.html
 Because the kargs are managed by `bootc`, to use this module it is required to be have it installed and to be using it for example for updating the image. This means that instead of `rpm-ostree update`, you need to use `bootc update` for kargs to get applied on the next boot.  
 
 To see which kargs are currently applied, you can issue `rpm-ostree kargs` command in a local terminal.
+
+To see which kargs are supported in the kernel, you can see [this detailed documentation](https://web.git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/tree/Documentation/admin-guide/kernel-parameters.txt?h=linux-6.13.y).  
+Switch the branch accordingly to the kernel version your image is on to get the updated version of the documentation.  
+Take a note it's possible that some working kargs are not in the documentation.

--- a/modules/kargs/README.md
+++ b/modules/kargs/README.md
@@ -5,7 +5,7 @@ The `kargs `module injects kernel arguments into the image. Kernel arguments can
 Instead of modifying & rebuilding the kernel, the module uses `/usr/lib/bootc/kargs.d/` to define the kernel arguments. See the link below for how `bootc` injects kernel arguments:  
 https://containers.github.io/bootc/building/kernel-arguments.html
 
-Because the kargs are managed by `bootc`, to use this module it is required to be have it installed and to be using it for example for updating the image. This means that instead of `rpm-ostree update`, you need to use `bootc update` for kargs to get applied on the next boot.  
+Because the kargs are managed by `bootc`, to use this module, it is required to be have it installed & to be using it for example for updating the image. This means that instead of `rpm-ostree update`, you need to use `bootc update` for kargs to get applied on the next boot.  
 
 To see which kargs are currently applied, you can issue `rpm-ostree kargs` command in a local terminal.
 

--- a/modules/kargs/README.md
+++ b/modules/kargs/README.md
@@ -1,14 +1,10 @@
-# kargs
+# `kargs`
 
-The kargs module injects kernel arguments into the image.
+The `kargs `module injects kernel arguments into the image. Kernel arguments can be used to define how kernel will interact with the hardware or software.
 
-Kernel arguments can be used to define how kernel will interact with the hardware or software.
+Instead of modifying & rebuilding the kernel, the module uses `/usr/lib/bootc/kargs.d/` to define the kernel arguments. See the link below for how `bootc` injects kernel arguments:  
+https://containers.github.io/bootc/building/kernel-arguments.html
 
-Instead of modifying & rebuilding the kernel, it is much easier to just input the kernel arguments & `bootc` will do its job.
+Because the kargs are managed by `bootc`, to use this module it is required to be have it installed and to be using it for example for updating the image. This means that instead of `rpm-ostree update`, you need to use `bootc update` for kargs to get applied on the next boot.  
 
-You can see how `bootc` injects kernel arguments [here](https://containers.github.io/bootc/building/kernel-arguments.html).
-
-For this reason, it is required to have `bootc` installed & used in the image.  
-By usage, it means that instead of `rpm-ostree update`, you need to use `bootc update` for kargs to get applied on next boot.  
-
-To see which kargs are currently applied to the system in run-time, you can issue `rpm-ostree kargs` command.
+To see which kargs are currently applied, you can issue `rpm-ostree kargs` command in a local terminal.

--- a/modules/kargs/README.md
+++ b/modules/kargs/README.md
@@ -1,0 +1,14 @@
+# kargs
+
+The kargs module injects kernel arguments into the image.
+
+Kernel arguments can be used to define how kernel will interact with the hardware or software.
+
+Instead of modifying & rebuilding the kernel, it is much easier to just input the kernel arguments & `bootc` will do its job.
+
+You can see how `bootc` injects kernel arguments [here](https://containers.github.io/bootc/building/kernel-arguments.html).
+
+For this reason, it is required to have `bootc` installed & used in the image.  
+By usage, it means that instead of `rpm-ostree update`, you need to use `bootc update` for kargs to get applied on next boot.  
+
+To see which kargs are currently applied to the system in run-time, you can issue `rpm-ostree kargs` command.

--- a/modules/kargs/README.md
+++ b/modules/kargs/README.md
@@ -9,6 +9,6 @@ Because the kargs are managed by `bootc`, to use this module it is required to b
 
 To see which kargs are currently applied, you can issue `rpm-ostree kargs` command in a local terminal.
 
-To see which kargs are supported in the kernel, you can see [this detailed documentation](https://web.git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/tree/Documentation/admin-guide/kernel-parameters.txt?h=linux-6.13.y).  
-Switch the branch accordingly to the kernel version your image is on to get the updated version of the documentation.  
+To see which kargs are supported in the kernel, you can see [this detailed documentation](https://web.git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/tree/Documentation/admin-guide/kernel-parameters.txt).  
+Switch the branch accordingly to the kernel version your image is on to get the more accurate version of the documentation.  
 Take a note it's possible that some working kargs are not in the documentation.

--- a/modules/kargs/kargs.sh
+++ b/modules/kargs/kargs.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if ! command -v bootc &> /dev/null; then
+  echo "ERROR: 'bootc' package is not installed, please install it, as it's necessary for injecting kargs."
+  exit 1
+fi
+
+KARGS_D="/usr/lib/bootc/kargs.d"
+BLUEBUILD_TOML="${KARGS_D}/bluebuild-kargs.toml"
+
+get_json_array KARGS 'try .["kargs"][]' "${1}"
+formatted_kargs=$(printf '"%s", ' "${KARGS[@]}")
+formatted_kargs=${formatted_kargs%, }
+
+ARCH=$(echo "${1}" | jq -r 'try .["arch"]')
+formatted_arch=$(echo "${ARCH}" | sed 's/[^, ]\+/"&"/g')
+
+if [[ ${#KARGS[@]} -gt 0 ]]; then
+  # Make kargs.d directory in case it doesn't exist
+  mkdir -p "${KARGS_D}"
+  # If bluebuild-kargs.toml already exists from the previous module run, append a new suffixed toml file instead
+  if [[ -f "${BLUEBUILD_TOML}" ]]; then
+    counter=1
+    new_filename="${KARGS_D}/bluebuild-kargs-${counter}.toml"
+    while [[ -f "${new_filename}" ]]; do
+        counter=$((counter + 1))
+        new_filename="${KARGS_D}/bluebuild-kargs-${counter}.toml"
+    done
+    BLUEBUILD_TOML="${new_filename}"
+  fi
+  # Write kargs to toml file
+  echo "Writing following kernel arguments to kargs.d TOML file: ${formatted_kargs}"
+  echo "kargs = [${formatted_kargs}]" > "${BLUEBUILD_TOML}"
+  if [[ -n "${ARCH}" || "${ARCH}" != "null" ]]; then
+    echo "Those kernel arguments are applied to the following specific OS architecture(s): ${formatted_arch}"
+    echo "match-architectures = [${formatted_arch}]" >> "${BLUEBUILD_TOML}"
+  fi
+else
+  echo "ERROR: You did not include any kernel arguments to inject in the image."
+  exit 1
+fi

--- a/modules/kargs/kargs.sh
+++ b/modules/kargs/kargs.sh
@@ -33,7 +33,7 @@ if [[ ${#KARGS[@]} -gt 0 ]]; then
   # Write kargs to toml file
   echo "Writing following kernel arguments to kargs.d TOML file: ${formatted_kargs}"
   echo "kargs = [${formatted_kargs}]" > "${BLUEBUILD_TOML}"
-  if [[ -n "${ARCH}" || "${ARCH}" != "null" ]]; then
+  if [[ "${ARCH}" != "null" ]]; then
     echo "Those kernel arguments are applied to the following specific OS architecture(s): ${formatted_arch}"
     echo "match-architectures = [${formatted_arch}]" >> "${BLUEBUILD_TOML}"
   fi

--- a/modules/kargs/kargs.tsp
+++ b/modules/kargs/kargs.tsp
@@ -13,7 +13,7 @@ model KargsModuleV1 {
    */
   type: "kargs" | "kargs@v1" | "kargs@latest";
 
-  /** Defines on which OS architectures are kargs applied. Defaults to all architectures if ommited. */
+  /** Defines on which OS architectures are kargs applied. Defaults to all architectures if omitted. */
   `arch`?: string;
 
   /** Kargs to inject in the image. */

--- a/modules/kargs/kargs.tsp
+++ b/modules/kargs/kargs.tsp
@@ -1,0 +1,21 @@
+import "@typespec/json-schema";
+using TypeSpec.JsonSchema;
+
+@jsonSchema("/modules/kargs-latest.json")
+model KargsModuleLatest {
+  ...KargsModuleV1;
+}
+
+@jsonSchema("/modules/kargs-v1.json")
+model KargsModuleV1 {
+  /** The kargs module injects kernel arguments into the image.
+   * https://blue-build.org/reference/modules/kargs/
+   */
+  type: "kargs" | "kargs@v1" | "kargs@latest";
+
+  /** Defines on which OS architectures are kargs applied. Defaults to all architectures if ommited. */
+  `arch`?: string;
+
+  /** Kargs to inject in the image. */
+  `kargs`: Array<string>;
+}

--- a/modules/kargs/module.yml
+++ b/modules/kargs/module.yml
@@ -2,7 +2,7 @@ name: kargs
 shortdesc: The kargs module injects kernel arguments into the image.
 example: |
   type: kargs
-  arch: x86_64, aarch64
+  arch: x86_64, aarch64 # only injects kernel arguments to those specific OS architectures
   kargs:
     - console=ttyS0,114800n8
     - mitigations=on

--- a/modules/kargs/module.yml
+++ b/modules/kargs/module.yml
@@ -1,0 +1,9 @@
+name: kargs
+shortdesc: The kargs module injects kernel arguments into the image.
+example: |
+  type: kargs
+  arch: x86_64, aarch64
+  kargs:
+    - console=ttyS0,114800n8
+    - mitigations=on
+    - systemd.unified_cgroup_hierarchy=0

--- a/modules/kargs/module.yml
+++ b/modules/kargs/module.yml
@@ -2,7 +2,7 @@ name: kargs
 shortdesc: The kargs module injects kernel arguments into the image.
 example: |
   type: kargs
-  arch: x86_64, aarch64 # only injects kernel arguments to those specific OS architectures
+  arch: x86_64, aarch64 # only inject kernel arguments to these specific OS architectures
   kargs:
     - console=ttyS0,114800n8
     - mitigations=on


### PR DESCRIPTION
Makes it easy to inject kernel arguments into the build.

Requires `bootc`.