### PR TITLE
fix(brew): Fix gcc check for images that already include gcc

### DIFF
--- a/modules/brew/brew.sh
+++ b/modules/brew/brew.sh
@@ -17,12 +17,12 @@ if ! command -v gcc &> /dev/null; then
   elif command -v rpm-ostree &> /dev/null; then
     echo "Installing \"gcc\" package, which is necessary for Brew to function"
     rpm-ostree install gcc
-  fi  
-else
-  echo "ERROR: \"gcc\" package could not be found"
-  echo "       Brew depends on \"gcc\" in order to function"
-  echo "       Please include \"gcc\" in the list of packages to install with the system package manager"
-  exit 1
+  else
+    echo "ERROR: \"gcc\" package could not be found"
+    echo "       Brew depends on \"gcc\" in order to function"
+    echo "       Please include \"gcc\" in the list of packages to install with the system package manager"
+    exit 1
+  fi
 fi
 
 # Check if zstd is installed & install it if it's not
@@ -35,7 +35,7 @@ if ! command -v zstd &> /dev/null; then
     echo "       Brew's installer depends on \"zstd\" in order to function"
     echo "       Please include \"zstd\" in the list of packages to install with the system package manager"
     exit 1
-  fi  
+  fi
 fi
 
 # Module-specific directories and paths
@@ -266,7 +266,7 @@ if [[ "${BREW_ANALYTICS}" == false ]]; then
   CURRENT_HOMEBREW_CONFIG=$(awk -F= '/HOMEBREW_NO_ANALYTICS/ {print $0}' "/etc/environment")
   if [[ -n "${CURRENT_ENVIRONMENT}" ]]; then
     if [[ "${CURRENT_HOMEBREW_CONFIG}" == "HOMEBREW_NO_ANALYTICS=0" ]]; then
-      echo "Disabling Brew analytics"  
+      echo "Disabling Brew analytics"
       sed -i 's/HOMEBREW_NO_ANALYTICS=0/HOMEBREW_NO_ANALYTICS=1/' "/etc/environment"
     elif [[ -z "${CURRENT_HOMEBREW_CONFIG}" ]]; then
       echo "Disabling Brew analytics"


### PR DESCRIPTION
The `gcc` check in the brew module was changed in commit 1c52771e2b1be93ae41fdf1741b591e476e5c816, and is causing [build errors](https://github.com/zelikos/zeliblue/actions/runs/13734724434/job/38417006752).

It looks like the `else` statement was moved, making it so that, if `gcc` *is* already present on the image, the script errors out. This PR moves that `else` statement back into the block that's checking for `dnf5` and `rpm-ostree`.