### PR TITLE
Fix syntax in brew-fish-completions.fish

### DIFF
--- a/modules/brew/brew-fish-completions.fish
+++ b/modules/brew/brew-fish-completions.fish
@@ -1,6 +1,6 @@
 #!/usr/bin/env fish
 #shellcheck disable=all
-if status --is-interactive and if test $(/usr/bin/id -u) -ne 0
+if status --is-interactive; and test $(/usr/bin/id -u) -ne 0
     if [ -d /home/linuxbrew/.linuxbrew ]
         eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
         if test -d (brew --prefix)/share/fish/completions


### PR DESCRIPTION
The patch added earlier today to not load brew into the shell environment for root introduced a syntax error that breaks brew integration with fish for all users (not just root). This fixes the error.