### PR TITLE
chore(default-flatpaks): Start services earlier & ensure consistent start

### DIFF
--- a/modules/default-flatpaks/v1/default-flatpaks.sh
+++ b/modules/default-flatpaks/v1/default-flatpaks.sh
@@ -9,9 +9,6 @@ cp -r "$MODULE_DIRECTORY"/default-flatpaks/system-flatpak-setup /usr/bin/system-
 cp -r "$MODULE_DIRECTORY"/default-flatpaks/user-flatpak-setup /usr/bin/user-flatpak-setup
 cp -r "$MODULE_DIRECTORY"/default-flatpaks/system-flatpak-setup.service /usr/lib/systemd/system/system-flatpak-setup.service
 cp -r "$MODULE_DIRECTORY"/default-flatpaks/user-flatpak-setup.service /usr/lib/systemd/user/user-flatpak-setup.service
-cp -r "$MODULE_DIRECTORY"/default-flatpaks/system-flatpak-setup.timer /usr/lib/systemd/system/system-flatpak-setup.timer
-cp -r "$MODULE_DIRECTORY"/default-flatpaks/user-flatpak-setup.timer /usr/lib/systemd/user/user-flatpak-setup.timer
-
 
 configure_flatpak_repo () {
     CONFIG_FILE=$1
@@ -153,8 +150,8 @@ check_flatpak_id_validity_from_flathub () {
 echo "Enabling flatpaks module"
 mkdir -p /usr/share/bluebuild/default-flatpaks/{system,user}
 mkdir -p /etc/bluebuild/default-flatpaks/{system,user}
-systemctl enable -f system-flatpak-setup.timer
-systemctl enable -f --global user-flatpak-setup.timer
+systemctl enable -f system-flatpak-setup.service
+systemctl enable -f --global user-flatpak-setup.service
 
 # Check that `system` is present before configuring. Also copy template list files before writing Flatpak IDs.
 if [[ $(echo "$1" | jq -r 'try .["system"]') != "null" ]]; then

--- a/modules/default-flatpaks/v1/system-flatpak-setup.service
+++ b/modules/default-flatpaks/v1/system-flatpak-setup.service
@@ -2,7 +2,12 @@
 Description=Manage system flatpaks
 Wants=network-online.target
 After=network-online.target
+After=systemd-user-sessions.service
+Before=user-flatpak-setup.service
 
 [Service]
 Type=oneshot
 ExecStart=/usr/bin/system-flatpak-setup
+
+[Install]
+WantedBy=multi-user.target

--- a/modules/default-flatpaks/v1/system-flatpak-setup.timer
+++ b/modules/default-flatpaks/v1/system-flatpak-setup.timer
@@ -1,8 +1,0 @@
-[Unit]
-Description=Timer for system-flatpak-setup
-
-[Timer]
-OnBootSec=30
-
-[Install]
-WantedBy=timers.target

--- a/modules/default-flatpaks/v1/user-flatpak-setup.service
+++ b/modules/default-flatpaks/v1/user-flatpak-setup.service
@@ -6,3 +6,6 @@ After=system-flatpak-setup.service
 [Service]
 Type=oneshot
 ExecStart=/usr/bin/user-flatpak-setup
+
+[Install]
+WantedBy=graphical-session.target

--- a/modules/default-flatpaks/v1/user-flatpak-setup.timer
+++ b/modules/default-flatpaks/v1/user-flatpak-setup.timer
@@ -1,8 +1,0 @@
-[Unit]
-Description=Timer for user-flatpak-setup
-
-[Timer]
-OnBootSec=30
-
-[Install]
-WantedBy=timers.target


### PR DESCRIPTION
It can't be assured that services will be executed successfully after 30s with timers, depending on boot speed & if user happened to remain idle on login screen.