### PR TITLE
Add nvidia driver installation to akmods module

### DIFF
--- a/modules/akmods/README.md
+++ b/modules/akmods/README.md
@@ -63,3 +63,19 @@ There is also the information of repo source of the akmod, where you can see whi
 All this information can be seen in [`akmods` repo](https://github.com/ublue-os/akmods#kmod-packages).
 
 The solution to this problem is to add the affected akmod repo to [`rpm-ostree`](https://blue-build.org/reference/modules/rpm-ostree/) module in `repos` section.
+
+### Nvidia module not loaded after rebasing to a new image
+
+If your original installation dates from an image based on Fedora 41 or earlier, you may need to manually add the Nvidia module to the kernel command line. Installations based on Fedora 42 or later should work out of the box due to the fact that they use `bootc` by default.
+
+First, check that the nvidia module is not loaded by running `lsmod | grep nvidia`. If the command does not return any output, you'll need to tweak the kernel command line. There are 2 options to do so:
+
+1. If you are using an image based on Universal Blue, you can simply run `sudo ujust configure-nvidia`.
+2. Manually tweak the kernel command line by running the following snippet from the command line:
+```
+rpm-ostree kargs \
+          --append-if-missing=rd.driver.blacklist=nouveau \
+          --append-if-missing=modprobe.blacklist=nouveau \
+          --append-if-missing=nvidia-drm.modeset=1 \
+          --delete-if-present=nomodeset
+```

--- a/modules/akmods/README.md
+++ b/modules/akmods/README.md
@@ -6,7 +6,7 @@ Only Universal Blue based images are officially supported. Universal Blue builds
 
 The [`akmods`](https://github.com/ublue-os/akmods) module is a tool used for managing and installing kernel modules built by Universal Blue. It simplifies the installation of kernel modules, improving the capabilities of your system.
 
-List of all available kernel modules & versions/tags are here:   
+List of all available kernel modules & versions/tags are here:
 https://github.com/ublue-os/akmods
 
 Ublue-os-akmods-addons & ublue-os-nvidia-addons are already included when necessary, so they are not needed to install.
@@ -19,6 +19,16 @@ By default, the `akmods` module installs the `main` version of akmods.
 If you want to install akmods for `surface` or `asus` images, change `base` entry in the recipe file.
 
 See available tags here: https://github.com/ublue-os/akmods/#how-its-organized
+
+## Nvidia modules
+
+To install Nvidia modules, specify which module version you wish to install in the `nvidia-driver:` section of your recipe/configuration file.
+
+The available options are:
+- `nvidia-open`: this flavour of the Nvidia drivers uses the open kernel module. This is the preferred option for graphics cards based on the Turing architecture and later, and the only supported version for Blackwell and later. Full list of supported cards here: https://github.com/NVIDIA/open-gpu-kernel-modules
+- `nvidia`: the propietary flavour of the drivers, compatible with cards since Maxwell until, but not including, Blackwell.
+
+Nvidia modules are only compatible with the `main`, `coreos-stable`, `coreos-testing`, and `bazzite` kernels.
 
 ## Known issues
 
@@ -45,9 +55,9 @@ Problem: conflicting requests
 - nothing provides kvmfr-kmod-common >= 0.0.git.21.ba370a9b needed by kmod-kvmfr-6.9.4-200.fc40.x86_64-0.0.git.21.ba370a9b-1.fc40.x86_64 from @commandline
 ```
 
-This happens when the mentioned akmod is not pulled from ublue-os/akmods COPR repo, but from some other one.  
-Those akmods are rare & they are residing in `extra` akmods stream.  
-There is also the information of repo source of the akmod, where you can see which akmod is the "exotic" one.  
+This happens when the mentioned akmod is not pulled from ublue-os/akmods COPR repo, but from some other one.
+Those akmods are rare & they are residing in `extra` akmods stream.
+There is also the information of repo source of the akmod, where you can see which akmod is the "exotic" one.
 All this information can be seen in [`akmods` repo](https://github.com/ublue-os/akmods#kmod-packages).
 
 The solution to this problem is to add the affected akmod repo to [`rpm-ostree`](https://blue-build.org/reference/modules/rpm-ostree/) module in `repos` section.

--- a/modules/akmods/README.md
+++ b/modules/akmods/README.md
@@ -20,15 +20,17 @@ If you want to install akmods for `surface` or `asus` images, change `base` entr
 
 See available tags here: https://github.com/ublue-os/akmods/#how-its-organized
 
-## Nvidia modules
+## Nvidia kernel modules
 
-To install Nvidia modules, specify which module version you wish to install in the `nvidia-driver:` section of your recipe/configuration file.
+This module can also install Nvidia drivers and kernel modules from `ublue-os/akmods` with the same installation script used by Universal Blue images.
+
+To install kernel Nvidia modules, specify which module version you wish to install in the `nvidia-driver:` section of your recipe/configuration file.
 
 The available options are:
 - `nvidia-open`: this flavour of the Nvidia drivers uses the open kernel module. This is the preferred option for graphics cards based on the Turing architecture and later, and the only supported version for Blackwell and later. Full list of supported cards here: https://github.com/NVIDIA/open-gpu-kernel-modules
 - `nvidia`: the propietary flavour of the drivers, compatible with cards since Maxwell until, but not including, Blackwell.
 
-Nvidia modules are only compatible with the `main`, `coreos-stable`, `coreos-testing`, and `bazzite` kernels.
+Nvidia kernel modules are only compatible with the `main`, `coreos-stable`, `coreos-testing`, and `bazzite` kernels.
 
 ## Known issues
 

--- a/modules/akmods/akmods.sh
+++ b/modules/akmods/akmods.sh
@@ -40,13 +40,13 @@ BASE_IMAGE_NAME=${BASE_IMAGE##*/}
 BASE_IMAGE_NAME=${BASE_IMAGE_NAME%-*}
 
 # Fetch Common AKMODS & Kernel RPMS
-skopeo copy --retry-times 3 docker://ghcr.io/ublue-os/akmods:"${KERNEL_BASE}"-"$(rpm -E %fedora)" dir:/tmp/akmods
+skopeo copy --retry-times 3 docker://ghcr.io/ublue-os/akmods:"${KERNEL_BASE}"-"$(rpm -E %fedora)"-"$(uname -r)" dir:/tmp/akmods
 AKMODS_TARGZ=$(jq -r '.layers[].digest' </tmp/akmods/manifest.json | cut -d : -f 2)
 tar -xvzf /tmp/akmods/"$AKMODS_TARGZ" -C /tmp/
 mv /tmp/rpms/* /tmp/akmods/
 
 echo "Pulling akmods nvidia image"
-skopeo copy --retry-times 3 docker://ghcr.io/ublue-os/akmods-"${NVIDIA_DRIVER}":"${KERNEL_BASE}"-"$(rpm -E %fedora)" dir:/tmp/akmods-rpms
+skopeo copy --retry-times 3 docker://ghcr.io/ublue-os/akmods-"${NVIDIA_DRIVER}":"${KERNEL_BASE}"-"$(rpm -E %fedora)"-"$(uname -r)" dir:/tmp/akmods-rpms
 
 NVIDIA_TARGZ=$(jq -r '.layers[].digest' </tmp/akmods-rpms/manifest.json | cut -d : -f 2)
 tar -xvzf /tmp/akmods-rpms/"$NVIDIA_TARGZ" -C /tmp/

--- a/modules/akmods/akmods.sh
+++ b/modules/akmods/akmods.sh
@@ -52,11 +52,6 @@ NVIDIA_TARGZ=$(jq -r '.layers[].digest' </tmp/akmods-rpms/manifest.json | cut -d
 tar -xvzf /tmp/akmods-rpms/"$NVIDIA_TARGZ" -C /tmp/
 mv /tmp/rpms/* /tmp/akmods-rpms/
 
-if ! grep -q negativo17 <(rpm -qi mesa-dri-drivers); then
-    echo "ERROR: you should be using mesa from negativo17 (this should be happening if you're using universal blue's images)"
-    exit 1
-fi
-
 # Install Nvidia RPMs
 curl -Lo /tmp/nvidia-install.sh https://raw.githubusercontent.com/ublue-os/main/main/build_files/nvidia-install.sh
 chmod +x /tmp/nvidia-install.sh

--- a/modules/akmods/akmods.sh
+++ b/modules/akmods/akmods.sh
@@ -14,12 +14,12 @@ if ! rpm -q rpmfusion-free-release &>/dev/null && ! rpm -q rpmfusion-nonfree-rel
     dnf5 -y install \
         https://mirrors.rpmfusion.org/free/fedora/rpmfusion-free-release-${OS_VERSION}.noarch.rpm \
         https://mirrors.rpmfusion.org/nonfree/fedora/rpmfusion-nonfree-release-${OS_VERSION}.noarch.rpm
-  elif command -v rpm-ostree &> /dev/null; then  
+  elif command -v rpm-ostree &> /dev/null; then
     rpm-ostree install \
         https://mirrors.rpmfusion.org/free/fedora/rpmfusion-free-release-${OS_VERSION}.noarch.rpm \
         https://mirrors.rpmfusion.org/nonfree/fedora/rpmfusion-nonfree-release-${OS_VERSION}.noarch.rpm
   fi
-  previously_not_installed_rpm_fusion=true    
+  previously_not_installed_rpm_fusion=true
 else
   previously_not_installed_rpm_fusion=false
 fi
@@ -35,10 +35,60 @@ if "${previously_not_installed_rpm_fusion}"; then
 fi
 }
 
+INSTALL_NVIDIA_DRIVER() {
+BASE_IMAGE_NAME=${BASE_IMAGE##*/}
+BASE_IMAGE_NAME=${BASE_IMAGE_NAME%-*}
+
+# Fetch Common AKMODS & Kernel RPMS
+skopeo copy --retry-times 3 docker://ghcr.io/ublue-os/akmods:"${KERNEL_BASE}"-"$(rpm -E %fedora)" dir:/tmp/akmods
+AKMODS_TARGZ=$(jq -r '.layers[].digest' </tmp/akmods/manifest.json | cut -d : -f 2)
+tar -xvzf /tmp/akmods/"$AKMODS_TARGZ" -C /tmp/
+mv /tmp/rpms/* /tmp/akmods/
+
+echo "Pulling akmods nvidia image"
+skopeo copy --retry-times 3 docker://ghcr.io/ublue-os/akmods-"${NVIDIA_DRIVER}":"${KERNEL_BASE}"-"$(rpm -E %fedora)" dir:/tmp/akmods-rpms
+
+NVIDIA_TARGZ=$(jq -r '.layers[].digest' </tmp/akmods-rpms/manifest.json | cut -d : -f 2)
+tar -xvzf /tmp/akmods-rpms/"$NVIDIA_TARGZ" -C /tmp/
+mv /tmp/rpms/* /tmp/akmods-rpms/
+
+if ! grep -q negativo17 <(rpm -qi mesa-dri-drivers); then
+    echo "ERROR: you should be using mesa from negativo17 (this should be happening if you're using universal blue's images)"
+    exit 1
+fi
+
+# Install Nvidia RPMs
+curl -Lo /tmp/nvidia-install.sh https://raw.githubusercontent.com/ublue-os/main/main/build_files/nvidia-install.sh
+chmod +x /tmp/nvidia-install.sh
+IMAGE_NAME="${BASE_IMAGE_NAME}" RPMFUSION_MIRROR="" /tmp/nvidia-install.sh
+rm -f /usr/share/vulkan/icd.d/nouveau_icd.*.json
+ln -sf libnvidia-ml.so.1 /usr/lib64/libnvidia-ml.so
+
+KARGS_D="/usr/lib/bootc/kargs.d"
+BLUEBUILD_NVIDIA_TOML="${KARGS_D}/00-bluebuild-nvidia-kargs.toml"
+
+# Create kargs folder if doesn't exist
+mkdir -p "${KARGS_D}"
+echo 'kargs = ["rd.driver.blacklist=nouveau", "modprobe.blacklist=nouveau", "nvidia-drm.modeset=1", "initcall_blacklist=simpledrm_platform_driver_init"]' >> "${BLUEBUILD_NVIDIA_TOML}"
+}
+
+INSTALL_NVIDIA=false
+NVIDIA_DRIVER=""
 get_json_array INSTALL 'try .["install"][]' "$1"
 
-if [[ ${#INSTALL[@]} -lt 1 ]]; then
-  echo "ERROR: You didn't specify any akmod for installation!"
+KERNEL_BASE=$(echo "$1" | jq -r 'try .["base"]')
+if [[ -z $KERNEL_BASE || $KERNEL_BASE == "null" ]]; then
+	KERNEL_BASE="main"
+fi
+
+NVIDIA_DRIVER=$(echo "$1" | jq -r 'try .["nvidia-driver"]')
+if [[ $NVIDIA_DRIVER == "nvidia" || $NVIDIA_DRIVER == "nvidia-open" ]]; then
+    INSTALL_NVIDIA=true
+fi
+
+
+if [[ ${#INSTALL[@]} -lt 1 && $INSTALL_NVIDIA == false ]]; then
+  echo "ERROR: You didn't specify any akmod or nvidia driver for installation!"
   exit 1
 fi
 
@@ -50,8 +100,17 @@ INSTALL_STR=$(echo "${INSTALL_PATH[*]}" | tr -d '\n')
 # WL & V4L2Loopback akmods currently require RPMFusion repo, so we temporarily install then uninstall it
 
 echo "Installing akmods"
-echo "Installing: $(echo "${INSTALL[*]}" | tr -d '\n')"
-ENABLE_AKMODS_REPO
-INSTALL_RPM_FUSION
-rpm-ostree install ${INSTALL_STR}
-UNINSTALL_RPM_FUSION
+
+echo "Total length of modules to install: ${#INSTALL[@]}"
+if [[ ${#INSTALL[@]} -gt 0 ]]; then
+    echo "Installing: $(echo "${INSTALL[*]}" | tr -d '\n')"
+    ENABLE_AKMODS_REPO
+    INSTALL_RPM_FUSION
+    rpm-ostree install ${INSTALL_STR}
+    UNINSTALL_RPM_FUSION
+fi
+
+if [[ $INSTALL_NVIDIA == true ]]; then
+    echo "Installing nvidia driver: $NVIDIA_DRIVER"
+    INSTALL_NVIDIA_DRIVER
+fi

--- a/modules/akmods/akmods.sh
+++ b/modules/akmods/akmods.sh
@@ -40,13 +40,13 @@ BASE_IMAGE_NAME=${BASE_IMAGE##*/}
 BASE_IMAGE_NAME=${BASE_IMAGE_NAME%-*}
 
 # Fetch Common AKMODS & Kernel RPMS
-skopeo copy --retry-times 3 docker://ghcr.io/ublue-os/akmods:"${KERNEL_BASE}"-"$(rpm -E %fedora)"-"$(uname -r)" dir:/tmp/akmods
+skopeo copy --retry-times 3 docker://ghcr.io/ublue-os/akmods:"${KERNEL_BASE}"-"$(rpm -E %fedora)" dir:/tmp/akmods
 AKMODS_TARGZ=$(jq -r '.layers[].digest' </tmp/akmods/manifest.json | cut -d : -f 2)
 tar -xvzf /tmp/akmods/"$AKMODS_TARGZ" -C /tmp/
 mv /tmp/rpms/* /tmp/akmods/
 
 echo "Pulling akmods nvidia image"
-skopeo copy --retry-times 3 docker://ghcr.io/ublue-os/akmods-"${NVIDIA_DRIVER}":"${KERNEL_BASE}"-"$(rpm -E %fedora)"-"$(uname -r)" dir:/tmp/akmods-rpms
+skopeo copy --retry-times 3 docker://ghcr.io/ublue-os/akmods-"${NVIDIA_DRIVER}":"${KERNEL_BASE}"-"$(rpm -E %fedora)" dir:/tmp/akmods-rpms
 
 NVIDIA_TARGZ=$(jq -r '.layers[].digest' </tmp/akmods-rpms/manifest.json | cut -d : -f 2)
 tar -xvzf /tmp/akmods-rpms/"$NVIDIA_TARGZ" -C /tmp/

--- a/modules/akmods/akmods.tsp
+++ b/modules/akmods/akmods.tsp
@@ -39,8 +39,8 @@ model AkmodsModuleV1 {
   install: Array<string>;
 
   /** Nvidia driver to install
-   * - nvidia : for the old nvidia propietary driver
-   * - nvidia-open : for the new kernel-open driver, to be used in Maxwell and newer cards
+   * - nvidia : for the old nvidia propietary driver, compatible with Maxwell and newer cards (but not Blackwell) 
+   * - nvidia-open : for the new kernel-open driver, to be used in Turing and newer cards
    */
   nvidia-driver: "nvidia" | "nvidia-open";
 }

--- a/modules/akmods/akmods.tsp
+++ b/modules/akmods/akmods.tsp
@@ -37,4 +37,10 @@ model AkmodsModuleV1 {
    * See all available akmods here: https://github.com/ublue-os/akmods#kmod-packages
    */
   install: Array<string>;
+
+  /** Nvidia driver to install
+   * - nvidia : for the old nvidia propietary driver
+   * - nvidia-open : for the new kernel-open driver, to be used in Maxwell and newer cards
+   */
+  nvidia-driver: "nvidia" | "nvidia-open";
 }

--- a/modules/akmods/akmods.tsp
+++ b/modules/akmods/akmods.tsp
@@ -42,5 +42,5 @@ model AkmodsModuleV1 {
    * - nvidia : for the old nvidia propietary driver, compatible with Maxwell and newer cards (but not Blackwell) 
    * - nvidia-open : for the new kernel-open driver, to be used in Turing and newer cards
    */
-  nvidia-driver: "nvidia" | "nvidia-open";
+  `nvidia-driver`: "nvidia" | "nvidia-open";
 }


### PR DESCRIPTION
This is an attempt to follow what UniversalBlue [does with their images to install the nvidia drivers](https://github.com/ublue-os/aurora/blob/main/build_files/base/03-install-kernel-akmods.sh).
If you're using one of their final images as your base, i.e. bazzite or aurora, you can directly use the `<image>-nvidia` or `<image>-nvidia-open` images. But if you plan to use the base images they [recommend building something similar for yours](https://github.com/ublue-os/main/issues/846).

This installation method relies on `bootc` to inject the `kargs`, so we need to document that `rpm-ostree` installs (before Fedora 42 basically) will need to manually add the parameters either from the command line or by using Ublue's default `just` scripts.