### PR TITLE
fix(bling): failover to download1 for rpmfusion

### DIFF
--- a/modules/bling/installers/rpmfusion.sh
+++ b/modules/bling/installers/rpmfusion.sh
@@ -13,13 +13,20 @@ if ! rpm -q rpmfusion-free-release &>/dev/null || ! rpm -q rpmfusion-nonfree-rel
   if ! rpm -q rpmfusion-free-release &>/dev/null && ! rpm -q rpmfusion-nonfree-release &>/dev/null; then
     rpm-ostree install \
       "https://mirrors.rpmfusion.org/free/fedora/rpmfusion-free-release-${OS_VERSION}.noarch.rpm" \
-      "https://mirrors.rpmfusion.org/nonfree/fedora/rpmfusion-nonfree-release-${OS_VERSION}.noarch.rpm"
+      "https://mirrors.rpmfusion.org/nonfree/fedora/rpmfusion-nonfree-release-${OS_VERSION}.noarch.rpm" || \
+    rpm-ostree install \
+      "https://download1.rpmfusion.org/free/fedora/rpmfusion-free-release-${OS_VERSION}.noarch.rpm" \
+      "https://download1.rpmfusion.org/nonfree/fedora/rpmfusion-nonfree-release-${OS_VERSION}.noarch.rpm"
   elif ! rpm -q rpmfusion-free-release &>/dev/null; then
     rpm-ostree install \
-      "https://mirrors.rpmfusion.org/free/fedora/rpmfusion-free-release-${OS_VERSION}.noarch.rpm"
+      "https://mirrors.rpmfusion.org/free/fedora/rpmfusion-free-release-${OS_VERSION}.noarch.rpm" || \
+    rpm-ostree install \
+      "https://download1.rpmfusion.org/free/fedora/rpmfusion-free-release-${OS_VERSION}.noarch.rpm"
   elif ! rpm -q rpmfusion-nonfree-release &>/dev/null; then
     rpm-ostree install \
-      "https://mirrors.rpmfusion.org/nonfree/fedora/rpmfusion-nonfree-release-${OS_VERSION}.noarch.rpm"
+      "https://mirrors.rpmfusion.org/nonfree/fedora/rpmfusion-nonfree-release-${OS_VERSION}.noarch.rpm" || \
+    rpm-ostree install \
+      "https://download1.rpmfusion.org/nonfree/fedora/rpmfusion-nonfree-release-${OS_VERSION}.noarch.rpm"
   fi
   if ! rpm -q rpmfusion-free-release-tainted &>/dev/null || ! rpm -q rpmfusion-nonfree-release-tainted &>/dev/null; then
     echo "Installing tainted RPMFusion repos"


### PR DESCRIPTION
I am getting recently quite a lot operation timeouts when using rpm-fusion mirrors.
I believe failing over to the download location would help.

```
============================= Start 'bling' Module =============================
Pulling from bling: rpmfusion
Running RPMFusion repos install...
Downloading https://mirrors.rpmfusion.org/free/fedora/rpmfusion-free-release-42.noarch.rpm...failed
error: Handling argument https://mirrors.rpmfusion.org/free/fedora/rpmfusion-free-release-42.noarch.rpm: error sending request for url (https://mirrors.rpmfusion.org/free/fedora/rpmfusion-free-release-42.noarch.rpm): operation timed out
============================ Failed 'bling' Module ============================
subprocess exited with status 1
subprocess exited with status 1
Error: building at STEP "RUN --mount=type=bind,from=stage-files,src=/files,dst=/tmp/files,rw --mount=type=bind,from=ghcr.io/blue-build/modules/bling:latest,src=/modules,dst=/tmp/modules,rw --mount=type=bind,from=ghcr.io/blue-build/cli/build-scripts:ac63f9e9fb1509f7c005e1046b6ffb81214fe7f3,src=/scripts/,dst=/tmp/scripts/ --mount=type=cache,dst=/var/cache/rpm-ostree,id=rpm-ostree-cache-workstation-latest,sharing=locked --mount=type=cache,dst=/var/cache/libdnf5,id=dnf-cache-workstation-latest,sharing=locked /tmp/scripts/run_module.sh 'bling' '{"type":"bling","install":["rpmfusion"]}'": exit status 1
error: Recipe `build-containerfile` failed on line 29 with exit code 1
```

The building is done on a AWS machine, provided by Fedora CI infrastructure. The network should be very stable there.

See
https://artifacts.dev.testing-farm.io/a065eed6-f896-4455-9113-d2a71598b84c/ for an example of a build of my workstation image.