### PR TITLE
feat: OS Release Module

### DIFF
--- a/modules.json
+++ b/modules.json
@@ -11,6 +11,7 @@
   "https://raw.githubusercontent.com/blue-build/modules/main/modules/justfiles/module.yml",  
   "https://raw.githubusercontent.com/blue-build/modules/main/modules/rpm-ostree/module.yml",
   "https://raw.githubusercontent.com/blue-build/modules/main/modules/dnf/module.yml",
+  "https://raw.githubusercontent.com/blue-build/modules/main/modules/os-release/module.yml",
   "https://raw.githubusercontent.com/blue-build/modules/main/modules/kargs/module.yml",
   "https://raw.githubusercontent.com/blue-build/modules/main/modules/initramfs/module.yml",
   "https://raw.githubusercontent.com/blue-build/modules/main/modules/script/module.yml",

--- a/modules/os-release/README.md
+++ b/modules/os-release/README.md
@@ -1,7 +1,7 @@
 # **`os-release` Module**
 
-The `os-release` module offers a way to declare values in your `/etc/os-release`.
-
+The `os-release` module offers a way to modify and set values in the [`/etc/os-release`](https://www.freedesktop.org/software/systemd/man/latest/os-release.html) file in your image. This file contains metadata about the running Linux operating system and is read by various programs. 
+ 
 ## Example
 
 ```yaml

--- a/modules/os-release/README.md
+++ b/modules/os-release/README.md
@@ -1,0 +1,13 @@
+# **`os-release` Module**
+
+The `os-release` module offers a way to declare values in your `/etc/os-release`.
+
+## Example
+
+```yaml
+type: os-release
+properties:
+  ID: blue_build
+  NAME: BlueBuild
+  PRETTY_NAME: BlueBuild Image
+```

--- a/modules/os-release/module.yml
+++ b/modules/os-release/module.yml
@@ -1,5 +1,5 @@
 name: os-release
-shortdesc: The `os-release` module offers a way to declare values in your `/etc/os-release`.
+shortdesc: The `os-release` module offers a way to modify and set values in the /etc/os-release file in your image.
 example: |
   type: os-release
   properties:

--- a/modules/os-release/module.yml
+++ b/modules/os-release/module.yml
@@ -1,0 +1,8 @@
+name: os-release
+shortdesc: The `os-release` module offers a way to declare values in your `/etc/os-release`.
+example: |
+  type: os-release
+  properties:
+    ID: blue_build
+    NAME: BlueBuild
+    PRETTY_NAME: BlueBuild Image

--- a/modules/os-release/os-release.nu
+++ b/modules/os-release/os-release.nu
@@ -1,0 +1,34 @@
+#!/usr/bin/env nu
+
+def main [config: string]: nothing -> nothing {
+  let config = $config
+    | from json
+    | default {} properties
+  mut os_release = open --raw /etc/os-release
+    | lines
+    | parse '{key}={value}'
+    | transpose --ignore-titles -dr
+    | str trim -c '"'
+    | str trim -c "'"
+  print $'(ansi green)Original release:(ansi reset)'
+  print $os_release
+
+  for $item in ($config.properties | transpose key value) {
+    if $item.key in $os_release {
+      print $'(ansi green)Updating (ansi cyan)($item.key)(ansi green) with value (ansi yellow)($item.value)(ansi reset)'
+      $os_release = $os_release | update $item.key $item.value
+    } else {
+      print $'(ansi green)Adding (ansi cyan)($item.key)(ansi green) with value (ansi yellow)($item.value)(ansi reset)'
+      $os_release = $os_release | insert $item.key $item.value
+    }
+  }
+
+  print $'(ansi green)New release:(ansi reset)'
+  print $os_release
+
+  $os_release
+    | transpose key value
+    | each { $'($in.key)="($in.value)"' }
+    | str join "\n"
+    | save --force /etc/os-release
+}

--- a/modules/os-release/os-release.tsp
+++ b/modules/os-release/os-release.tsp
@@ -1,0 +1,13 @@
+import "@typespec/json-schema";
+using TypeSpec.JsonSchema;
+
+@jsonSchema("/modules/os-release-latest.json")
+model OsReleaseLatest {
+  ...OsReleaseV1;
+}
+
+@jsonSchema("/modules/os-release-v1.json")
+model OsReleaseV1 {
+  /** The properties of the `/etc/os-release` file to set. */
+  properties: Record<string>;
+}


### PR DESCRIPTION
This is a simple module designed to update the `/etc/os-release` variables. It's as easy as:

```yaml
type: os-release
properties:
  NAME: WunkerOS
  ID: wunker_os
  PRETTY_NAME: Wunker OS for Nvidia
```

The result on my machine becomes:

```bash
cat /etc/os-release
NAME="WunkerOS"
VERSION="42.20250603.0 (Kinoite)"
RELEASE_TYPE="stable"
ID="wunker_os"
ID_LIKE="fedora"
VERSION_ID="42"
VERSION_CODENAME="Holographic"
PLATFORM_ID="platform:f42"
PRETTY_NAME="Wunker OS for Nvidia"
ANSI_COLOR="0;38;2;138;43;226"
LOGO="bazzite-logo-icon"
CPE_NAME="cpe:/o:universal-blue:bazzite:42"
DEFAULT_HOSTNAME="bazzite"
HOME_URL="https://bazzite.gg"
DOCUMENTATION_URL="https://docs.bazzite.gg"
SUPPORT_URL="https://discord.bazzite.gg"
BUG_REPORT_URL="https://github.com/ublue-os/bazzite/issues/"
SUPPORT_END="2026-05-13"
VARIANT="Kinoite"
VARIANT_ID="bazzite-nvidia"
OSTREE_VERSION="42.20250603.0"
BUILD_ID="Stable (F42.20250603)"
BOOTLOADER_NAME="Bazzite Stable (F42.20250603)"
IMAGE_ID="bazzite-nvidia-42.20250603"
```