### PR TITLE
modules/script: fix path in example comment

### DIFF
--- a/modules/script/module.yml
+++ b/modules/script/module.yml
@@ -6,4 +6,4 @@ example: |
     - "curl https://example.com/examplebinary > /usr/bin/examplebinary" # example: download binary
     - "ln -sf /usr/bin/ld.bfd /etc/alternatives/ld && ln -sf /etc/alternatives/ld /usr/bin/ld" # example: ld alternatives symlink workaround
   scripts:
-    - myscript.sh # example: run config/scripts/myscript.sh
+    - myscript.sh # example: run files/scripts/myscript.sh


### PR DESCRIPTION
We moved from /config to /files a long time ago. This fixes the comment in the example to say `/files/scripts` instead of `/config/scripts`.