### PR TITLE
docs(os-release): Add note about module placement

### DIFF
--- a/modules/os-release/README.md
+++ b/modules/os-release/README.md
@@ -2,8 +2,9 @@
 
 The `os-release` module offers a way to modify and set values in the [`/etc/os-release`](https://www.freedesktop.org/software/systemd/man/latest/os-release.html) file in your image. This file contains metadata about the running Linux operating system and is read by various programs. 
 
-> [!NOTE]  
-> Modifying the `ID` value within `/etc/os-release` can cause COPR package identification and installation failure during the build process. Therefore, it is recommended to place thie `os-release` module at the end of your recipe, such as before the `signing` module.
+:::note
+Modifying the `ID` value within `/etc/os-release` can cause COPR package identification and installation failure during the build process. Therefore, it is recommended to place thie `os-release` module at the end of your recipe, such as before the `signing` module.
+:::
  
 ## Example
 

--- a/modules/os-release/README.md
+++ b/modules/os-release/README.md
@@ -1,6 +1,9 @@
 # **`os-release` Module**
 
 The `os-release` module offers a way to modify and set values in the [`/etc/os-release`](https://www.freedesktop.org/software/systemd/man/latest/os-release.html) file in your image. This file contains metadata about the running Linux operating system and is read by various programs. 
+
+> [!NOTE]  
+> Modifying the `ID` value within `/etc/os-release` can cause COPR package identification and installation failure during the build process. Therefore, it is recommended to place thie `os-release` module at the end of your recipe, such as before the `signing` module.
  
 ## Example
 

--- a/modules/os-release/README.md
+++ b/modules/os-release/README.md
@@ -3,7 +3,7 @@
 The `os-release` module offers a way to modify and set values in the [`/etc/os-release`](https://www.freedesktop.org/software/systemd/man/latest/os-release.html) file in your image. This file contains metadata about the running Linux operating system and is read by various programs. 
 
 :::note
-Modifying the `ID` value within `/etc/os-release` can cause COPR package identification and installation failure during the build process. Therefore, it is recommended to place thie `os-release` module at the end of your recipe, such as before the `signing` module.
+Modifying the `ID` value within `/etc/os-release` can cause COPR package identification and installation failures during the build process. Therefore, it is recommended to place thie `os-release` module at the end of your build, if you are planning to modify that value.
 :::
  
 ## Example

--- a/modules/os-release/README.md
+++ b/modules/os-release/README.md
@@ -3,7 +3,7 @@
 The `os-release` module offers a way to modify and set values in the [`/etc/os-release`](https://www.freedesktop.org/software/systemd/man/latest/os-release.html) file in your image. This file contains metadata about the running Linux operating system and is read by various programs. 
 
 :::note
-Modifying the `ID` value within `/etc/os-release` can cause COPR package identification and installation failures during the build process. Therefore, it is recommended to place thie `os-release` module at the end of your build, if you are planning to modify that value.
+Modifying the `ID` value within `/etc/os-release` can cause COPR package identification and installation failures during the build process. When changing the `ID`, you should always set `ID_LIKE` to the type of base image you are using, ex. `ID_LIKE: fedora`. Errors from setting the `ID` may also be alleviated by running the module at the end of the build process, but beware that those errors would still be present in images derived from your image.
 :::
  
 ## Example


### PR DESCRIPTION
Modifying `ID` may cause failures in identification and installation of COPR packages during the build process, and is ideally placed later in the recipe.