### PR TITLE
feat: Add ability to specify chroot for COPR repo

### DIFF
--- a/modules/dnf/README.md
+++ b/modules/dnf/README.md
@@ -42,13 +42,15 @@ repos:
 ### Add COPR Repositories
 
 - [COPR](https://copr.fedorainfracloud.org/) contains software repositories maintained by fellow Fedora users
+- The `chroot` can be specified for the repo. The `chroot` is basically the OS in which the package was built.
 
 ```yaml
 type: dnf
 repos:
   copr:
     - atim/starship
-    - trixieua/mutter-patched
+    - name: trixieua/mutter-patched
+      chroot: fedora-42-x86_64
 ```
 
 ### Disable/Enable Repositories
@@ -65,6 +67,8 @@ repos:
   copr:
     enable:
       - ryanabx/cosmic-epoch
+      - name: trixieua/mutter-patched
+        chroot: fedora-42-x86_64
     disable:
       - kylegospo/oversteer
 ```

--- a/modules/dnf/dnf.tsp
+++ b/modules/dnf/dnf.tsp
@@ -48,7 +48,7 @@ model Repo {
    * You can also specify 2 lists
    * instead to 'enable' or 'disable' COPR repos.
    */
-  copr?: Array<string> | RepoCopr;
+  copr?: Array<string | RepoCoprEnable> | RepoCopr;
 
   /** List of links to key files to import for installing from custom repositories. */
   keys?: Array<string>;
@@ -77,10 +77,18 @@ model RepoFiles {
 
 model RepoCopr {
   /** List of COPR repos to enable */
-  enable?: Array<string>;
+  enable?: Array<string | RepoCoprEnable>;
 
   /** List of COPR repos to disable */
   disable?: Array<string>;
+}
+
+model RepoCoprEnable {
+  /** The COPR repo's name */
+  name: string;
+
+  /** The chroot for the COPR repo */
+  chroot: string;
 }
 
 model Install {

--- a/modules/dnf/dnf_interface.nu
+++ b/modules/dnf/dnf_interface.nu
@@ -134,12 +134,21 @@ export def "dnf config-manager setopt" [
   }
 }
 
-export def "dnf copr enable" [copr: string]: nothing -> nothing {
+export def "dnf copr enable" [
+  copr: string
+  chroot?: string
+]: nothing -> nothing {
   check_dnf_plugins
   let dnf = dnf version
   
   try {
-    ^$dnf.path -y copr enable ($copr | check_copr)
+    ^$dnf.path -y copr enable ($copr | check_copr) ...(
+      if $chroot == null {
+        []
+      } else {
+        [$chroot]
+      }
+    )
   } catch {|e|
     print $'($e.msg)'
     exit 1


### PR DESCRIPTION
This add the ability to set the `chroot` for a COPR repo. This is useful for images that have a different default `chroot` like SecureBlue (see #445 ).