### PR TITLE
fix(bling): `ublue-update` not working

### DIFF
--- a/modules/bling/installers/ublue-update.sh
+++ b/modules/bling/installers/ublue-update.sh
@@ -14,7 +14,11 @@ set_config_value() {
 
 # Check if ublue-os-update-services rpm is installed, these services conflict with ublue-update
 if rpm -q ublue-os-update-services > /dev/null; then
-    rpm-ostree override remove ublue-os-update-services
+    if command -v dnf 1> /dev/null; then
+      dnf remove ublue-os-update-services
+    elif command -v rpm-ostree 1> /dev/null; then
+      rpm-ostree override remove ublue-os-update-services
+    fi
 fi
 
 # Change the conflicting update policy for rpm-ostreed
@@ -28,14 +32,37 @@ fi
 systemctl disable rpm-ostreed-automatic.timer
 
 # Fetch ublue COPR
-REPO_URL="https://copr.fedorainfracloud.org/coprs/ublue-os/staging/repo/fedora-${OS_VERSION}/ublue-os-staging-fedora-${OS_VERSION}.repo"
-echo "Downloading repo file ${REPO_URL}"
-curl -fLs --create-dirs "${REPO_URL}" -o "/etc/yum.repos.d/ublue-os-staging-fedora-${OS_VERSION}.repo"
-echo "Downloaded repo file ${REPO_URL}"
+RPM_URL="https://github.com/ublue-os/ublue-update/releases/download/v1.3.0/ublue-update-1.0.0+2e65a65-1.fc38.noarch.rpm"
+echo "Downloading RPM ${RPM_URL}"
+curl -fLs --create-dirs "${RPM_URL}" -o "/tmp/ublue-update-1.0.0+2e65a65-1.fc38.noarch.rpm"
+echo "Downloaded RPM ${RPM_URL}"
 
 # topgrade is REQUIRED by ublue-update to install
-rpm-ostree install topgrade
-rpm-ostree install ublue-update
+# we have to rely on 3rd party COPR repo for topgrade & on clunky skopeo + file workaround for ublue-update ghcr container,
+# because Universal Blue removed them in their copr repo
+if command -v dnf 1> /dev/null; then
+  dnf copr enable lilay/topgrade
+  dnf install topgrade skopeo
+  mkdir -p /tmp/ublue-update
+  skopeo copy docker://ghcr.io/ublue-os/ublue-update:latest oci:/tmp/ublue-update/ublue-update:latest
+  GZIP="$(file /tmp/ublue-update/ublue-update/*/*/* | grep 'gzip compressed data' | cut -d: -f1)"
+  tar -xzf "$GZIP" --strip-components=1 -C /tmp/ublue-update rpms/
+  dnf install /tmp/ublue-update/ublue-update.noarch.rpm
+elif command -v rpm-ostree 1> /dev/null; then
+  topgrade_url="https://copr.fedorainfracloud.org/coprs/lilay/topgrade/repo/fedora-${OS_VERSION}/lilay-topgrade-fedora-${OS_VERSION}.repo"
+  echo "Downloading topgrade repo ${topgrade_url}"
+  curl -fLs --create-dirs "${topgrade_url}" -o "/etc/yum.repos.d/_copr_topgrade.repo"
+  echo "Downloaded topgrade repo ${topgrade_url}"
+  rpm-ostree install topgrade skopeo
+  mkdir -p /tmp/ublue-update
+  skopeo copy docker://ghcr.io/ublue-os/ublue-update:latest oci:/tmp/ublue-update/ublue-update:latest
+  GZIP="$(file /tmp/ublue-update/ublue-update/*/*/* | grep 'gzip compressed data' | cut -d: -f1)"
+  tar -xzf "$GZIP" --strip-components=1 -C /tmp/ublue-update rpms/
+  rpm-ostree install /tmp/ublue-update/ublue-update.noarch.rpm
+fi
+# Fix files present in /usr/etc in RPM spec
+if [[ -d /usr/etc/ublue-update ]]; then
+  mv /usr/etc/ublue-update /etc/ublue-update
+fi
 
-# Remove ublue COPR
-rm /etc/yum.repos.d/ublue-os-staging-fedora-*.repo
+rm -rf /tmp/ublue-update


### PR DESCRIPTION
Universal Blue removed `topgrade` & `ublue-update` from their repos, so I had to improvise with `skopeo`, since their `ublue-update` release is older than their `ghcr` container.
I also had to improvise with using 3rd party COPR repo for `topgrade`, which is a dependency to `ublue-update`, as Universal Blue also removed it from their repos.

It is recommended to use `uupd` instead, as `ublue-update` is deprecated, I just fixed it so it can work until possible `uupd` bling submodule arrives.

Fixes: #424 