### PR TITLE
fix: akmod example make the build fail

### DIFF
--- a/modules/akmods/module.yml
+++ b/modules/akmods/module.yml
@@ -5,6 +5,5 @@ example: |
   base: asus # if not specified, classic "main" base is used by default
   install:
     - openrazer
-    - openrgb
     - v4l2loopback
-    - winesync
+    - xone


### PR DESCRIPTION
`openrgb` and `winesync` are not in ublue-os' kmod-package [list](https://github.com/ublue-os/akmods) anymore, making any build on a recipe containing this example fail.