### PR TITLE
fix: Add check for empty flatpak list

### DIFF
--- a/modules/default-flatpaks/v2/post-boot/system-flatpak-setup
+++ b/modules/default-flatpaks/v2/post-boot/system-flatpak-setup
@@ -23,15 +23,16 @@ def main [] {
             flatpak remote-delete --system fedora-testing --force
         }
 
-        let fedoraApps = flatpak list --system --app --columns=origin,application | detect columns --no-headers | where column0 == fedora | get column1
-        if (($fedoraApps | length) > 0) {
-            flatpak remove --system --noninteractive ...$fedoraApps
-        }
-
-        let fedoraRuntimes = flatpak list --system --runtime --columns=origin,application,arch,branch | detect columns --no-headers | where column0 == fedora | each {|i| $"($i.column1)/($i.column2)/($i.column3)" }
-        if (($fedoraRuntimes | length) > 0) {
+	let appList = (flatpak list --system --app --columns=origin,application)
+	if ($appList | is-not-empty) {
+	    let fedoraApps = $appList | detect columns --no-headers | where column0 == fedora | get column1
+	    flatpak remove --system --noninteractive ...$fedoraApps
+	}
+	let runtimeList = (flatpak list --system --runtime --columns=origin,application,arch,branch)
+	if ($runtimeList | is-not-empty) {
+	    let fedoraRuntimes = $runtimeList | detect columns --no-headers | where column0 == fedora | each {|i| $"($i.column1)/($i.column2)/($i.column3)" }
             flatpak remove --system --noninteractive ...$fedoraRuntimes
-        }
+	}
     }
 
     for config in ($configFile | where scope == system) {

--- a/modules/default-flatpaks/v2/post-boot/user-flatpak-setup
+++ b/modules/default-flatpaks/v2/post-boot/user-flatpak-setup
@@ -19,15 +19,17 @@ def main [] {
             flatpak remote-delete --user fedora-testing --force
         }
 
-        let fedoraApps = flatpak list --user --app --columns=origin,application | detect columns --no-headers | where column0 == fedora | get column1
-        if (($fedoraApps | length) > 0) {
-            flatpak remove --user --noninteractive ...$fedoraApps
-        }
+	let appList = (flatpak list --user --app --columns=origin,application)
+	if ($appList | is-not-empty) {
+	    let fedoraApps = $appList | detect columns --no-headers | where column0 == fedora | get column1
+	    flatpak remove --user --noninteractive ...$fedoraApps
+	}
 
-        let fedoraRuntimes = flatpak list --user --runtime --columns=origin,application,arch,branch | detect columns --no-headers | where column0 == fedora | each {|i| $"($i.column1)/($i.column2)/($i.column3)" }
-        if (($fedoraRuntimes | length) > 0) {
-            flatpak remove --user --noninteractive ...$fedoraRuntimes
-        }
+	let runtimeList = (flatpak list --user --runtime --columns=origin,application,arch,branch)
+	if ($runtimeList | is-not-empty) {
+	    let fedoraRuntimes = $runtimeList | detect columns --no-headers | where column0 == fedora | each {|i| $"($i.column1)/($i.column2)/($i.column3)" }
+	    flatpak remove --user --noninteractive ...$fedoraRuntimes
+	}
     }
 
     for config in ($configFile | where scope == user) {


### PR DESCRIPTION
Adds a check when `flatpak list` for the apps and runtimes is empty.

Fixes an issue where the flatpaks wouldn't install when no runtimes or apps where installed in user-space, due to an empty input being piped into `empty columns`

Fixes issue #437 