### PR TITLE
fix: Ensure the flatpak list is filtered before checking for empty

### DIFF
--- a/modules/default-flatpaks/v2/post-boot/system-flatpak-setup
+++ b/modules/default-flatpaks/v2/post-boot/system-flatpak-setup
@@ -22,17 +22,17 @@ def main [] {
         if ($systemRemotes | any {|remote| $remote == "fedora-testing"}) {
             flatpak remote-delete --system fedora-testing --force
         }
+        let fedoraAppList = (flatpak list --system --app --columns=origin,application | detect columns --no-headers | default [] | where column0 == fedora)
+        if ($fedoraAppList | is-not-empty) {
+            let fedoraApps = $fedoraAppList | get column1
+            flatpak remove --user --noninteractive ...$fedoraApps
+        }
 
-	let appList = (flatpak list --system --app --columns=origin,application)
-	if ($appList | is-not-empty) {
-	    let fedoraApps = $appList | detect columns --no-headers | where column0 == fedora | get column1
-	    flatpak remove --system --noninteractive ...$fedoraApps
-	}
-	let runtimeList = (flatpak list --system --runtime --columns=origin,application,arch,branch)
-	if ($runtimeList | is-not-empty) {
-	    let fedoraRuntimes = $runtimeList | detect columns --no-headers | where column0 == fedora | each {|i| $"($i.column1)/($i.column2)/($i.column3)" }
-            flatpak remove --system --noninteractive ...$fedoraRuntimes
-	}
+        let fedoraRuntimeList = (flatpak list --system --runtime --columns=origin,application,arch,branch | detect columns --no-headers | default [] | where column0 == fedora)
+        if ($fedoraRuntimeList | is-not-empty) {
+            let fedoraRuntimes = $fedoraRuntimeList | each {|i| $"($i.column1)/($i.column2)/($i.column3)" }
+            flatpak remove --user --noninteractive ...$fedoraRuntimes
+        }
     }
 
     for config in ($configFile | where scope == system) {

--- a/modules/default-flatpaks/v2/post-boot/user-flatpak-setup
+++ b/modules/default-flatpaks/v2/post-boot/user-flatpak-setup
@@ -19,17 +19,17 @@ def main [] {
             flatpak remote-delete --user fedora-testing --force
         }
 
-	let appList = (flatpak list --user --app --columns=origin,application)
-	if ($appList | is-not-empty) {
-	    let fedoraApps = $appList | detect columns --no-headers | where column0 == fedora | get column1
-	    flatpak remove --user --noninteractive ...$fedoraApps
-	}
+        let fedoraAppList = (flatpak list --user --app --columns=origin,application | detect columns --no-headers | default [] | where column0 == fedora)
+        if ($fedoraAppList | is-not-empty) {
+            let fedoraApps = $fedoraAppList | get column1
+            flatpak remove --user --noninteractive ...$fedoraApps
+        }
 
-	let runtimeList = (flatpak list --user --runtime --columns=origin,application,arch,branch)
-	if ($runtimeList | is-not-empty) {
-	    let fedoraRuntimes = $runtimeList | detect columns --no-headers | where column0 == fedora | each {|i| $"($i.column1)/($i.column2)/($i.column3)" }
-	    flatpak remove --user --noninteractive ...$fedoraRuntimes
-	}
+        let fedoraRuntimeList = (flatpak list --user --runtime --columns=origin,application,arch,branch | detect columns --no-headers | default [] | where column0 == fedora)
+        if ($fedoraRuntimeList | is-not-empty) {
+            let fedoraRuntimes = $fedoraRuntimeList | each {|i| $"($i.column1)/($i.column2)/($i.column3)" }
+            flatpak remove --user --noninteractive ...$fedoraRuntimes
+        }
     }
 
     for config in ($configFile | where scope == user) {


### PR DESCRIPTION
In order for the logic to work properly, the flatpak list needs to be filtered down before checking for empty. Otherwise, in the `if` clause, the list would become empty, and would cause the flatpak call to fail.