### PR TITLE
fix: only stop gnome-software if it exists on the system

### DIFF
--- a/modules/default-flatpaks/v2/post-boot/system-flatpak-setup
+++ b/modules/default-flatpaks/v2/post-boot/system-flatpak-setup
@@ -12,7 +12,10 @@ def main [] {
 
     let systemRemotes = (flatpak remotes --system --columns name | split row "\n")
     if (not $keepFedora and ($systemRemotes | any {|remote| $remote == "fedora" or $remote == "fedora-testing"})) {
-        /usr/bin/gnome-software --quit
+        let gnomeSoftwareExists = (which /usr/bin/gnome-software)
+        if $gnomeSoftwareExists.exit_code == 0 {
+            /usr/bin/gnome-software --quit
+        }
         /usr/lib/fedora-third-party/fedora-third-party-opt-out
         /usr/bin/fedora-third-party disable
 

--- a/modules/default-flatpaks/v2/post-boot/system-flatpak-setup
+++ b/modules/default-flatpaks/v2/post-boot/system-flatpak-setup
@@ -12,8 +12,7 @@ def main [] {
 
     let systemRemotes = (flatpak remotes --system --columns name | split row "\n")
     if (not $keepFedora and ($systemRemotes | any {|remote| $remote == "fedora" or $remote == "fedora-testing"})) {
-        let gnomeSoftwareExists = (which /usr/bin/gnome-software)
-        if $gnomeSoftwareExists.exit_code == 0 {
+        if ('/usr/bin/gnome-software' | path exists) {
             /usr/bin/gnome-software --quit
         }
         /usr/lib/fedora-third-party/fedora-third-party-opt-out


### PR DESCRIPTION
Checks if gnome-software exists on system before trying to stop it. Otherwise this service fails here.

Closes #446 