### PR TITLE
fix: only run fedora removal -related commands if binaries exist

### DIFF
--- a/modules/default-flatpaks/v2/README.md
+++ b/modules/default-flatpaks/v2/README.md
@@ -6,6 +6,8 @@ For instructions on migration from v1 to v2, see the [announcement blog post](/b
 
 The `default-flatpaks` module can be used to install Flatpaks from a configurable remote on every boot. By default the module will remove the Fedora Flatpak remote and install the Flathub remote, but you can also configure it to install other Flatpaks from other remotes.
 
+Note that by default Universal Blue images ship with the system Flathub remote included and with Fedora Flatpaks disabled ([source](https://github.com/ublue-os/main/blob/main/sys_files/usr/lib/systemd/system/flatpak-add-flathub-repos.service)), so you don't need to use this module just to configure those repositories.
+
 ## Features
 
 - System and user systemd services that are based on your configuration

--- a/modules/default-flatpaks/v2/post-boot/system-flatpak-setup
+++ b/modules/default-flatpaks/v2/post-boot/system-flatpak-setup
@@ -15,8 +15,12 @@ def main [] {
         if ('/usr/bin/gnome-software' | path exists) {
             /usr/bin/gnome-software --quit
         }
-        /usr/lib/fedora-third-party/fedora-third-party-opt-out
-        /usr/bin/fedora-third-party disable
+        if ('/usr/lib/fedora-third-party/fedora-third-party-opt-out' | path exists) {
+            /usr/lib/fedora-third-party/fedora-third-party-opt-out
+        }
+        if ('/usr/bin/fedora-third-party' | path exists) {
+            /usr/bin/fedora-third-party disable
+        }
 
         if ($systemRemotes | any {|remote| $remote == "fedora"}) {
             flatpak remote-delete --system fedora --force


### PR DESCRIPTION
(ublue removes these by default, but keeps fedora repos as disabled)