### PR TITLE
fix(initramfs): set dracut log levels for efficiency

### DIFF
--- a/modules/initramfs/initramfs.sh
+++ b/modules/initramfs/initramfs.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 if ! command -v rpm-ostree &> /dev/null || ! command -v bootc &> /dev/null; then
   echo "This module is only compatible with Fedora Atomic images"
   exit 1
-fi  
+fi
 
 if [[ "${OS_VERSION}" -le 40 ]]; then
   echo "This module is only compatible with Fedora 41+ images."
@@ -34,9 +34,29 @@ if [[ "${#QUALIFIED_KERNEL[@]}" -gt 1 ]]; then
   echo "      It is most ideal to have only 1 kernel, to make initramfs regeneration faster."
 fi
 
+# Set dracut log levels using temporary configuration file.
+# This avoids logging messages to the system journal, which can significantly
+# impact performance in the default configuration.
+temp_conf_dir="$(mktemp -d)"
+cat >"${temp_conf_dir}/loglevels.conf" <<'EOF'
+stdloglvl=4
+sysloglvl=0
+kmsgloglvl=0
+fileloglvl=0
+EOF
+
 for qual_kernel in "${QUALIFIED_KERNEL[@]}"; do
   INITRAMFS_IMAGE="${KERNEL_MODULES_PATH}/${qual_kernel}/initramfs.img"
   echo "Starting initramfs regeneration for kernel version: ${qual_kernel}"
-  "${DRACUT}" --no-hostonly --kver "${qual_kernel}" --reproducible -v --add ostree -f "${INITRAMFS_IMAGE}"
+  "${DRACUT}" \
+    --kver "${qual_kernel}" \
+    --force \
+    --add 'ostree' \
+    --add-confdir "${temp_conf_dir}" \
+    --no-hostonly \
+    --reproducible \
+    "${INITRAMFS_IMAGE}"
   chmod 0600 "${INITRAMFS_IMAGE}"
 done
+
+rm -rf "${temp_conf_dir}"


### PR DESCRIPTION
Dracut is configured by default to set `sysloglvl=5`, which results in a large amount of debug info being sent to the system journal during the build process. This is also implemented inefficiently in shell script, and has a major performance impact. Since we don't care about system journal output at all during the build process, we can just disable all logging to everywhere except stderr using a temporary dracut conf file.