### PR TITLE
feat(platforms): Add support for building all platforms

### DIFF
--- a/.github/workflows/build-individual.yml
+++ b/.github/workflows/build-individual.yml
@@ -1,6 +1,8 @@
 name: build-individual
 on:
   push:
+    branches:
+      - main
     paths-ignore: # don't rebuild if only documentation has changed
       - "**.md"
   pull_request:
@@ -18,6 +20,11 @@ jobs:
           version: v0.93
 
       - uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
+        with:
+          install: true
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 # v3.5.0

--- a/.github/workflows/build-unified.yml
+++ b/.github/workflows/build-unified.yml
@@ -1,6 +1,8 @@
 name: build-unified
 on:
   push:
+    branches:
+      - main
     paths-ignore: # don't rebuild if only documentation has changed
       - "**.md"
   pull_request:
@@ -18,6 +20,11 @@ jobs:
           version: v0.93
 
       - uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
+        with:
+          install: true
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 # v3.5.0

--- a/build-individual.nu
+++ b/build-individual.nu
@@ -1,24 +1,7 @@
 #!/usr/bin/env nu
 # build separate images for each module in the repo
 
-const PLATFORMS = [
-  'linux/amd64'
-  'linux/amd64/v2'
-  'linux/arm64'
-  'linux/arm'
-  'linux/arm/v6'
-  'linux/arm/v7'
-  'linux/386'
-  'linux/loong64'
-  'linux/mips'
-  'linux/mipsle'
-  'linux/mips64'
-  'linux/mips64le'
-  'linux/ppc64'
-  'linux/ppc64le'
-  'linux/riscv64'
-  'linux/s390x'
-]
+use constants.nu *
 
 print $"(ansi green_bold)Gathering images"
 

--- a/build-unified.nu
+++ b/build-unified.nu
@@ -1,24 +1,7 @@
 #!/usr/bin/env nu
 # generates modules-latest directory with only latest versions of modules and builds the Containerfile
 
-const PLATFORMS = [
-  'linux/amd64'
-  'linux/amd64/v2'
-  'linux/arm64'
-  'linux/arm'
-  'linux/arm/v6'
-  'linux/arm/v7'
-  'linux/386'
-  'linux/loong64'
-  'linux/mips'
-  'linux/mipsle'
-  'linux/mips64'
-  'linux/mips64le'
-  'linux/ppc64'
-  'linux/ppc64le'
-  'linux/riscv64'
-  'linux/s390x'
-]
+use constants.nu *
 
 print $"(ansi green_bold)Gathering images(ansi reset)"
 

--- a/constants.nu
+++ b/constants.nu
@@ -1,0 +1,18 @@
+export const PLATFORMS = [
+  'linux/amd64'
+  'linux/amd64/v2'
+  'linux/arm64'
+  'linux/arm'
+  'linux/arm/v6'
+  'linux/arm/v7'
+  'linux/386'
+  'linux/loong64'
+  'linux/mips'
+  'linux/mipsle'
+  'linux/mips64'
+  'linux/mips64le'
+  'linux/ppc64'
+  'linux/ppc64le'
+  'linux/riscv64'
+  'linux/s390x'
+]


### PR DESCRIPTION
This is to support the upcoming multi-platform build feature with the CLI. The build will still work without this, but it will throw up warnings in the log that could throw our users off when trying to diagnose the problem with their image.

This would normally be a very computationally intense process creating all these images. However, since the modules are basically single layer `COPY`'s, this shouldn't take too long.