### PR TITLE
fix(bling): Correct 1Password installation path

### DIFF
--- a/modules/bling/installers/1password.sh
+++ b/modules/bling/installers/1password.sh
@@ -48,11 +48,11 @@ rpm-ostree install 1password 1password-cli
 rm /etc/yum.repos.d/1password.repo -f
 
 # And then we do the hacky dance!
-mv /var/opt/1Password /usr/lib/1Password # move this over here
+mv /opt/1Password /usr/lib/1Password # move this over here
 
-# Create a symlink /usr/bin/1password => /opt/1Password/1password
+# Create a symlink /usr/bin/1password => /usr/lib/1Password/1password
 rm /usr/bin/1password
-ln -s /opt/1Password/1password /usr/bin/1password
+ln -s /usr/lib/1Password/1password /usr/bin/1password
 
 #####
 # The following is a bastardization of "after-install.sh"


### PR DESCRIPTION
The 1Password RPM package installs its files to `/opt/1Password`, but the installation script was attempting to move them from `/var/opt/1Password`. This resulted in a broken installation.

This commit corrects the source path in the `mv` command to `/opt/1Password` and updates the symbolic link to point to the correct executable location in `/usr/lib/1Password/1password`.