### PR TITLE
fix(files): ShellCheck, spelling, formatting fixes

### DIFF
--- a/modules/files/files.sh
+++ b/modules/files/files.sh
@@ -14,55 +14,55 @@ fi
 
 cd "${FILES_DIR}"
 shopt -s dotglob
- 
-if [[ ${#FILES[@]} -gt 0 ]]; then
-    echo "Adding files to image"
-    for pair in "${FILES[@]}"; do
-      # Support for legacy recipe format to satisfy transition period to new source/destination recipe format
-      if [[ $(echo "$pair" | jq -r 'try .["source"]') == "null" || -z $(echo "$pair" | jq -r 'try .["source"]') ]] && [[ $(echo "$pair" | jq -r 'try .["destination"]') == "null" || -z $(echo "$pair" | jq -r 'try .["destination"]') ]]; then
-        echo "ATTENTION: You are using the legacy module recipe format"
-        echo "           It is advised to switch to new module recipe format,"
-        echo "           which contains 'source' & 'destination' YAML keys"
-        echo "           For more details, please visit 'files' module documentation:"
-        echo "           https://blue-build.org/reference/modules/files/"
-        FILE="$PWD/$(echo $pair | jq -r 'to_entries | .[0].key')"
-        DEST=$(echo $pair | jq -r 'to_entries | .[0].value')
-      else
-        FILE="$PWD/$(echo "$pair" | jq -r 'try .["source"]')"
-        DEST=$(echo "$pair" | jq -r 'try .["destination"]')
-      fi 
-        if [ -d "$FILE" ]; then
-            if [ ! -d "$DEST" ]; then
-                mkdir -p "$DEST"
-            fi
-            echo "Copying $FILE/* to $DEST"
-            cp -rf "$FILE"/* $DEST
-            if [[ "${DEST}" =~ *"/" ]] || [[ "${DEST}" == "/" ]]; then
-              rm -f "${DEST}.gitkeep"
-            else
-              rm -f "${DEST}/.gitkeep"
-            fi  
-        elif [ -f "$FILE" ]; then
-            DEST_DIR=$(dirname "$DEST")
-            if [ ! -d "$DEST_DIR" ]; then
-                mkdir -p "$DEST_DIR"
-            fi
-            echo "Copying $FILE to $DEST"
-            cp -f $FILE $DEST
-            if [[ "${DEST}" =~ *"/" ]] || [[ "${DEST}" == "/" ]]; then
-              rm -f "${DEST}.gitkeep"
-            else
-              rm -f "${DEST}/.gitkeep"
-            fi  
-        else
-            echo "File or Directory $FILE Does Not Exist in ${FILES_DIR}"
-            exit 1
-        fi
-    done
-else
-  echo "ERROR: You did not add any file or folder to the module recipe for copying,"
-  echo "       Please assure that you performed this operation correctly"
+
+if [[ ${#FILES[@]} -eq 0 ]]; then
+  echo "ERROR: You did not add any file or folder to the module recipe for copying."
+  echo "       Please ensure that you performed this operation correctly."
   exit 1
 fi
+
+echo "Adding files to image"
+for pair in "${FILES[@]}"; do
+  # Support for legacy recipe format to satisfy transition period to new source/destination recipe format
+  if [[ $(echo "$pair" | jq -r 'try .["source"]') == "null" || -z $(echo "$pair" | jq -r 'try .["source"]') ]] && [[ $(echo "$pair" | jq -r 'try .["destination"]') == "null" || -z $(echo "$pair" | jq -r 'try .["destination"]') ]]; then
+    echo "ATTENTION: You are using the legacy module recipe format."
+    echo "           It is advised to switch to the new module recipe format,"
+    echo "           which contains 'source' & 'destination' YAML keys."
+    echo "           For more details, please visit 'files' module documentation:"
+    echo "           https://blue-build.org/reference/modules/files/"
+    FILE="$PWD/$(echo "$pair" | jq -r 'to_entries | .[0].key')"
+    DEST=$(echo "$pair" | jq -r 'to_entries | .[0].value')
+  else
+    FILE="$PWD/$(echo "$pair" | jq -r 'try .["source"]')"
+    DEST=$(echo "$pair" | jq -r 'try .["destination"]')
+  fi
+  if [[ -d "$FILE" ]]; then
+    if [[ ! -d "$DEST" ]]; then
+      mkdir -p "$DEST"
+    fi
+    echo "Copying $FILE/* to $DEST"
+    cp -rf "$FILE"/* "$DEST"
+    if [[ "$DEST" == */ ]]; then
+      rm -f "${DEST}.gitkeep"
+    else
+      rm -f "${DEST}/.gitkeep"
+    fi
+  elif [[ -f "$FILE" ]]; then
+    DEST_DIR=$(dirname "$DEST")
+    if [[ ! -d "$DEST_DIR" ]]; then
+      mkdir -p "$DEST_DIR"
+    fi
+    echo "Copying $FILE to $DEST"
+    cp -f "$FILE" "$DEST"
+    if [[ "$DEST" == */ ]]; then
+      rm -f "${DEST}.gitkeep"
+    else
+      rm -f "${DEST}/.gitkeep"
+    fi
+  else
+    echo "File or directory ${FILE} does not exist in ${FILES_DIR}."
+    exit 1
+  fi
+done
 
 shopt -u dotglob


### PR DESCRIPTION
* Fix pattern-match that was incorrectly interpreted as regex (this fixes #480), and remove redundant check: `/` already matches the pattern `*/`.
* Double-quote variables to avoid unintended shell splitting.
* Move check for empty `FILES` array with early exit ahead of main loop to reduce indentation, and consistently use 2-space indentation.
* Consistently use `[[ ]]` instead of `[ ]` for tests.
* Spelling/capitalization/punctuation fixes in error messages.

(I recommend viewing the diff with the "hide whitespace" option, otherwise it's hard to read due to the indentation changes.)