### PR TITLE
fix: concurrency deadlock in build workflow

### DIFF
--- a/.github/workflows/build-reusable.yml
+++ b/.github/workflows/build-reusable.yml
@@ -12,7 +12,7 @@ on:
 permissions: {}
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ inputs.build_script }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
Having identical concurrency groups in a reusable workflow and a job that calls it results in a deadlock. This can be avoided by including the workflow input in the reusable workflow's concurrency group. (See for example: https://github.com/github/vscode-github-actions/issues/135)