### PR TITLE
fix(brew): remove verbose option from tar command

### DIFF
--- a/modules/brew/brew.sh
+++ b/modules/brew/brew.sh
@@ -107,7 +107,7 @@ if [[ "${DIRECT_PULL}" == true ]]; then
     rm /.dockerenv
 
     # pack homebrew
-    tar --zstd -cvf /tmp/homebrew-tarball.tar.zst /home/linuxbrew/.linuxbrew
+    tar --zstd -cf /tmp/homebrew-tarball.tar.zst /home/linuxbrew/.linuxbrew
     rm -rf /home/linuxbrew/.linuxbrew
 else
     # Download pre-packaged Brew from uBlue repo


### PR DESCRIPTION
This avoids printing 5000+ lines of path names to the build logs.