### PR TITLE
Fix flatpak removal scope mismatch in system-flatpak-setup

### DIFF
--- a/modules/default-flatpaks/v2/post-boot/system-flatpak-setup
+++ b/modules/default-flatpaks/v2/post-boot/system-flatpak-setup
@@ -31,13 +31,13 @@ def main [] {
         let fedoraAppList = (flatpak list --system --app --columns=origin,application | detect columns --no-headers | default [] | where column0 == fedora)
         if ($fedoraAppList | is-not-empty) {
             let fedoraApps = $fedoraAppList | get column1
-            flatpak remove --user --noninteractive ...$fedoraApps
+            flatpak remove --system --noninteractive ...$fedoraApps
         }
 
         let fedoraRuntimeList = (flatpak list --system --runtime --columns=origin,application,arch,branch | detect columns --no-headers | default [] | where column0 == fedora)
         if ($fedoraRuntimeList | is-not-empty) {
             let fedoraRuntimes = $fedoraRuntimeList | each {|i| $"($i.column1)/($i.column2)/($i.column3)" }
-            flatpak remove --user --noninteractive ...$fedoraRuntimes
+            flatpak remove --system --noninteractive ...$fedoraRuntimes
         }
     }
 


### PR DESCRIPTION
The module was failing when attempting to remove Fedora flatpaks if a Fedora remote was already installed. The issue occurred because the script queried for apps and runtimes at the system level (`flatpak list --system`) but attempted to remove them at the user level (`flatpak remove --user`).