### PR TITLE
fix(default-flatpaks): Remove --head from curl command

### DIFF
--- a/modules/default-flatpaks/v1/default-flatpaks.sh
+++ b/modules/default-flatpaks/v1/default-flatpaks.sh
@@ -128,7 +128,7 @@ check_flatpak_id_validity_from_flathub () {
         fi  
         if [[ ${#INSTALL[@]} -gt 0 ]]; then
           for id in "${INSTALL[@]}"; do
-            if ! curl --output /dev/null --silent --head --fail "${URL}/${id}"; then
+            if ! curl --output /dev/null --silent --fail "${URL}/${id}"; then
               echo "ERROR: This ${INSTALL_LEVEL} install flatpak ID '${id}' doesn't exist in FlatHub repo, please check if you typed it correctly in the recipe."
               exit 1
             fi
@@ -136,7 +136,7 @@ check_flatpak_id_validity_from_flathub () {
         fi
         if [[ ${#REMOVE[@]} -gt 0 ]]; then  
           for id in "${REMOVE[@]}"; do
-            if ! curl --output /dev/null --silent --head --fail "${URL}/${id}"; then
+            if ! curl --output /dev/null --silent --fail "${URL}/${id}"; then
               echo "ERROR: This ${INSTALL_LEVEL} removal flatpak ID '${id}' doesn't exist in FlatHub repo, please check if you typed it correctly in the recipe."
               exit 1
             fi


### PR DESCRIPTION
This started to return a 405 and will cause builds to fail. Removing head fixes any issues with regard to that.

```bash
$ curl --output /dev/null --silent --head --fail https://flathub.org/api/v2/stats/org.gnome.Boxes; echo $?
22

$ curl --output /dev/null --silent --fail https://flathub.org/api/v2/stats/org.gnome.Boxes; echo $?
0

$ curl --output /dev/null --silent --fail https://flathub.org/api/v2/stats/org.gnome.Blah; echo $?
22
```