### PR TITLE
Remove `gnome-software --quit` from system-flatpak-setup to avoid root-run failure

### DIFF
--- a/modules/default-flatpaks/v2/post-boot/system-flatpak-setup
+++ b/modules/default-flatpaks/v2/post-boot/system-flatpak-setup
@@ -12,9 +12,6 @@ def main [] {
 
     let systemRemotes = (flatpak remotes --system --columns name | split row "\n")
     if (not $keepFedora and ($systemRemotes | any {|remote| $remote == "fedora" or $remote == "fedora-testing"})) {
-        if ('/usr/bin/gnome-software' | path exists) {
-            /usr/bin/gnome-software --quit
-        }
         if ('/usr/lib/fedora-third-party/fedora-third-party-opt-out' | path exists) {
             /usr/lib/fedora-third-party/fedora-third-party-opt-out
         }


### PR DESCRIPTION
This change removes the `gnome-software --quit` step from the `system-flatpak-setup` script. Running `gnome-software --quit` as root was failing because the GNOME Software service runs under a user session; the command returned a non-zero exit code which aborted the remaining setup steps. Since this script runs before any user login, GNOME Software is unlikely to be running, so the quit step is unnecessary and causes harm.

If this removal is inappropriate, an alternative would be to guard the quit command so it only runs when a user session is present (for example, by checking for a running gnome-software process owned by a logged-in user or by ignoring non-zero exit codes), but removing the step is the simplest fix that prevents the current failure.