### PR TITLE
fix(default-flatpaks-v1): Allow curl to retry 3 times for checks

### DIFF
--- a/modules/default-flatpaks/v1/default-flatpaks.sh
+++ b/modules/default-flatpaks/v1/default-flatpaks.sh
@@ -128,7 +128,7 @@ check_flatpak_id_validity_from_flathub () {
         fi  
         if [[ ${#INSTALL[@]} -gt 0 ]]; then
           for id in "${INSTALL[@]}"; do
-            if ! curl --output /dev/null --silent --fail "${URL}/${id}"; then
+            if ! curl --retry 3 --retry-all-erros --output /dev/null --silent --fail "${URL}/${id}"; then
               echo "ERROR: This ${INSTALL_LEVEL} install flatpak ID '${id}' doesn't exist in FlatHub repo, please check if you typed it correctly in the recipe."
               exit 1
             fi
@@ -136,7 +136,7 @@ check_flatpak_id_validity_from_flathub () {
         fi
         if [[ ${#REMOVE[@]} -gt 0 ]]; then  
           for id in "${REMOVE[@]}"; do
-            if ! curl --output /dev/null --silent --fail "${URL}/${id}"; then
+            if ! curl --retry 3 --retry-all-erros --output /dev/null --silent --fail "${URL}/${id}"; then
               echo "ERROR: This ${INSTALL_LEVEL} removal flatpak ID '${id}' doesn't exist in FlatHub repo, please check if you typed it correctly in the recipe."
               exit 1
             fi


### PR DESCRIPTION
Been noticing that this api endpoint fails randomly. This will allow curl to try hitting the endpoint 3 times before giving up.