### PR TITLE
fix: make curl options consistent across modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,9 @@ These are general guidelines for writing official bash modules and their documen
      -  You can also use `set -euxo pipefail` during debugging, where each executed command is printed. This should not be used in a published module. 
 - For downloading files, we utilize `curl`. Here's the template for what we're using:  
   - Download file with differently specified filename:  
-`curl -fLs --create-dirs "${URL}" -o "${DIR}/${FILENAME.EXT}"`  
+`curl -fLsS --retry 5 --create-dirs "${URL}" -o "${DIR}/${FILENAME.EXT}"`  
   - Download file to directory with no filename changes:  
-`curl -fLs --create-dirs -O "${URL}" --output-dir "${DIR}"`
+`curl -fLsS --retry 5 --create-dirs -O "${URL}" --output-dir "${DIR}"`
 
 Using [Shellcheck](https://www.shellcheck.net/) in your editor is recommended.
 

--- a/modules/akmods/akmods.sh
+++ b/modules/akmods/akmods.sh
@@ -53,7 +53,7 @@ tar -xvzf /tmp/akmods-rpms/"$NVIDIA_TARGZ" -C /tmp/
 mv /tmp/rpms/* /tmp/akmods-rpms/
 
 # Install Nvidia RPMs
-curl -Lo /tmp/nvidia-install.sh https://raw.githubusercontent.com/ublue-os/main/main/build_files/nvidia-install.sh
+curl -fLsS --retry 5 -o /tmp/nvidia-install.sh https://raw.githubusercontent.com/ublue-os/main/main/build_files/nvidia-install.sh
 chmod +x /tmp/nvidia-install.sh
 IMAGE_NAME="${BASE_IMAGE_NAME}" RPMFUSION_MIRROR="" /tmp/nvidia-install.sh
 rm -f /usr/share/vulkan/icd.d/nouveau_icd.*.json

--- a/modules/bling/installers/gnome-vrr.sh
+++ b/modules/bling/installers/gnome-vrr.sh
@@ -12,7 +12,7 @@ fi
 REPO_URL="https://copr.fedorainfracloud.org/coprs/ublue-os/staging/repo/fedora-${OS_VERSION}/ublue-os-staging-fedora-${OS_VERSION}.repo"
 
 echo "Downloading repo file ${REPO_URL}"
-curl -fLs --create-dirs "${REPO_URL}" -o "/etc/yum.repos.d/ublue-os-staging.repo"
+curl -fLsS --retry 5 --create-dirs "${REPO_URL}" -o "/etc/yum.repos.d/ublue-os-staging.repo"
 echo "Downloaded repo file ${REPO_URL}"
 
 rpm-ostree override replace --experimental --from repo=copr:copr.fedorainfracloud.org:ublue-os:staging mutter mutter-common gnome-control-center gnome-control-center-filesystem xorg-x11-server-Xwayland

--- a/modules/bling/installers/negativo17.sh
+++ b/modules/bling/installers/negativo17.sh
@@ -45,7 +45,7 @@ if [[ -n "${NEGATIVO_REPO_FILE}" ]]; then
   sed -i '0,/enabled=1/{s/enabled=1/enabled=1\npriority=90/}' "${NEGATIVO_REPO_FILE}"
 else
   echo "Installing Negativo17 repo..."
-  curl -Lo /etc/yum.repos.d/negativo17-fedora-multimedia.repo https://negativo17.org/repos/fedora-multimedia.repo
+  curl -fLsS --retry 5 -o /etc/yum.repos.d/negativo17-fedora-multimedia.repo https://negativo17.org/repos/fedora-multimedia.repo
   echo "Setting Negativo17 repo priority to 90..."
   sed -i '0,/enabled=1/{s/enabled=1/enabled=1\npriority=90/}' /etc/yum.repos.d/negativo17-fedora-multimedia.repo
 fi

--- a/modules/bling/installers/ublue-update.sh
+++ b/modules/bling/installers/ublue-update.sh
@@ -45,7 +45,7 @@ if command -v dnf 1> /dev/null; then
 elif command -v rpm-ostree 1> /dev/null; then
   topgrade_url="https://copr.fedorainfracloud.org/coprs/lilay/topgrade/repo/fedora-${OS_VERSION}/lilay-topgrade-fedora-${OS_VERSION}.repo"
   echo "Downloading topgrade repo ${topgrade_url}"
-  curl -fLs --create-dirs "${topgrade_url}" -o "/etc/yum.repos.d/_copr_topgrade.repo"
+  curl -fLsS --retry 5 --create-dirs "${topgrade_url}" -o "/etc/yum.repos.d/_copr_topgrade.repo"
   echo "Downloaded topgrade repo ${topgrade_url}"
   rpm-ostree install topgrade skopeo
   mkdir -p /tmp/ublue-update

--- a/modules/chezmoi/chezmoi.sh
+++ b/modules/chezmoi/chezmoi.sh
@@ -99,7 +99,7 @@ else
 	echo "Checking if curl is installed and executable at /usr/bin/curl"
 	if [ -x /usr/bin/curl ]; then
 		echo "Downloading chezmoi binary from the latest Github release"
-		/usr/bin/curl -fLs --create-dirs https://github.com/twpayne/chezmoi/releases/latest/download/chezmoi-linux-amd64 -o /usr/bin/chezmoi
+		/usr/bin/curl -fLsS --retry 5 --create-dirs https://github.com/twpayne/chezmoi/releases/latest/download/chezmoi-linux-amd64 -o /usr/bin/chezmoi
 		echo "Downloaded chezmoi binary and installed into /usr/bin"
 		echo "Ensuring chezmoi is executable"
 		/usr/bin/chmod 755 /usr/bin/chezmoi

--- a/modules/default-flatpaks/v1/default-flatpaks.sh
+++ b/modules/default-flatpaks/v1/default-flatpaks.sh
@@ -128,7 +128,7 @@ check_flatpak_id_validity_from_flathub () {
         fi  
         if [[ ${#INSTALL[@]} -gt 0 ]]; then
           for id in "${INSTALL[@]}"; do
-            if ! curl --retry 3 --retry-all-errors --output /dev/null --silent --fail "${URL}/${id}"; then
+            if ! curl -fLsS --retry 5 --retry-all-errors -o /dev/null "${URL}/${id}"; then
               echo "ERROR: This ${INSTALL_LEVEL} install flatpak ID '${id}' doesn't exist in FlatHub repo, please check if you typed it correctly in the recipe."
               exit 1
             fi
@@ -136,7 +136,7 @@ check_flatpak_id_validity_from_flathub () {
         fi
         if [[ ${#REMOVE[@]} -gt 0 ]]; then  
           for id in "${REMOVE[@]}"; do
-            if ! curl --retry 3 --retry-all-errors --output /dev/null --silent --fail "${URL}/${id}"; then
+            if ! curl -fLsS --retry 5 --retry-all-errors -o /dev/null "${URL}/${id}"; then
               echo "ERROR: This ${INSTALL_LEVEL} removal flatpak ID '${id}' doesn't exist in FlatHub repo, please check if you typed it correctly in the recipe."
               exit 1
             fi

--- a/modules/fonts/sources/google-fonts.sh
+++ b/modules/fonts/sources/google-fonts.sh
@@ -15,7 +15,7 @@ for FONT in "${FONTS[@]}"; do
 
         readarray -t "FILE_REFS" < <(
             if JSON=$(
-                curl -sf "https://fonts.google.com/download/list?family=${FONT// /%20}" | # spaces are replaced with %20 for the URL
+                curl -fLsS --retry 5 "https://fonts.google.com/download/list?family=${FONT// /%20}" | # spaces are replaced with %20 for the URL
                 tail -n +2 # remove first line, which as of March 2024 contains ")]}'" and breaks JSON parsing
             ); then
                 if FILE_REFS=$(echo "$JSON" | jq -c '.manifest.fileRefs[]' 2>/dev/null); then
@@ -31,7 +31,7 @@ for FONT in "${FONTS[@]}"; do
                 if FILENAME=$(echo "${FILE_REF}" | jq -er '.filename' 2>/dev/null); then
                     if URL=$(echo "${FILE_REF}" | jq -er '.url' 2>/dev/null); then
                         echo "Downloading ${FILENAME} from ${URL}"
-                        curl -fLs --create-dirs "${URL}" -o "${DEST}/${FONT}/${FILENAME##*/}" # everything before the last / is removed to get the filename
+                        curl -fLsS --retry 5 --create-dirs "${URL}" -o "${DEST}/${FONT}/${FILENAME##*/}" # everything before the last / is removed to get the filename
                         echo "Downloaded ${FILENAME}"
                     else
                         echo "Failed to extract URLs for: ${FONT}" >&2

--- a/modules/fonts/sources/nerd-fonts.sh
+++ b/modules/fonts/sources/nerd-fonts.sh
@@ -15,7 +15,7 @@ for FONT in "${FONTS[@]}"; do
         mkdir -p "${DEST}/${FONT}"
 
         echo "Downloading ${FONT} from ${URL}/${FONT}.tar.xz"
-        curl -fLs --create-dirs "${URL}/${FONT}.tar.xz" -o "/tmp/fonts/${FONT}.tar.xz"
+        curl -fLsS --retry 5 --create-dirs "${URL}/${FONT}.tar.xz" -o "/tmp/fonts/${FONT}.tar.xz"
         echo "Downloaded ${FONT}"
 
         tar -xf "/tmp/fonts/${FONT}.tar.xz" -C "${DEST}/${FONT}"

--- a/modules/fonts/sources/url-fonts.sh
+++ b/modules/fonts/sources/url-fonts.sh
@@ -26,7 +26,7 @@ for FONT_JSON in "${FONTS[@]}"; do
 
         TMPFILE=$(mktemp)
         echo "Downloading ${NAME} from ${URL}"
-        curl -fLs "$URL" -o "$TMPFILE"
+        curl -fLsS --retry 5 "$URL" -o "$TMPFILE"
 
         case "$URL" in
             *.zip)

--- a/modules/gnome-extensions/gnome-extensions.sh
+++ b/modules/gnome-extensions/gnome-extensions.sh
@@ -18,7 +18,7 @@ if ! command -v gnome-shell &> /dev/null; then
 fi
 
 echo "Testing connection with https://extensions.gnome.org/..."
-if ! curl --output /dev/null --silent --head --fail "https://extensions.gnome.org/"; then
+if ! curl -fLsS --retry 5 -o /dev/null --head "https://extensions.gnome.org/"; then
   echo "ERROR: Connection unsuccessful."
   echo "       This usually happens when https://extensions.gnome.org/ website is down."
   echo "       Please try again later (or disable the module temporarily)"
@@ -56,7 +56,7 @@ if [[ ${#INSTALL[@]} -gt 0 ]]; then
       echo "Installing ${EXTENSION} Gnome extension with version ${VERSION}"
       # Download archive
       echo "Downloading ZIP archive ${URL}"
-      curl -fLs --create-dirs "${URL}" -o "${ARCHIVE_DIR}"
+      curl -fLsS --retry 5 --create-dirs "${URL}" -o "${ARCHIVE_DIR}"
       echo "Downloaded ZIP archive ${URL}"
       # Extract archive
       echo "Extracting ZIP archive"
@@ -138,7 +138,7 @@ if [[ ${#INSTALL[@]} -gt 0 ]] && ! "${LEGACY}"; then
         # Literal-name extension config
         # Replaces whitespaces with %20 for install entries which contain extension name, since URLs can't contain whitespace      
         WHITESPACE_HTML="${INSTALL_EXT// /%20}"
-        URL_QUERY=$(curl -sf "https://extensions.gnome.org/extension-query/?search=${WHITESPACE_HTML}")
+        URL_QUERY=$(curl -fLsS --retry 5 "https://extensions.gnome.org/extension-query/?search=${WHITESPACE_HTML}")
         QUERIED_EXT=$(echo "${URL_QUERY}" | jq ".extensions[] | select(.name == \"${INSTALL_EXT}\")")
         if [[ -z "${QUERIED_EXT}" ]] || [[ "${QUERIED_EXT}" == "null" ]]; then
           echo "ERROR: Extension '${INSTALL_EXT}' does not exist in https://extensions.gnome.org/ website"
@@ -163,7 +163,7 @@ if [[ ${#INSTALL[@]} -gt 0 ]] && ! "${LEGACY}"; then
         fi
       else
         # PK ID extension config fallback if specified
-        URL_QUERY=$(curl -sf "https://extensions.gnome.org/extension-info/?pk=${INSTALL_EXT}")
+        URL_QUERY=$(curl -fLsS --retry 5 "https://extensions.gnome.org/extension-info/?pk=${INSTALL_EXT}")
         PK_EXT=$(echo "${URL_QUERY}" | jq -r '.["pk"]' 2>/dev/null)
         if [[ -z "${PK_EXT}" ]] || [[ "${PK_EXT}" == "null" ]]; then
           echo "ERROR: Extension with PK ID '${INSTALL_EXT}' does not exist in https://extensions.gnome.org/ website"
@@ -188,7 +188,7 @@ if [[ ${#INSTALL[@]} -gt 0 ]] && ! "${LEGACY}"; then
       echo "Installing '${EXT_NAME}' Gnome extension with version ${SUITABLE_VERSION}"
       # Download archive
       echo "Downloading ZIP archive ${URL}"
-      curl -fLs --create-dirs "${URL}" -o "${ARCHIVE_DIR}"
+      curl -fLsS --retry 5 --create-dirs "${URL}" -o "${ARCHIVE_DIR}"
       echo "Downloaded ZIP archive ${URL}"
       # Extract archive
       echo "Extracting ZIP archive"
@@ -247,7 +247,7 @@ if [[ ${#UNINSTALL[@]} -gt 0 ]]; then
         # Replaces whitespaces with %20 for install entries which contain extension name, since URLs can't contain whitespace
         # Getting json query from the website is useful to intuitively uninstall the extension without need to manually input UUID
         WHITESPACE_HTML="${UNINSTALL_EXT// /%20}"
-        URL_QUERY=$(curl -sf "https://extensions.gnome.org/extension-query/?search=${WHITESPACE_HTML}")
+        URL_QUERY=$(curl -fLsS --retry 5 "https://extensions.gnome.org/extension-query/?search=${WHITESPACE_HTML}")
         QUERIED_EXT=$(echo "${URL_QUERY}" | jq ".extensions[] | select(.name == \"${UNINSTALL_EXT}\")")
         if [[ -z "${QUERIED_EXT}" ]] || [[ "${QUERIED_EXT}" == "null" ]]; then
           echo "ERROR: Extension '${UNINSTALL_EXT}' does not exist in https://extensions.gnome.org/ website"
@@ -259,7 +259,7 @@ if [[ ${#UNINSTALL[@]} -gt 0 ]]; then
         EXT_NAME=$(echo "${QUERIED_EXT}" | jq -r '.["name"]')
       else
         # PK ID extension config fallback if specified
-        URL_QUERY=$(curl -sf "https://extensions.gnome.org/extension-info/?pk=${UNINSTALL_EXT}")
+        URL_QUERY=$(curl -fLsS --retry 5 "https://extensions.gnome.org/extension-info/?pk=${UNINSTALL_EXT}")
         PK_EXT=$(echo "${URL_QUERY}" | jq -r '.["pk"]' 2>/dev/null)
         if [[ -z "${PK_EXT}" ]] || [[ "${PK_EXT}" == "null" ]]; then
           echo "ERROR: Extension with PK ID '${UNINSTALL_EXT}' does not exist in https://extensions.gnome.org/ website"

--- a/modules/rpm-ostree/rpm-ostree.sh
+++ b/modules/rpm-ostree/rpm-ostree.sh
@@ -15,14 +15,14 @@ if [[ ${#REPOS[@]} -gt 0 ]]; then
         # If it's not, then download the repo with URL in it's filename, to avoid duplicate repo name issue
         if [[ "${REPO}" =~ ^https?:\/\/.* ]] && [[ "${REPO}" == "https://copr.fedorainfracloud.org/coprs/"* ]]; then
           echo "Downloading repo file ${REPO}"
-          curl -fLs --create-dirs -O "${REPO}" --output-dir "/etc/yum.repos.d/"
+          curl -fLsS --retry 5 --create-dirs -O "${REPO}" --output-dir "/etc/yum.repos.d/"
           echo "Downloaded repo file ${REPO}"
         elif [[ "${REPO}" =~ ^https?:\/\/.* ]] && [[ "${REPO}" != "https://copr.fedorainfracloud.org/coprs/"* ]]; then
           CLEAN_REPO_NAME=$(echo "${REPO}" | sed -E 's|^https?://([^?]+)(\?.*)?$|\1|')
           CLEAN_REPO_NAME="${CLEAN_REPO_NAME//\//.}"
           
           echo "Downloading repo file ${REPO}"
-          curl -fLs --create-dirs "${REPO}" -o "/etc/yum.repos.d/${CLEAN_REPO_NAME}"
+          curl -fLsS --retry 5 --create-dirs "${REPO}" -o "/etc/yum.repos.d/${CLEAN_REPO_NAME}"
           echo "Downloaded repo file ${REPO}"
         elif [[ ! "${REPO}" =~ ^https?:\/\/.* ]] && [[ "${REPO}" == *".repo" ]] && [[ -f "${CONFIG_DIRECTORY}/rpm-ostree/${REPO}" ]]; then
           cp "${CONFIG_DIRECTORY}/rpm-ostree/${REPO}" "/etc/yum.repos.d/${REPO##*/}"
@@ -169,7 +169,7 @@ if [[ ${#REPLACE[@]} -gt 0 ]]; then
         REPO_URL="${REPO//[$'\t\r\n ']}"
 
         echo "Downloading repo file ${REPO_URL}"
-        curl -fLs --create-dirs -O "${REPO_URL}" --output-dir "/etc/yum.repos.d/"
+        curl -fLsS --retry 5 --create-dirs -O "${REPO_URL}" --output-dir "/etc/yum.repos.d/"
         echo "Downloaded repo file ${REPO_URL}"
 
         rpm-ostree override replace --experimental --from "repo=copr:copr.fedorainfracloud.org:${MAINTAINER}:${REPO_NAME}" ${REPLACE_STR}

--- a/modules/soar/soar.sh
+++ b/modules/soar/soar.sh
@@ -5,10 +5,10 @@ set -euo pipefail
 # Install 'soar'
 echo "Downloading & installing 'soar' package manager"
 REPO="pkgforge/soar"
-LATEST_VER="$(basename $(curl -Ls -o /dev/null -w %{url_effective} https://github.com/${REPO}/releases/latest))"
+LATEST_VER="$(basename $(curl -fLsS --retry 5 -o /dev/null -w '%{url_effective}' https://github.com/${REPO}/releases/latest))"
 # Assuming that ARM64 custom images will be built from ARM64 runners for this working detection
 ARCH="$(uname -m)"
-curl -fLs --create-dirs "https://github.com/${REPO}/releases/download/${LATEST_VER}/soar-${ARCH}-linux" -o "/usr/bin/soar"
+curl -fLsS --retry 5 --create-dirs "https://github.com/${REPO}/releases/download/${LATEST_VER}/soar-${ARCH}-linux" -o "/usr/bin/soar"
 chmod +x "/usr/bin/soar"
 
 # Configuration values for package auto-upgrades (using upgrade term here from brew)

--- a/modules/yafti/yafti.sh
+++ b/modules/yafti/yafti.sh
@@ -29,8 +29,8 @@ fi
 echo "Installing yafti"
 YAFTI_REPO="https://github.com/fiftydinar/Yafti-AppImage"
 ARCH="$(uname -m)"
-VER=$(basename $(curl -Ls -o /dev/null -w %{url_effective} "$YAFTI_REPO"/releases/latest))
-curl -fLs --create-dirs "$YAFTI_REPO/releases/download/${VER}/yafti-${VER%@*}-anylinux-${ARCH}.AppImage" -o /usr/bin/yafti
+VER=$(basename $(curl -fLsS --retry 5 -o /dev/null -w '%{url_effective}' "$YAFTI_REPO"/releases/latest))
+curl -fLsS --retry 5 --create-dirs "$YAFTI_REPO/releases/download/${VER}/yafti-${VER%@*}-anylinux-${ARCH}.AppImage" -o /usr/bin/yafti
 chmod +x /usr/bin/yafti
 
 get_json_array FLATPAKS 'try .["custom-flatpaks"][]' "${1}"


### PR DESCRIPTION
Consistently use `curl -fLsS --retry 5` across all modules where `curl` is used. This ensures that `curl` handles HTTP errors, retries a few times upon receiving errors that are typically temporary, and does not suppress error output in case of failure. This should reduce the frequency of build errors caused by transient network issues, and should make such errors easier to identify in build logs when they do occur.