### PR TITLE
Normalize permissions for fonts installed by url-fonts

### DIFF
--- a/modules/fonts/sources/url-fonts.sh
+++ b/modules/fonts/sources/url-fonts.sh
@@ -62,5 +62,12 @@ for FONT_JSON in "${FONTS[@]}"; do
     fi
 done
 
+# Normalize permissions so fonts are usable by all users
+# Directories: 755, Files: 644
+if [ -d "${DEST}" ]; then
+    find "${DEST}" -type d -exec chmod 755 {} + || true
+    find "${DEST}" -type f -exec chmod 644 {} + || true
+fi
+
 fc-cache --system-only --really-force "${DEST}"
 echo "Font cache updated"


### PR DESCRIPTION
### Summary

This PR fixes the permissions applied to fonts installed by the `url-fonts` feature
of the `fonts` module. Previously, the downloaded font files were ending up with
`600` (`rw-------`) permissions under `/usr/share/fonts/url-fonts`, which made them
invisible to non-root processes.

The script now normalizes permissions after all downloads/extractions:

- Directories: `755` (`rwxr-xr-x`)
- Font files: `644` (`rw-r--r--`)

### Details

The `modules/fonts/sources/url-fonts.sh` script is updated to run:

- `find /usr/share/fonts/url-fonts -type d -exec chmod 755 {} +`
- `find /usr/share/fonts/url-fonts -type f -exec chmod 644 {} +`

immediately after installing fonts and before calling `fc-cache`.

This matches the expected permissions for system fonts and ensures:

1. Native apps can read and use the installed fonts.
2. Flatpak/sandboxed apps can access the fonts (when the directory is mounted).
3. `fontconfig` can scan the fonts without permission errors.

### Rationale

Without world-read permissions, fonts installed via `url-fonts`:

- Do not appear in font pickers.
- Cannot be used by the desktop environment.
- Fail to render in applications for non-root users.

Normalizing permissions under `/usr/share/fonts/url-fonts` brings the behavior in
line with other system font directories.

### Related

- Fixes: blue-build/modules#506