### PR TITLE
fix(dnf): Specify the repo for swap

### DIFF
--- a/modules/dnf/dnf.nu
+++ b/modules/dnf/dnf.nu
@@ -585,6 +585,7 @@ def replace_pkgs [replace_list: list]: nothing -> nothing {
           for $pkg_pair in $swap_packages {
             (dnf
               swap
+              --repo $from_repo
               --opts $pkg_pair
               --global-opts $replacement
               $pkg_pair.old

--- a/modules/dnf/dnf_interface.nu
+++ b/modules/dnf/dnf_interface.nu
@@ -170,18 +170,33 @@ export def "dnf copr disable" [copr: string]: nothing -> nothing {
 export def "dnf swap" [
   --opts: record
   --global-opts: record
+  --repo: string
   old: string
   new: string
 ]: nothing -> nothing {
   let dnf = dnf version
 
   try {
-    (^$dnf.path
-      -y
-      swap
-      ...($opts | install_args --global-config $global_opts 'allow-erasing')
-      $old
-      $new)
+    match $dnf.command {
+      "dnf4" => {
+        (^dnf4
+          -y
+          swap
+          ...($opts | install_args --global-config $global_opts 'allow-erasing')
+          --repo $repo
+          $old
+          $new)
+      }
+      "dnf5" => {
+        (^dnf5
+          -y
+          swap
+          ...($opts | install_args --global-config $global_opts 'allow-erasing')
+          --from-repo $repo
+          $old
+          $new)
+      }
+    }
   } catch {|e|
     print $'($e.msg)'
     exit 1


### PR DESCRIPTION
The `dnf swap` commands were never specifying the repo to swap for. This fixes that oversight.