### PR TITLE
fix: switch to nvidia-lts tag for the LTS driver

### DIFF
--- a/modules/akmods/akmods.sh
+++ b/modules/akmods/akmods.sh
@@ -79,6 +79,15 @@ fi
 NVIDIA_DRIVER=$(echo "$1" | jq -r 'try .["nvidia-driver"]')
 if [[ $NVIDIA_DRIVER == "nvidia" || $NVIDIA_DRIVER == "nvidia-open" ]]; then
     INSTALL_NVIDIA=true
+
+    if [[ "$NVIDIA_DRIVER" == *"open"* ]]; then
+        echo "nvidia-open kernel driver selected"
+    else
+        echo "nvidia-lts kernel driver selected"
+        curl -fLsS --retry 5 -o /etc/yum.repos.d/fedora-nvidia-580.repo https://negativo17.org/repos/fedora-nvidia-580.repo
+        sed -i '/^enabled=1/a\priority=90' /etc/yum.repos.d/fedora-nvidia-580.repo
+        NVIDIA_DRIVER="nvidia-lts"
+    fi
 fi
 
 


### PR DESCRIPTION
UniversalBlue [has renamed](https://github.com/ublue-os/akmods/pull/432) the `-nvidia` images with `-nvidia-lts` following the release of the 590 drivers and [the new repository for the 580](https://negativo17.org/nvidia-driver-580-lts-repository/).
Changing the driver name when the non-open is requested to avoid breaking changes in the akmod definition.

Edit: tested both driver options in the following builds: [nvidia](https://github.com/franute/nimbus-os/actions/runs/20285227954/job/58257229228?pr=44) and [nvidia-open](https://github.com/franute/nimbus-os/actions/runs/20285216448/job/58257196238?pr=43).