### PR TITLE
fix (fonts): Stop removing previously installed fonts

### DIFF
--- a/modules/fonts/sources/google-fonts.sh
+++ b/modules/fonts/sources/google-fonts.sh
@@ -5,12 +5,12 @@ mapfile -t FONTS <<< "$@"
 DEST="/usr/share/fonts/google-fonts"
 
 echo "Installation of google-fonts started"
-rm -rf "${DEST}"
 
 for FONT in "${FONTS[@]}"; do
     if [ -n "${FONT}" ]; then
         FONT="${FONT#"${FONT%%[![:space:]]*}"}" # Trim leading whitespace
         FONT="${FONT%"${FONT##*[![:space:]]}"}" # Trim trailing whitespace
+        rm -rf "${DEST}/${FONT}"
         mkdir -p "${DEST}/${FONT}"
 
         readarray -t "FILE_REFS" < <(

--- a/modules/fonts/sources/nerd-fonts.sh
+++ b/modules/fonts/sources/nerd-fonts.sh
@@ -12,6 +12,7 @@ mkdir -p /tmp/fonts
 for FONT in "${FONTS[@]}"; do
     FONT=${FONT// /} # remove spaces
     if [ ${#FONT} -gt 0 ]; then
+        rm -rf "${DEST}/${FONT}"
         mkdir -p "${DEST}/${FONT}"
 
         echo "Downloading ${FONT} from ${URL}/${FONT}.tar.xz"

--- a/modules/fonts/sources/url-fonts.sh
+++ b/modules/fonts/sources/url-fonts.sh
@@ -22,6 +22,7 @@ for FONT_JSON in "${FONTS[@]}"; do
         fi
         
         NAME=$(echo "$NAME" | xargs) # trim whitespace
+        rm -rf "${DEST}/${FONT}"
         mkdir -p "${DEST}/${NAME}"
 
         TMPFILE=$(mktemp)


### PR DESCRIPTION
As currently coded, the fonts module removes everything installed in ``/usr/share/fonts/[nerd-fonts|google-fonts|url-fonts]``.  This can cause issues when fonts were installed earlier, either by a prior invocation of the module, or on a base image.  Instead, we only remove directories that the module is going to write to.

Fixes #519 