### PR TITLE
fix:(fonts) #520 but for nerd and url-fonts too

### DIFF
--- a/modules/fonts/sources/nerd-fonts.sh
+++ b/modules/fonts/sources/nerd-fonts.sh
@@ -6,7 +6,6 @@ URL="https://github.com/ryanoasis/nerd-fonts/releases/latest/download"
 DEST="/usr/share/fonts/nerd-fonts"
 
 echo "Installation of nerd-fonts started"
-rm -rf "${DEST}"
 
 mkdir -p /tmp/fonts
 for FONT in "${FONTS[@]}"; do

--- a/modules/fonts/sources/url-fonts.sh
+++ b/modules/fonts/sources/url-fonts.sh
@@ -6,8 +6,6 @@ readarray -t FONTS < <(echo "$@" | jq -c '.[]')
 DEST="/usr/share/fonts/url-fonts"
 
 echo "Installation of url-fonts started"
-rm -rf "${DEST}"
-mkdir -p "${DEST}"
 
 for FONT_JSON in "${FONTS[@]}"; do
     if [ -n "${FONT_JSON}" ]; then


### PR DESCRIPTION
In #520 I forgot to remove the code that deleted the destination directory in {{nerd-font.sh}} and{{google-fonts.sh}}, so this PR corrects the omission.