### PR TITLE
feat(bootc): Create basic package manager modules

### DIFF
--- a/modules/apk/README.md
+++ b/modules/apk/README.md
@@ -1,0 +1,33 @@
+# **`apk` Module**
+
+The `apk` module offers pseudo-declarative package and repository management using [`apk`](https://github.com/alpinelinux/apk-tools).
+
+## Features
+
+This module is capable of:
+
+- Package Management
+  - Installing packages
+  - Removing packages
+
+## Package Management
+
+### Installing
+
+```yaml
+type: apk
+install:
+  packages:
+    - package-1
+    - package-2
+```
+
+### Removing Packages
+
+```yaml
+type: apk
+remove:
+  packages:
+    - package-1
+    - package-2
+```

--- a/modules/apk/apk.nu
+++ b/modules/apk/apk.nu
@@ -1,0 +1,65 @@
+#!/usr/bin/env nu
+
+# Remove packages.
+def remove_pkgs [remove: record]: nothing -> nothing {
+  let remove = $remove
+    | default [] packages
+
+  let remove_list = $remove.packages
+    | str trim
+
+  if ($remove.packages | is-not-empty) {
+    print $'(ansi green)Removing packages:(ansi reset)'
+    $remove_list
+      | each {
+        print $'- (ansi cyan)($in)(ansi reset)'
+      }
+
+    try {
+      ^apk remove ...($remove_list)
+    } catch {|err|
+      return (error make {
+        msg: $"Failed to remove packages\n($err.msg)"
+      })
+    }
+  }
+}
+
+# Install packages.
+#
+# You can specify a list of packages to install, and you can
+# specify a list of packages for a specific repo to install.
+def install_pkgs [install: record]: nothing -> nothing {
+  let install = $install
+    | default [] packages
+
+  # Gather lists of the various ways a package is installed
+  # to report back to the user.
+  let install_list = $install.packages
+    | str trim
+
+  if ($install_list | is-not-empty) {
+    print $'(ansi green)Installing packages:(ansi reset)'
+    $install_list
+      | each {
+        print $'- (ansi cyan)($in)(ansi reset)'
+      }
+    try {
+      ^apk add ...($install_list)
+    } catch {|err|
+      return (error make {
+        msg: $"Failed to install packages\n($err.msg)"
+      })
+    }
+  }
+}
+
+def main [config: string]: nothing -> nothing {
+  let config = $config
+    | from json
+    | default {} remove
+    | default {} install
+
+  remove_pkgs $config.remove
+  install_pkgs $config.install
+}

--- a/modules/apk/apk.tsp
+++ b/modules/apk/apk.tsp
@@ -1,0 +1,32 @@
+import "@typespec/json-schema";
+using TypeSpec.JsonSchema;
+
+@jsonSchema("/modules/apk-latest.json")
+model ApkModuleLatest {
+  ...ApkModuleV1;
+}
+
+@jsonSchema("/modules/apk-v1.json")
+model ApkModuleV1 {
+  /**
+   * The apk module offers pseudo-declarative package and repository management using apk.
+   * https://blue-build.org/reference/modules/apk/
+   */
+  type: "apk" | "apk@v1" | "apk@latest";
+
+  /** Configuration of packages removal. */
+  remove?: Remove;
+
+  /** Configuration of packages install. */
+  install?: Install;
+}
+
+model Install {
+  /** List of packages to install. */
+  packages: Array<string>;
+}
+
+model Remove {
+  /** List of packages to remove. */
+  packages: Array<string>;
+}

--- a/modules/apk/module.yml
+++ b/modules/apk/module.yml
@@ -1,0 +1,11 @@
+name: apk
+shortdesc: The apk module offers pseudo-declarative package and repository management using apt.
+example: |
+  type: apk
+  install:
+    packages:
+      - git
+  remove:
+    packages:
+      - firefox
+      - firefox-langpacks

--- a/modules/apt/README.md
+++ b/modules/apt/README.md
@@ -1,0 +1,33 @@
+# **`apt` Module**
+
+The `apt` module offers pseudo-declarative package and repository management using [`apt`](https://salsa.debian.org/apt-team/apt).
+
+## Features
+
+This module is capable of:
+
+- Package Management
+  - Installing packages
+  - Removing packages
+
+## Package Management
+
+### Installing
+
+```yaml
+type: apt
+install:
+  packages:
+    - package-1
+    - package-2
+```
+
+### Removing Packages
+
+```yaml
+type: apt
+remove:
+  packages:
+    - package-1
+    - package-2
+```

--- a/modules/apt/apt.nu
+++ b/modules/apt/apt.nu
@@ -1,0 +1,69 @@
+#!/usr/bin/env nu
+
+# Remove packages.
+def remove_pkgs [remove: record]: nothing -> nothing {
+  let remove = $remove
+    | default [] packages
+
+  let remove_list = $remove.packages
+    | str trim
+
+  if ($remove.packages | is-not-empty) {
+    print $'(ansi green)Removing packages:(ansi reset)'
+    $remove_list
+      | each {
+        print $'- (ansi cyan)($in)(ansi reset)'
+      }
+
+    try {
+      ^apt-get -y remove ...($remove_list)
+    } catch {|err|
+      return (error make {
+        msg: $"Failed to remove packages\n($err.msg)"
+      })
+    }
+  }
+}
+
+# Install packages.
+#
+# You can specify a list of packages to install, and you can
+# specify a list of packages for a specific repo to install.
+def install_pkgs [install: record]: nothing -> nothing {
+  let install = $install
+    | default [] packages
+
+  # Gather lists of the various ways a package is installed
+  # to report back to the user.
+  let install_list = $install.packages
+    | str trim
+
+  if ($install_list | is-not-empty) {
+    print $'(ansi green)Installing packages:(ansi reset)'
+    $install_list
+      | each {
+        print $'- (ansi cyan)($in)(ansi reset)'
+      }
+    try {
+      ^apt-get -y install ...($install_list)
+    } catch {|err|
+      return (error make {
+        msg: $"Failed to install packages\n($err.msg)"
+      })
+    }
+  }
+}
+
+def main [config: string]: nothing -> nothing {
+  let config = $config
+    | from json
+    | default {} remove
+    | default {} install
+
+  $env.DEBIAN_FRONTEND = 'noninteractive'
+
+  ^apt-get update
+
+  remove_pkgs $config.remove
+  install_pkgs $config.install
+}

--- a/modules/apt/apt.tsp
+++ b/modules/apt/apt.tsp
@@ -1,0 +1,32 @@
+import "@typespec/json-schema";
+using TypeSpec.JsonSchema;
+
+@jsonSchema("/modules/apt-latest.json")
+model AptModuleLatest {
+  ...AptModuleV1;
+}
+
+@jsonSchema("/modules/apt-v1.json")
+model AptModuleV1 {
+  /**
+   * The apt module offers pseudo-declarative package and repository management using apt.
+   * https://blue-build.org/reference/modules/apt/
+   */
+  type: "apt" | "apt@v1" | "apt@latest";
+
+  /** Configuration of packages removal. */
+  remove?: Remove;
+
+  /** Configuration of packages install. */
+  install?: Install;
+}
+
+model Install {
+  /** List of packages to install. */
+  packages: Array<string>;
+}
+
+model Remove {
+  /** List of packages to remove. */
+  packages: Array<string>;
+}

--- a/modules/apt/module.yml
+++ b/modules/apt/module.yml
@@ -1,0 +1,11 @@
+name: apt
+shortdesc: The apt module offers pseudo-declarative package and repository management using apt.
+example: |
+  type: apt
+  install:
+    packages:
+      - git
+  remove:
+    packages:
+      - firefox
+      - firefox-langpacks

--- a/modules/pacman/README.md
+++ b/modules/pacman/README.md
@@ -1,0 +1,33 @@
+# **`pacman` Module**
+
+The `pacman` module offers pseudo-declarative package and repository management using [`pacman`](https://gitlab.archlinux.org/pacman/pacman/).
+
+## Features
+
+This module is capable of:
+
+- Package Management
+  - Installing packages
+  - Removing packages
+
+## Package Management
+
+### Installing
+
+```yaml
+type: pacman
+install:
+  packages:
+    - package-1
+    - package-2
+```
+
+### Removing Packages
+
+```yaml
+type: pacman
+remove:
+  packages:
+    - package-1
+    - package-2
+```

--- a/modules/pacman/module.yml
+++ b/modules/pacman/module.yml
@@ -1,0 +1,11 @@
+name: pacman
+shortdesc: The pacman module offers pseudo-declarative package and repository management using apt.
+example: |
+  type: pacman
+  install:
+    packages:
+      - git
+  remove:
+    packages:
+      - firefox
+      - firefox-langpacks

--- a/modules/pacman/pacman.nu
+++ b/modules/pacman/pacman.nu
@@ -1,0 +1,65 @@
+#!/usr/bin/env nu
+
+# Remove packages.
+def remove_pkgs [remove: record]: nothing -> nothing {
+  let remove = $remove
+    | default [] packages
+
+  let remove_list = $remove.packages
+    | str trim
+
+  if ($remove.packages | is-not-empty) {
+    print $'(ansi green)Removing packages:(ansi reset)'
+    $remove_list
+      | each {
+        print $'- (ansi cyan)($in)(ansi reset)'
+      }
+
+    try {
+      ^pacman --remove --noconfirm --recursive --unneeded ...($remove_list)
+    } catch {|err|
+      return (error make {
+        msg: $"Failed to remove packages\n($err.msg)"
+      })
+    }
+  }
+}
+
+# Install packages.
+#
+# You can specify a list of packages to install, and you can
+# specify a list of packages for a specific repo to install.
+def install_pkgs [install: record]: nothing -> nothing {
+  let install = $install
+    | default [] packages
+
+  # Gather lists of the various ways a package is installed
+  # to report back to the user.
+  let install_list = $install.packages
+    | str trim
+
+  if ($install_list | is-not-empty) {
+    print $'(ansi green)Installing packages:(ansi reset)'
+    $install_list
+      | each {
+        print $'- (ansi cyan)($in)(ansi reset)'
+      }
+    try {
+      ^pacman --sync --noconfirm --refresh --sysupgrade ...($install_list)
+    } catch {|err|
+      return (error make {
+        msg: $"Failed to install packages\n($err.msg)"
+      })
+    }
+  }
+}
+
+def main [config: string]: nothing -> nothing {
+  let config = $config
+    | from json
+    | default {} remove
+    | default {} install
+
+  remove_pkgs $config.remove
+  install_pkgs $config.install
+}

--- a/modules/pacman/pacman.tsp
+++ b/modules/pacman/pacman.tsp
@@ -1,0 +1,32 @@
+import "@typespec/json-schema";
+using TypeSpec.JsonSchema;
+
+@jsonSchema("/modules/pacman-latest.json")
+model PacmanModuleLatest {
+  ...PacmanModuleV1;
+}
+
+@jsonSchema("/modules/pacman-v1.json")
+model PacmanModuleV1 {
+  /**
+   * The pacman module offers pseudo-declarative package and repository management using pacman.
+   * https://blue-build.org/reference/modules/pacman/
+   */
+  type: "pacman" | "pacman@v1" | "pacman@latest";
+
+  /** Configuration of packages removal. */
+  remove?: Remove;
+
+  /** Configuration of packages install. */
+  install?: Install;
+}
+
+model Install {
+  /** List of packages to install. */
+  packages: Array<string>;
+}
+
+model Remove {
+  /** List of packages to remove. */
+  packages: Array<string>;
+}

--- a/modules/zypper/README.md
+++ b/modules/zypper/README.md
@@ -1,0 +1,33 @@
+# **`zypper` Module**
+
+The `zypper` module offers pseudo-declarative package and repository management using [`zypper`](https://github.com/openSUSE/zypper).
+
+## Features
+
+This module is capable of:
+
+- Package Management
+  - Installing packages
+  - Removing packages
+
+## Package Management
+
+### Installing
+
+```yaml
+type: zypper
+install:
+  packages:
+    - package-1
+    - package-2
+```
+
+### Removing Packages
+
+```yaml
+type: zypper
+remove:
+  packages:
+    - package-1
+    - package-2
+```

--- a/modules/zypper/module.yml
+++ b/modules/zypper/module.yml
@@ -1,0 +1,11 @@
+name: zypper
+shortdesc: The zypper module offers pseudo-declarative package and repository management using apt.
+example: |
+  type: zypper
+  install:
+    packages:
+      - git
+  remove:
+    packages:
+      - firefox
+      - firefox-langpacks

--- a/modules/zypper/zypper.nu
+++ b/modules/zypper/zypper.nu
@@ -1,0 +1,65 @@
+#!/usr/bin/env nu
+
+# Remove packages.
+def remove_pkgs [remove: record]: nothing -> nothing {
+  let remove = $remove
+    | default [] packages
+
+  let remove_list = $remove.packages
+    | str trim
+
+  if ($remove.packages | is-not-empty) {
+    print $'(ansi green)Removing packages:(ansi reset)'
+    $remove_list
+      | each {
+        print $'- (ansi cyan)($in)(ansi reset)'
+      }
+
+    try {
+      ^zypper --non-interactive remove ...($remove_list)
+    } catch {|err|
+      return (error make {
+        msg: $"Failed to remove packages\n($err.msg)"
+      })
+    }
+  }
+}
+
+# Install packages.
+#
+# You can specify a list of packages to install, and you can
+# specify a list of packages for a specific repo to install.
+def install_pkgs [install: record]: nothing -> nothing {
+  let install = $install
+    | default [] packages
+
+  # Gather lists of the various ways a package is installed
+  # to report back to the user.
+  let install_list = $install.packages
+    | str trim
+
+  if ($install_list | is-not-empty) {
+    print $'(ansi green)Installing packages:(ansi reset)'
+    $install_list
+      | each {
+        print $'- (ansi cyan)($in)(ansi reset)'
+      }
+    try {
+      ^zypper --non-interactive install --auto-agree-with-licenses ...($install_list)
+    } catch {|err|
+      return (error make {
+        msg: $"Failed to install packages\n($err.msg)"
+      })
+    }
+  }
+}
+
+def main [config: string]: nothing -> nothing {
+  let config = $config
+    | from json
+    | default {} remove
+    | default {} install
+
+  remove_pkgs $config.remove
+  install_pkgs $config.install
+}

--- a/modules/zypper/zypper.tsp
+++ b/modules/zypper/zypper.tsp
@@ -1,0 +1,32 @@
+import "@typespec/json-schema";
+using TypeSpec.JsonSchema;
+
+@jsonSchema("/modules/zypper-latest.json")
+model ZypperModuleLatest {
+  ...ZypperModuleV1;
+}
+
+@jsonSchema("/modules/zypper-v1.json")
+model ZypperModuleV1 {
+  /**
+   * The zypper module offers pseudo-declarative package and repository management using zypper.
+   * https://blue-build.org/reference/modules/zypper/
+   */
+  type: "zypper" | "zypper@v1" | "zypper@latest";
+
+  /** Configuration of packages removal. */
+  remove?: Remove;
+
+  /** Configuration of packages install. */
+  install?: Install;
+}
+
+model Install {
+  /** List of packages to install. */
+  packages: Array<string>;
+}
+
+model Remove {
+  /** List of packages to remove. */
+  packages: Array<string>;
+}


### PR DESCRIPTION
This PR will be adding basic functionality modules for other package managers. This follows #504 and #503 to increase more widespread adoption of other distros with our ecosystem. I will be starting out with adding very basic functionality. Installing and removing packages. My intent is to create something for each distro that [bootcrew](https://github.com/bootcrew) currently has. So that includes:

- `pacman`
  - https://github.com/bootcrew/arch-bootc
  - https://github.com/bootcrew/steamos-bootc
- `apt`
  - https://github.com/bootcrew/ubuntu-bootc
  - https://github.com/bootcrew/debian-bootc
  - https://github.com/bootcrew/linuxmint-bootc
- `zypper`
  - https://github.com/bootcrew/opensuse-bootc
- `apk`
  - https://github.com/bootcrew/postmarketos-bootc