### PR TITLE
fix(scripts): make all scripts executable before running scripts

### DIFF
--- a/modules/script/v2/script.nu
+++ b/modules/script/v2/script.nu
@@ -6,15 +6,17 @@ def main [config: string]: nothing -> nothing {
     | default [] scripts
     | default [] snippets
 
+  cd $'($env.CONFIG_DIRECTORY)/scripts'
+  ^find . -type f -execdir chmod +x '{}' +
 
   $config.scripts
     | each {|script|
-      cd $'($env.CONFIG_DIRECTORY)/scripts'
       let script = $'($env.PWD)/($script)'
-      chmod +x $script
       print -e $'(ansi green)Running script: (ansi cyan)($script)(ansi reset)'
       ^$script
     }
+
+  cd -
 
   $config.snippets
     | each {|snippet|


### PR DESCRIPTION
If scripts are only made executable right before they run, then a script that attempts to call a script later in the list will fail because that script won't be executable yet. Instead, make all files in the scripts directory executable first, then run the scripts in order.