### PR TITLE
fix(script-v2): Use nushell built-ins

### DIFF
--- a/modules/script/v2/script.nu
+++ b/modules/script/v2/script.nu
@@ -7,7 +7,9 @@ def main [config: string]: nothing -> nothing {
     | default [] snippets
 
   cd $'($env.CONFIG_DIRECTORY)/scripts'
-  ^find . -type f -execdir chmod +x '{}' +
+  ls
+    | where { ($in | path type) == 'file' }
+    | each { chmod +x $in }
 
   $config.scripts
     | each {|script|


### PR DESCRIPTION
Was running into an issue testing on an alpine image:

```
[04:28:22 g.i/b/c/test-build-chunked-oci:pr-662-43_linux_amd64_unchunked] => ============================ Start 'script' Module ============================
[04:28:22 g.i/b/c/test-build-chunked-oci:pr-662-43_linux_amd64_unchunked] => find: unrecognized: -execdir
[04:28:22 g.i/b/c/test-build-chunked-oci:pr-662-43_linux_amd64_unchunked] => BusyBox v1.37.0 (2025-12-16 14:19:28 UTC) multi-call binary.
```

This PR updates the code to use Nushell built-ins to keep similar functionality across distros.