### PR TITLE
fix(script-v2): Use nushell built-ins

### DIFF
--- a/modules/script/v2/script.nu
+++ b/modules/script/v2/script.nu
@@ -6,14 +6,17 @@ def main [config: string]: nothing -> nothing {
     | default [] scripts
     | default [] snippets
 
-  cd $'($env.CONFIG_DIRECTORY)/scripts'
-  glob ./**/*{.sh,.nu}
+  let script_dir = [$env.CONFIG_DIRECTORY scripts] | path join
+  cd $script_dir
+  glob ./**/*{.sh,.nu,.py}
     | each { chmod +x $in }
 
   $config.scripts
     | each {|script|
-      let script = $'($env.PWD)/($script)'
       print -e $'(ansi green)Running script: (ansi cyan)($script)(ansi reset)'
+
+      let script = [$script_dir $script] | path join
+      chmod +x $script
       ^$script
     }
 

--- a/modules/script/v2/script.nu
+++ b/modules/script/v2/script.nu
@@ -7,7 +7,8 @@ def main [config: string]: nothing -> nothing {
     | default [] snippets
 
   cd $'($env.CONFIG_DIRECTORY)/scripts'
-  ^find . -type f -execdir chmod +x '{}' +
+  glob ./**/*{.sh,.nu}
+    | each { chmod +x $in }
 
   $config.scripts
     | each {|script|
@@ -23,4 +24,6 @@ def main [config: string]: nothing -> nothing {
       print -e $"(ansi green)Running snippet:\n(ansi cyan)($snippet)(ansi reset)"
       /bin/sh -c $'($snippet)'
     }
+
+  print -e $'(ansi green)Done(ansi reset)'
 }


### PR DESCRIPTION
Fixes the [previous fix](https://github.com/blue-build/modules/pull/528) that was [reverted](https://github.com/blue-build/modules/commit/18e98def5d88ae0a4ea12ad69f0fcb7512e1fdc6). Updated to use a glob to recursively find all `.sh` and `.nu` files and mark them as executable.