### PR TITLE
doc(systemd): copies not limited to unit files

### DIFF
--- a/modules/systemd/README.md
+++ b/modules/systemd/README.md
@@ -2,13 +2,16 @@
 
 The `systemd` module streamlines the management of systemd units during image building. Units are divided into `system` and `user` categories, with `system` units managed directly using `systemctl` and `user` units using `systemctl --global`. You can specify which units to enable/disable or unmask/mask under each category.
 
-You can also include your systemd units to be copied into system directories into these locations,  
+You can also include your systemd units and [drop-in files](https://wiki.archlinux.org/title/Systemd#Drop-in_files) (allowing to override an existing unit) to be copied into system directories into these locations,  
 depending if your unit is `system` or `user` based:  
 `files/systemd/system/`  
 `files/systemd/user/`
 
-Those units are then copied into these folders (depending on unit base):  
+The found files are then copied into these folders (depending on unit base):  
 `/usr/lib/systemd/system`  
 `/usr/lib/systemd/user`
+
+The directory structure will be preserved:
+for example the file `files/systemd/system/getty@.d/autologin.conf` will be copied into `/usr/lib/system/getty@.d/`.
 
 Supported management operations are [enabling](https://www.freedesktop.org/software/systemd/man/latest/systemctl.html#enable%20UNIT%E2%80%A6), [disabling](https://www.freedesktop.org/software/systemd/man/latest/systemctl.html#disable%20UNIT%E2%80%A6), [masking](https://www.freedesktop.org/software/systemd/man/latest/systemctl.html#mask%20UNIT%E2%80%A6%E2%80%A6) and [unmasking](https://www.freedesktop.org/software/systemd/man/latest/systemctl.html#unmask%20UNIT%E2%80%A6).


### PR DESCRIPTION
I was wondering if the systemd module could handle [drop-in files](https://wiki.archlinux.org/title/Systemd#Drop-in_files) (it's usefull when needing to override an existing unit file provided by a package, for example).

It turns out that, yes, it can. Because this module doesn't care about file type and preserves the directory structure. I thought it would be useful to add a note about this in the documentation.

Let me know if you would like to change anything !