### PR TITLE
fix: Fixes akmods for the new versions of NVIDIA drivers

### DIFF
--- a/modules/akmods/akmods.sh
+++ b/modules/akmods/akmods.sh
@@ -53,9 +53,7 @@ tar -xvzf /tmp/akmods-rpms/"$NVIDIA_TARGZ" -C /tmp/
 mv /tmp/rpms/* /tmp/akmods-rpms/
 
 # Install Nvidia RPMs
-curl -fLsS --retry 5 -o /tmp/nvidia-install.sh https://raw.githubusercontent.com/ublue-os/main/main/build_files/nvidia-install.sh
-chmod +x /tmp/nvidia-install.sh
-IMAGE_NAME="${BASE_IMAGE_NAME}" RPMFUSION_MIRROR="" /tmp/nvidia-install.sh
+IMAGE_NAME="${BASE_IMAGE_NAME}" RPMFUSION_MIRROR="" /tmp/akmods-rpms/ublue-os/nvidia-install.sh
 rm -f /usr/share/vulkan/icd.d/nouveau_icd.*.json
 ln -sf libnvidia-ml.so.1 /usr/lib64/libnvidia-ml.so
 


### PR DESCRIPTION
New releases of NVIDIA drivers ([starting 595.45.04](https://www.nvidia.com/en-us/drivers/details/265320/)) no longer require modeset to be set, therefore negativo17 drivers stopped bundling the nvidia-modeset.conf file in order to prepare for the update in advance.

The nvidia-install.sh used by akmods module is out-of-date. Bluefin also had this issue and fixed it by using the nvidia-install.sh file bundled with the nvidia driver RPMs. This PR does the same thing and fixes builds that have been broken for roughly the past 10 days.

This way, bluebuild configs that use ublue-main and nvidia-open akmods can continue building without any issue.