### PR TITLE
feat: add OCI annotations to containers

### DIFF
--- a/.github/workflows/build-reusable.yml
+++ b/.github/workflows/build-reusable.yml
@@ -46,9 +46,15 @@ jobs:
 
       - uses: sigstore/cosign-installer@faadad0cce49287aee09b3a48701e75088a2c6ad # v4.0.0
 
+      - name: Lowercase container registry name
+        id: registry
+        shell: bash
+        run: |
+          echo "registry=ghcr.io/${GITHUB_REPOSITORY_OWNER,,}" >>"${GITHUB_OUTPUT}"
+
       - name: Run build and push script
         env:
-          REGISTRY: ghcr.io/${{ github.repository_owner }}
+          REGISTRY: ${{ steps.registry.outputs.registry }}
           COSIGN_PRIVATE_KEY: ${{ secrets.SIGNING_SECRET }}
           GH_EVENT_NAME: ${{ github.event_name }}
           GH_PR_NUMBER: ${{ github.event.number }}

--- a/build-individual.nu
+++ b/build-individual.nu
@@ -85,7 +85,17 @@ $images | par-each { |img|
         ...($PLATFORMS | each { $'--platform=($in)' })
         ...($img.tags | each { |tag| ["-t", $"($env.REGISTRY)/modules/($img.name):($tag)"] } | flatten) # generate and spread list of tags
         --build-arg $"DIRECTORY=($img.directory)"
-        --build-arg $"NAME=($img.name)")
+        --build-arg $"NAME=($img.name)"
+        --annotation $"index,manifest:org.opencontainers.image.created=(date now | date to-timezone UTC | format date '%Y-%m-%dT%H:%M:%SZ')"
+        --annotation "index,manifest:org.opencontainers.image.url=https://github.com/blue-build/modules"
+        --annotation $"index,manifest:org.opencontainers.image.documentation=https://blue-build.org/reference/modules/($img.name)/"
+        --annotation "index,manifest:org.opencontainers.image.source=https://github.com/blue-build/modules"
+        --annotation "index,manifest:org.opencontainers.image.version=nightly"
+        --annotation $"index,manifest:org.opencontainers.image.revision=($env.GITHUB_SHA)"
+        --annotation "index,manifest:org.opencontainers.image.licenses=Apache-2.0"
+        --annotation $"index,manifest:org.opencontainers.image.title=BlueBuild Module: ($img.name)"
+        --annotation "index,manifest:org.opencontainers.image.description=BlueBuild standard modules used for building your Atomic Images"
+    )
 
     let inspect_image = $'($env.REGISTRY)/modules/($img.name):($img.tags | first)'
     print $"(ansi cyan)Inspecting image:(ansi reset) ($inspect_image)"
@@ -102,7 +112,7 @@ $images | par-each { |img|
     print $"(ansi cyan)Signing image:(ansi reset) ($digest_image)"
     (cosign sign
         --new-bundle-format=false
-        --use-signing-config=false 
+        --use-signing-config=false
         -y --recursive
         --key env://COSIGN_PRIVATE_KEY
         $digest_image)

--- a/build-unified.nu
+++ b/build-unified.nu
@@ -48,6 +48,15 @@ print $"(ansi green_bold)Generated tags for image:(ansi reset) ($tag)"
     --push
     ...($PLATFORMS | each { $'--platform=($in)' })
     -t $"($env.REGISTRY)/modules:($tag)"
+    --annotation $"index,manifest:org.opencontainers.image.created=(date now | date to-timezone UTC | format date '%Y-%m-%dT%H:%M:%SZ')"
+    --annotation "index,manifest:org.opencontainers.image.url=https://github.com/blue-build/modules"
+    --annotation "index,manifest:org.opencontainers.image.documentation=https://blue-build.org/"
+    --annotation "index,manifest:org.opencontainers.image.source=https://github.com/blue-build/modules"
+    --annotation "index,manifest:org.opencontainers.image.version=nightly"
+    --annotation $"index,manifest:org.opencontainers.image.revision=($env.GITHUB_SHA)"
+    --annotation "index,manifest:org.opencontainers.image.licenses=Apache-2.0"
+    --annotation "index,manifest:org.opencontainers.image.title=BlueBuild Modules"
+    --annotation "index,manifest:org.opencontainers.image.description=BlueBuild standard modules used for building your Atomic Images"
 )
 
 let inspect_image = $'($env.REGISTRY)/modules:($tag)'
@@ -65,7 +74,7 @@ let digest_image = $'($env.REGISTRY)/modules@($digest)'
 print $"(ansi cyan)Signing image:(ansi reset) ($digest_image)"
 (cosign sign
     --new-bundle-format=false
-    --use-signing-config=false 
+    --use-signing-config=false
     -y --recursive
     --key env://COSIGN_PRIVATE_KEY
     $digest_image)


### PR DESCRIPTION
Add annotations to module images using keys from the [OCI annotations spec](https://specs.opencontainers.org/image-spec/annotations/). These annotations are used by various dependency management tools (such as renovate-bot) to find metadata associated with dependency updates.

Also lowercase the container registry name: GitHub container registry names have to be lowercase, and repo forks might not have all-lowercase usernames, so this is necessary for the workflow to work properly on forks.