### PR TITLE
fix(brew): direct pull by default

### DIFF
--- a/modules/brew/brew.sh
+++ b/modules/brew/brew.sh
@@ -87,7 +87,7 @@ fi
 
 DIRECT_PULL=$(echo "${1}" | jq -r 'try .["direct-pull"]')
 if [[ -z "${DIRECT_PULL}" || "${DIRECT_PULL}" == "null" ]]; then
-  DIRECT_PULL=false
+  DIRECT_PULL=true
 fi
 
 INSTALLER_COMMIT=$(echo "${1}" | jq -r 'try .["installer-commit"]')
@@ -112,8 +112,8 @@ if [[ "${DIRECT_PULL}" == true ]]; then
 else
   # Download pre-packaged Brew from uBlue repo
   asset_urls=$(curl -fLsS --retry 5 'https://api.github.com/repos/ublue-os/packages/releases' |
-    jq -cr '[.[] | .assets[]] 
-    | map({(.name): .browser_download_url}) 
+    jq -cr '[.[] | .assets[]]
+    | map({(.name): .browser_download_url})
     | add')
   case "$OS_ARCH" in
   x86_64 | aarch64)

--- a/modules/brew/brew.tsp
+++ b/modules/brew/brew.tsp
@@ -48,7 +48,7 @@ model BrewModuleV1 {
   /** Whether to skip ublue's cache and directly install from Homebrew using the official installer.
    * Ublue provides a tarball cache of a Homebrew installation.
    */
-  `direct-pull`?: boolean = false;
+  `direct-pull`?: boolean = true;
 
   /** The commit to use when directly pulling the Homebrew install script.
    * Defaults to "HEAD".


### PR DESCRIPTION
https://github.com/blue-build/modules/issues/559

This quick and dirty PR just switched direct pull on by default. Overall, I think we should decide between these two options
1. Rely entirely on `ublue-os/brew` and trim the down the module to the bare minimum
2. Do not rely on ublue at all

As a lazy person, 1. feels like an easy thing to do. But hey, if the "direct pull" just works and makes it such that we do not need ublue to stay still for this to keep working, I guess 2. is better.