### PR TITLE
feat(dnf): add builddep support

### DIFF
--- a/modules/dnf/README.md
+++ b/modules/dnf/README.md
@@ -16,6 +16,7 @@ This module is capable of:
 - Package Management
   - Installing packages from RPM urls, local RPM files, or package repositories
   - Installing packages from a specific repository
+  - Installing build dependencies for source packages
   - Removing packages
   - Replacing installed packages with versions from another repository
 - Optfix
@@ -177,6 +178,18 @@ group-install:
     - wm-package-2
 ```
 
+#### Build Dependencies
+
+- Installs package build dependencies using `dnf builddep`
+
+```yaml
+type: dnf
+builddep:
+  packages:
+    - podman
+    - python3
+```
+
 #### Replace Packages
 - You can specify one or more packages that will be swapped from another repo
 - This process uses `distro-sync` to perform this operation
@@ -205,7 +218,7 @@ replace:
 
 #### Options
 
-The following options can specified in the package installation, group installation, and package replacement sections.
+The following options can specified in the package installation, build dependency installation, group installation, and package replacement sections.
 
 - `install-weak-deps` enables installation of the weak dependencies of RPMs
   - Enabled by default
@@ -244,6 +257,10 @@ replace:
       ...
     packages:
       ...
+builddep:
+  skip-unavailable: true
+  packages:
+    - podman
 ```
 
 ### Removing

--- a/modules/dnf/dnf.nu
+++ b/modules/dnf/dnf.nu
@@ -540,6 +540,28 @@ def install_pkgs [install: record]: nothing -> nothing {
   }
 }
 
+# Install build dependencies.
+def builddep_pkgs [builddep: record]: nothing -> nothing {
+  let builddep = $builddep
+    | default [] packages
+  let builddep_list = $builddep
+    | get packages
+    | each { str trim }
+
+  if ($builddep_list | is-not-empty) {
+    print $'(ansi green)Installing build dependencies:(ansi reset)'
+    $builddep_list
+      | each {
+        print $'- (ansi cyan)($in)(ansi reset)'
+      }
+
+    (dnf
+      builddep
+      --opts $builddep
+      $builddep_list)
+  }
+}
+
 # Perform a replace operation for a list of packages that
 # you want to replace from a specific repo.
 def replace_pkgs [replace_list: list]: nothing -> nothing {
@@ -619,6 +641,7 @@ def main [config: string]: nothing -> nothing {
     | default {} group-install
     | default {} remove
     | default {} install
+    | default {} builddep
     | default [] optfix
     | default [] replace
   let should_cleanup = $config.repos
@@ -636,6 +659,7 @@ def main [config: string]: nothing -> nothing {
   group_install $config.group-install
   remove_pkgs $config.remove
   install_pkgs $config.install
+  builddep_pkgs $config.builddep
   replace_pkgs $config.replace
 
   if $should_cleanup {

--- a/modules/dnf/dnf.tsp
+++ b/modules/dnf/dnf.tsp
@@ -32,6 +32,9 @@ model DnfModuleV1 {
   /** Configuration of RPM packages install. */
   install?: DnfInstall;
 
+  /** Configuration of RPM build dependencies install. */
+  builddep?: DnfBuilddep;
+
   /** List of configurations for replacing packages from another repo. */
   replace?: Array<DnfReplace>;
 }
@@ -94,6 +97,13 @@ model DnfRepoCoprEnable {
 model DnfInstall {
   /** List of RPM packages to install. */
   packages: Array<string | DnfInstallRepo>;
+
+  ...DnfInstallCommon;
+}
+
+model DnfBuilddep {
+  /** List of RPM source package names to install build dependencies for. */
+  packages: Array<string>;
 
   ...DnfInstallCommon;
 }

--- a/modules/dnf/dnf_interface.nu
+++ b/modules/dnf/dnf_interface.nu
@@ -34,6 +34,36 @@ export def "dnf install" [
   }
 }
 
+export def "dnf builddep" [
+  --opts: record
+  packages: list
+]: nothing -> nothing {
+  check_dnf_plugins
+  let dnf = dnf version
+
+  if ($packages | is-empty) {
+    return (error make {
+      msg: 'At least one package is required'
+      label: {
+        text: 'Packages'
+        span: (metadata $packages).span
+      }
+    })
+  }
+
+  try {
+    (^$dnf.path
+      -y
+      ($opts | weak_arg)
+      builddep
+      ...($opts | install_args)
+      ...$packages)
+  } catch {|e|
+    print $'($e.msg)'
+    exit 1
+  }
+}
+
 export def "dnf remove" [
   --opts: record
   packages: list
@@ -488,4 +518,3 @@ def check_copr []: string -> string {
 
   $in
 }
-

--- a/modules/dnf/module.yml
+++ b/modules/dnf/module.yml
@@ -24,6 +24,9 @@ example: |
       - kubectl.rpm
     exclude:
       - alacritty
+  builddep:
+    packages:
+      - python3
   remove:
     packages:
       - firefox


### PR DESCRIPTION
Adds a section in the yaml to install builddeps via dnf builddep

```yaml
type: dnf
builddep:
  packages:
    - podman
    - python3
```