### PR TITLE
fix(dnf): use str starts-with for record type check in install_pkgs

### DIFF
--- a/modules/dnf/dnf.nu
+++ b/modules/dnf/dnf.nu
@@ -517,7 +517,7 @@ def install_pkgs [install: record]: nothing -> nothing {
   # Get all the entries that have a repo and/or packages specified as an object.
   let object_install_list = $install.packages
     | where {|pkg|
-      ($pkg | describe) == 'record'
+      ($pkg | describe) | str starts-with 'record'
     }
 
   for $object_install in $object_install_list {


### PR DESCRIPTION
In Nushell, `describe` on a record returns the full type signature (e.g. `record<repo: string, packages: list<string>>`), not just `"record"`, so the equality check introduced in #564 always fails and silently skips all repo-specific package installs. Fix matches the pattern already used in `add_coprs`.

Closes #571